### PR TITLE
Uses new cashay-loader signature to stop rethink when we want

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -26,7 +26,21 @@ if (authToken) { // eslint-disable-line
 const store = makeStore(initialState);
 
 // Create the Cashay singleton:
-const cashaySchema = require('cashay!../server/utils/getCashaySchema.js');
+let cashaySchema = null;
+if (__CLIENT__) {
+  /*
+   * During the client bundle build, the server will need to be stopped:
+   */
+  // eslint-disable-next-line global-require
+  cashaySchema = require('cashay!../server/utils/getCashaySchema.js?stopRethink');
+} else {
+  /*
+   * Hey! We're the server. No need to stop rethink. The server will
+   * take care of that when it wants to exit.
+   */
+  // eslint-disable-next-line global-require
+  cashaySchema = require('cashay!../server/utils/getCashaySchema.js');
+}
 const authToken = localStorage.getItem(localStorageVars.authTokenName);
 
 const cashayHttpTransport = new ActionHTTPTransport(authToken);

--- a/src/server/utils/getCashaySchema.js
+++ b/src/server/utils/getCashaySchema.js
@@ -3,6 +3,10 @@ require('babel-polyfill');
 const {transformSchema} = require('cashay');
 const graphql = require('graphql').graphql;
 const rootSchema = require('../graphql/rootSchema');
-// const r = require('../database/rethinkDriver');
-// r.getPoolMaster().drain();
-module.exports = transformSchema(rootSchema, graphql);
+const r = require('../database/rethinkDriver');
+module.exports = (param) => {
+  if (param === '?stopRethink') {
+    r.getPoolMaster().drain();
+  }
+  return transformSchema(rootSchema, graphql);
+};


### PR DESCRIPTION
@mattkrick see: https://github.com/mattkrick/cashay/pull/67

I couldn't find a good way to put the loader directly into the webpack config in a way that would allow us to sometimes exit, sometimes not. And, I certainly couldn't find a way to accomplish what we wanted without adding a param (unless we had two separate implementations of `getCashaySchema.js`, ick!)

Look ok to you?