### PR TITLE
rename deploy:client -> build:client-min; fix to stop rethink

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bs": "rimraf build && concurrently \"npm run build:client\" \"npm run build:server\" \"npm run start\"",
     "quickstart": "rimraf build && concurrently \"npm run db:migrate\" \"npm run build:client\" \"npm run build:server\" \"npm run start\"",
     "build:client": "NODE_ENV=production webpack --config ./webpack/prod.babel.js",
-    "deploy:client": "NODE_ENV=production DEPLOY=true webpack --config ./webpack/prod.babel.js",
+    "build:client-min": "NODE_ENV=production DEPLOY=true webpack --config ./webpack/prod.babel.js",
     "build:server": "NODE_ENV=production webpack --config ./webpack/server.babel.js",
     "db:migrate": "./src/server/database/migrate.sh up-all",
     "test": "NODE_ENV=testing ava ./src/**/__tests__/**/*-tests.js --verbose",

--- a/src/server/utils/getCashaySchema.js
+++ b/src/server/utils/getCashaySchema.js
@@ -6,7 +6,7 @@ const rootSchema = require('../graphql/rootSchema');
 const r = require('../database/rethinkDriver');
 
 module.exports = params => {
-  if (params === '?exitRethink') {
+  if (params === '?stopRethink') {
     // optional pool draining if your schema starts a DB connection pool
     r.getPoolMaster().drain();
   }


### PR DESCRIPTION
@mattkrick: I guess more than a tweak. Note `exitRethink` -> `stopRethink`. Allows build to complete and exit.

Cosmetically, I'd like to reserve the `deploy` command to possibly actually deploy the app one day. Hence, rename to put `client-min` behind `build:`.