### PR TITLE
Fix for #104

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "babel-polyfill": "6.9.1",
     "babel-runtime": "6.9.2",
     "body-parser": "1.15.2",
-    "cashay": "^0.11.4",
+    "cashay": "^0.12.0",
     "cheerio": "^0.20.0",
     "compression": "1.6.2",
     "cors": "2.7.1",

--- a/src/universal/decorators/loginWithToken/loginWithToken.js
+++ b/src/universal/decorators/loginWithToken/loginWithToken.js
@@ -22,14 +22,12 @@ export default ComposedComponent => {
 
     render() {
       const {dispatch, authToken, user} = this.props;
-
       if (authToken && user) {
-        if (user.profile.isNew) {
+        if (user.profile.isNew === true) {
           dispatch(push('/welcome'));
         } else if (user.profile.isNew === false) {
           dispatch(push('/me'));
         }
-        return null;
       }
       return <ComposedComponent {...this.props}/>;
     }

--- a/src/universal/modules/landing/containers/Landing/LandingContainer.js
+++ b/src/universal/modules/landing/containers/Landing/LandingContainer.js
@@ -2,7 +2,6 @@ import React, {PropTypes, Component} from 'react';
 import Landing from 'universal/modules/landing/components/Landing/Landing';
 import Helmet from 'react-helmet';
 import {head, auth0} from 'universal/utils/clientOptions';
-import {push} from 'react-router-redux';
 import {cashay} from 'cashay';
 import ActionHTTPTransport from 'universal/utils/ActionHTTPTransport';
 import loginWithToken from 'universal/decorators/loginWithToken/loginWithToken';
@@ -17,7 +16,6 @@ export default class LandingContainer extends Component {
   };
 
   handleOnMeetingCreateClick = () => {
-    const {dispatch, user} = this.props;
     // Lock isn't smart enough to run in a SSR context
     const Auth0Lock = require('auth0-lock'); // eslint-disable-line global-require
     const {clientId, account} = auth0;
@@ -28,20 +26,11 @@ export default class LandingContainer extends Component {
       }
     }, async(error, profile, authToken) => {
       if (error) throw error;
+      const {dispatch} = this.props;
       dispatch(setAuthToken(authToken));
       cashay.create({transport: new ActionHTTPTransport(authToken)});
       const options = {variables: {authToken}};
-      await cashay.mutate('updateUserWithAuthToken', options);
-      if (!user.profile) {
-        // TODO handle this. either join CachedUser with UserProfile, write a mutation to correct it, etc.
-        console.warn('User profile was not instatiated when the account was created');
-      }
-      if (user.profile.isNew) {
-        dispatch(push('/welcome'));
-      } else {
-        // TODO make the "createTeam" CTA big n bold when hitting this route from here
-        dispatch(push('/me'));
-      }
+      cashay.mutate('updateUserWithAuthToken', options);
     });
   };
 

--- a/src/universal/modules/notifications/ducks/notifications.js
+++ b/src/universal/modules/notifications/ducks/notifications.js
@@ -9,7 +9,7 @@ export default function reducer(state = initialState, action) {
     case NOTIFICATIONS_SHOW: {
       // eslint-disable-next-line no-unused-vars
       const {type, ...typelessAction} = action;
-      return state.concat({...typelessAction, nid: ++nid});
+      return state.concat({...typelessAction});
     }
     case NOTIFICATIONS_HIDE:
       return state.filter(notification => notification.nid !== action.nid);
@@ -22,7 +22,8 @@ export function show(opts, level = 'success') {
   return {
     type: NOTIFICATIONS_SHOW,
     ...opts,
-    level
+    level,
+    nid: ++nid
   };
 }
 

--- a/src/universal/redux/getAuthedUser.js
+++ b/src/universal/redux/getAuthedUser.js
@@ -59,5 +59,6 @@ const updateTokenMutationHandlers = {
 
 export const authedOptions = {
   component: 'getAuthedUser',
-  mutationHandlers: updateTokenMutationHandlers
+  mutationHandlers: updateTokenMutationHandlers,
+  localOnly: true
 };


### PR DESCRIPTION
Problems:
- `loginWithToken` was sending `getCurrentUser` to the server when we wanted it to only look locally
- `notifications` had an impure reducer (`++nid`)
- `LandingContainer` duplicated `loginWithToken` logic

cleaner code, fewer lines, & fixes all 3 problems!
fixes #104 