### PR TITLE
Fix for #106 – team memberships missing after on-boarding wizard

### DIFF
--- a/src/server/graphql/models/Team/teamMutation.js
+++ b/src/server/graphql/models/Team/teamMutation.js
@@ -1,15 +1,19 @@
-import {Team, CreateTeamInput, UpdateTeamInput} from './teamSchema';
+import {
+  Team,
+  CreateTeamInput,
+  CreateTeamOutput,
+  UpdateTeamInput
+} from './teamSchema';
 import r from '../../../database/rethinkDriver';
 import {
   GraphQLNonNull,
-  GraphQLBoolean
 } from 'graphql';
 import {requireSUOrTeamMember, requireSUOrSelf} from '../authorization';
 import {updatedOrOriginal} from '../utils';
 
 export default {
   createTeam: {
-    type: GraphQLBoolean,
+    type: CreateTeamOutput,
     description: 'Create a new team and add the first team member',
     args: {
       newTeam: {
@@ -26,9 +30,13 @@ export default {
       const verifiedLeader = {...leader, isActive: true, isLead: true, isFacilitator: true};
       await r.table('TeamMember').insert(verifiedLeader);
       await r.table('Team').insert(team);
-      await r.table('UserProfile').get(userId).update({isNew: false});
-      // TODO: trigger welcome email
-      return true;
+      const updatedProfile = await r.table('UserProfile').get(userId).update({isNew: false}, {returnChanges: true});
+      const outputObj = {
+        team,
+        leader: verifiedLeader,
+        updatedProfile: updatedProfile.replaced > 0 ? updatedProfile.changes[0].new_val : null
+      };
+      return outputObj;
     }
   },
   updateTeamName: {

--- a/src/server/graphql/models/Team/teamSchema.js
+++ b/src/server/graphql/models/Team/teamSchema.js
@@ -7,6 +7,7 @@ import {
   GraphQLList
 } from 'graphql';
 import {TeamMember, CreateTeamMemberInput} from '../TeamMember/teamMemberSchema';
+import {UserProfile} from '../UserProfile/userProfileSchema';
 import GraphQLISO8601Type from 'graphql-custom-datetype';
 import {nonnullifyInputThunk} from '../utils';
 
@@ -46,3 +47,22 @@ const teamInputThunk = () => ({
 
 export const CreateTeamInput = nonnullifyInputThunk('CreateTeamInput', teamInputThunk, ['id', 'name']);
 export const UpdateTeamInput = nonnullifyInputThunk('UpdateTeamInput', teamInputThunk, ['id']);
+
+export const CreateTeamOutput = new GraphQLObjectType({
+  name: 'CreateTeamOutput',
+  description: 'A compound type returned by createTeam mutation',
+  fields: () => ({
+    team: {
+      type: Team,
+      description: 'the new team'
+    },
+    leader: {
+      type: TeamMember,
+      description: 'the new team\'s leader'
+    },
+    updatedProfile: {
+      type: UserProfile,
+      description: 'the updated user profile'
+    }
+  }),
+});

--- a/src/universal/decorators/requireAuth/requireAuth.js
+++ b/src/universal/decorators/requireAuth/requireAuth.js
@@ -1,3 +1,4 @@
+import {authedOptions} from 'universal/redux/getAuthedUser';
 import requireAuthAndRole from '../requireAuthAndRole/requireAuthAndRole';
 
 /*
@@ -5,4 +6,5 @@ import requireAuthAndRole from '../requireAuthAndRole/requireAuthAndRole';
  * user requireAuthAndRole but pass it an undefined role to match. This
  * checks only for an authenticated user.
  */
-export default ComposedComponent => requireAuthAndRole()(ComposedComponent);
+export default (cashayAuthQueryOpts = authedOptions) => (ComposedComponent) =>
+  requireAuthAndRole(null, cashayAuthQueryOpts)(ComposedComponent);

--- a/src/universal/decorators/requireAuthAndRole/requireAuthAndRole.js
+++ b/src/universal/decorators/requireAuthAndRole/requireAuthAndRole.js
@@ -16,14 +16,15 @@ const unauthenticated = {
   message: 'Hey! You haven\'t signed in yet. Taking you to the sign in page.'
 };
 
-const mapStateToProps = state => {
-  return {
-    authToken: state.authToken,
-    user: cashay.query(getAuthQueryString, authedOptions).data.user
-  };
-};
 
-export default role => ComposedComponent => {
+export default (role, cashayAuthQueryOpts = authedOptions) => (ComposedComponent) => {
+  const mapStateToProps = state => {
+    return {
+      authToken: state.authToken,
+      user: cashay.query(getAuthQueryString, cashayAuthQueryOpts).data.user
+    };
+  };
+
   @connect(mapStateToProps)
   class RequiredAuthAndRole extends Component {
     static propTypes = {

--- a/src/universal/modules/meeting/containers/MeetingLobby/MeetingLobby.js
+++ b/src/universal/modules/meeting/containers/MeetingLobby/MeetingLobby.js
@@ -19,7 +19,7 @@ const mapStateToProps = state => ({
 });
 
 @connect(mapStateToProps)
-@requireAuth
+@requireAuth()
 @reduxSocket({}, {AuthEngine})
 @look
 // eslint-disable-next-line react/prefer-stateless-function

--- a/src/universal/modules/teamDashboard/containers/Team/Team.js
+++ b/src/universal/modules/teamDashboard/containers/Team/Team.js
@@ -25,5 +25,5 @@ TeamContainer.propTypes = {
 };
 
 export default connect(mapStateToProps)(
-  requireAuth(TeamContainer)
+  requireAuth()(TeamContainer)
 );

--- a/src/universal/modules/userDashboard/containers/Me/Me.js
+++ b/src/universal/modules/userDashboard/containers/Me/Me.js
@@ -34,5 +34,5 @@ MeContainer.propTypes = {
 };
 
 export default connect(mapStateToProps)(
-  requireAuth(MeContainer)
+  requireAuth()(MeContainer)
 );

--- a/src/universal/modules/userDashboard/containers/MeSettings/MeSettings.js
+++ b/src/universal/modules/userDashboard/containers/MeSettings/MeSettings.js
@@ -34,5 +34,5 @@ MeSettingsContainer.propTypes = {
 };
 
 export default connect(mapStateToProps)(
-  requireAuth(MeSettingsContainer)
+  requireAuth()(MeSettingsContainer)
 );

--- a/src/universal/modules/welcome/components/WelcomeWizardForms/Step1PreferredName.js
+++ b/src/universal/modules/welcome/components/WelcomeWizardForms/Step1PreferredName.js
@@ -13,7 +13,6 @@ const Step1PreferredName = (props) => {
   const {handleSubmit, preferredName, dispatch, user} = props;
   const onPreferredNameSubmit = submissionData => {
     const {preferredName: newPrefferedName} = submissionData;
-    console.log(user);
     const options = {
       component: 'WelcomeContainer',
       variables: {

--- a/src/universal/modules/welcome/components/WelcomeWizardForms/Step1PreferredName.js
+++ b/src/universal/modules/welcome/components/WelcomeWizardForms/Step1PreferredName.js
@@ -13,7 +13,9 @@ const Step1PreferredName = (props) => {
   const {handleSubmit, preferredName, dispatch, user} = props;
   const onPreferredNameSubmit = submissionData => {
     const {preferredName: newPrefferedName} = submissionData;
+    console.log(user);
     const options = {
+      component: 'WelcomeContainer',
       variables: {
         updatedProfile: {
           id: user.id,

--- a/src/universal/modules/welcome/components/WelcomeWizardForms/Step2TeamName.js
+++ b/src/universal/modules/welcome/components/WelcomeWizardForms/Step2TeamName.js
@@ -11,6 +11,15 @@ import {nextPage, setWelcomeTeam} from 'universal/modules/welcome/ducks/welcomeD
 import shortid from 'shortid';
 import {cashay} from 'cashay';
 
+export const mutationHandlers = {
+  createTeam(optimisticVariables, queryResponse, currentResponse) {
+    if (queryResponse) {
+      currentResponse.user.memberships.push(queryResponse.leader);
+    }
+    return currentResponse;
+  }
+};
+
 const Step2TeamName = (props) => {
   const {dispatch, handleSubmit, preferredName, teamName, user} = props;
   const onTeamNameSubmit = data => {
@@ -19,6 +28,7 @@ const Step2TeamName = (props) => {
     const teamMemberId = shortid.generate();
     dispatch(setWelcomeTeam({teamId, teamMemberId}));
     const createTeamOptions = {
+      component: 'WelcomeContainer',
       variables: {
         newTeam: {
           id: teamId,

--- a/src/universal/modules/welcome/components/WelcomeWizardForms/Step2TeamName.js
+++ b/src/universal/modules/welcome/components/WelcomeWizardForms/Step2TeamName.js
@@ -11,14 +11,6 @@ import {nextPage, setWelcomeTeam} from 'universal/modules/welcome/ducks/welcomeD
 import shortid from 'shortid';
 import {cashay} from 'cashay';
 
-export const mutationHandlers = {
-  createTeam(optimisticVariables, queryResponse, currentResponse) {
-    if (queryResponse) {
-      currentResponse.user.memberships.push(queryResponse.leader);
-    }
-    return currentResponse;
-  }
-};
 
 const Step2TeamName = (props) => {
   const {dispatch, handleSubmit, preferredName, teamName, user} = props;

--- a/src/universal/modules/welcome/components/WelcomeWizardForms/Step3InviteTeam.js
+++ b/src/universal/modules/welcome/components/WelcomeWizardForms/Step3InviteTeam.js
@@ -55,6 +55,7 @@ const Step3InviteTeam = (props) => {
       return inviteeForServer;
     });
     const options = {
+      component: 'WelcomeContainer',
       variables: {
         teamId,
         invitees: serverInvitees

--- a/src/universal/modules/welcome/containers/Welcome/Welcome.js
+++ b/src/universal/modules/welcome/containers/Welcome/Welcome.js
@@ -45,10 +45,6 @@ const mapStateToProps = (state) => ({
   inviteesRaw: selector(state, 'inviteesRaw'),
   preferredName: selector(state, 'preferredName'),
   teamName: selector(state, 'teamName'),
-  /*
-   * NOTE: cashay user object doesn't appear he, as we won't depend on
-   *       rendering upon it.
-   */
   welcome: state.welcome
 });
 

--- a/src/universal/modules/welcome/containers/Welcome/Welcome.js
+++ b/src/universal/modules/welcome/containers/Welcome/Welcome.js
@@ -3,6 +3,9 @@ import {connect} from 'react-redux';
 import {formValueSelector} from 'redux-form';
 import {HotKeys} from 'react-hotkeys';
 import requireAuth from 'universal/decorators/requireAuth/requireAuth';
+import {authedOptions} from 'universal/redux/getAuthedUser';
+
+import {mutationHandlers as Step2MutationHandlers} from '../../components/WelcomeWizardForms/Step2TeamName';
 
 import {
   Step1PreferredName,
@@ -10,19 +13,42 @@ import {
   Step3InviteTeam
 } from '../../components/WelcomeWizardForms';
 
+/*
+ * Setup and extend requireAuth cashay mutation handlers:
+ */
+const cashayAuthQueryOpts = {
+  component: 'WelcomeContainer',
+  mutationHandlers: Object.assign(authedOptions.mutationHandlers,
+    Step2MutationHandlers,
+  ),
+  localOnly: true
+};
+
+/*
+ * Setup HotKeys events:
+ */
+
 const keyMap = {
   keyEnter: 'enter',
   seqHelp: 'shift+/' // TODO: presently unused
 };
 
+/*
+ * Setup `redux-form` selector
+ */
+
 const selector = formValueSelector('welcomeWizard');
 
 const mapStateToProps = (state) => ({
+  authToken: state.authToken,
   invitees: selector(state, 'invitees'),
   inviteesRaw: selector(state, 'inviteesRaw'),
   preferredName: selector(state, 'preferredName'),
   teamName: selector(state, 'teamName'),
-  authToken: state.authToken,
+  /*
+   * NOTE: cashay user object doesn't appear he, as we won't depend on
+   *       rendering upon it.
+   */
   welcome: state.welcome
 });
 
@@ -50,5 +76,5 @@ WelcomeContainer.propTypes = {
 };
 
 export default connect(mapStateToProps)(
-  requireAuth(WelcomeContainer)
+  requireAuth(cashayAuthQueryOpts)(WelcomeContainer)
 );

--- a/src/universal/modules/welcome/containers/Welcome/Welcome.js
+++ b/src/universal/modules/welcome/containers/Welcome/Welcome.js
@@ -5,8 +5,6 @@ import {HotKeys} from 'react-hotkeys';
 import requireAuth from 'universal/decorators/requireAuth/requireAuth';
 import {authedOptions} from 'universal/redux/getAuthedUser';
 
-import {mutationHandlers as Step2MutationHandlers} from '../../components/WelcomeWizardForms/Step2TeamName';
-
 import {
   Step1PreferredName,
   Step2TeamName,
@@ -18,8 +16,16 @@ import {
  */
 const cashayAuthQueryOpts = {
   component: 'WelcomeContainer',
-  mutationHandlers: Object.assign(authedOptions.mutationHandlers,
-    Step2MutationHandlers,
+  mutationHandlers: Object.assign({},
+    authedOptions.mutationHandlers,
+    {
+      createTeam(optimisticVariables, queryResponse, currentResponse) {
+        if (queryResponse) {
+          currentResponse.user.memberships.push(queryResponse.leader);
+        }
+        return currentResponse;
+      }
+    }
   ),
   localOnly: true
 };


### PR DESCRIPTION
* Added param add cashay query options (such as mutationHandlers) to requireAuth decorator
    * Refactored affected components
* Added mutationHandler for Step2TeamName's createTeam mutation
* Changed createTeam mutation to return output type