### PR TITLE
Added meetingDuck reset state action, cleanup, and unit tests

### DIFF
--- a/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
@@ -8,7 +8,7 @@ import MeetingLayout from 'universal/modules/meeting/components/MeetingLayout/Me
 import MeetingSection from 'universal/modules/meeting/components/MeetingSection/MeetingSection';
 import Sidebar from 'universal/modules/team/components/Sidebar/Sidebar';
 import {withRouter} from 'react-router';
-import {createMembers} from 'universal/modules/meeting/ducks/meetingDuck';
+import {createMembers, reset as resetDuck} from 'universal/modules/meeting/ducks/meetingDuck';
 import getLocalPhase from 'universal/modules/meeting/helpers/getLocalPhase';
 import handleRedirects from 'universal/modules/meeting/helpers/handleRedirects';
 import AvatarGroup from 'universal/modules/meeting/components/AvatarGroup/AvatarGroup';
@@ -81,6 +81,11 @@ export default class MeetingContainer extends Component {
         router.push(pushURL);
       }
     }
+  }
+
+  componentWillUnmount() {
+    const {dispatch} = this.props;
+    dispatch(resetDuck());
   }
 
   render() {

--- a/src/universal/modules/meeting/ducks/__tests__/meetingDuck-tests.js
+++ b/src/universal/modules/meeting/ducks/__tests__/meetingDuck-tests.js
@@ -1,0 +1,129 @@
+import test from 'ava';
+import reducer, {createMembers, reset} from '../meetingDuck';
+
+const stateTemplate = {
+  members: [],
+};
+
+const teamMembers = [
+  {
+    checkInOrder: 1,
+    id: 'userMoe::teamStooge',
+    isActive: true,
+    isCheckedIn: false,
+    isFacilitator: true,
+    isLead: true,
+    picture: 'http://stooge.com/moe.jpg',
+    preferredName: 'Moe'
+  },
+  {
+    checkInOrder: 2,
+    id: 'userLarry::teamStooge',
+    isActive: true,
+    isCheckedIn: false,
+    isFacilitator: true,
+    isLead: true,
+    picture: 'http://stooge.com/moe.jpg',
+    preferredName: 'Larry'
+  },
+  {
+    checkInOrder: 3,
+    id: 'userCurly::teamStooge',
+    isActive: true,
+    isCheckedIn: false,
+    isFacilitator: true,
+    isLead: true,
+    picture: 'http://stooge.com/moe.jpg',
+    preferredName: 'Curly'
+  }
+];
+
+const presence = [
+  {
+    id: 'xxa',
+    userId: 'userLarry'
+  },
+  {
+    id: 'xxb',
+    userId: 'userMoe'
+  }
+];
+
+const team = {
+  id: 'teamStooge',
+  name: 'The Three Stooges',
+  meetingId: 'abc123',
+  activeFacilitator: 'userMoe::teamStooge',
+  facilitatorPhase: 0,
+  facilitatorPhaseItem: 0,
+  meetingPhase: 0,
+  meetingPhaseItem: 0
+};
+
+const user = {
+  id: 'userMoe'
+};
+
+test('initial state', t => {
+  const initialState = reducer();
+  t.deepEqual(initialState, stateTemplate);
+});
+
+test('setMembers() updates members array', t => {
+  const initialState = reducer();
+
+  const nextState = reducer(initialState,
+    createMembers(teamMembers, presence, team, user)
+  );
+
+  t.deepEqual(nextState,
+    {
+      members: [
+        {
+          checkInOrder: 1,
+          id: 'userMoe::teamStooge',
+          isActive: true,
+          isCheckedIn: false,
+          isLead: true,
+          picture: 'http://stooge.com/moe.jpg',
+          preferredName: 'Moe',
+          isConnected: true,
+          isFacilitator: true,
+          isSelf: true
+        },
+        {
+          checkInOrder: 2,
+          id: 'userLarry::teamStooge',
+          isActive: true,
+          isCheckedIn: false,
+          isLead: true,
+          picture: 'http://stooge.com/moe.jpg',
+          preferredName: 'Larry',
+          isConnected: true,
+          isFacilitator: false,
+          isSelf: false
+        },
+        {
+          checkInOrder: 3,
+          id: 'userCurly::teamStooge',
+          isActive: true,
+          isCheckedIn: false,
+          isLead: true,
+          picture: 'http://stooge.com/moe.jpg',
+          preferredName: 'Curly',
+          isConnected: false,
+          isFacilitator: false,
+          isSelf: false
+        }
+      ]
+    }
+  );
+});
+
+test('reset() resets state', t => {
+  const state = reducer(stateTemplate,
+    createMembers(teamMembers, presence, team, user)
+  );
+  const nextState = reducer(state, reset());
+  t.deepEqual(nextState, stateTemplate);
+});

--- a/src/universal/modules/meeting/ducks/meetingDuck.js
+++ b/src/universal/modules/meeting/ducks/meetingDuck.js
@@ -1,25 +1,19 @@
-const SET_MEMBERS = '@@meeting/SET_MEMBERS';
-const SET_LOCAL_PHASE = '@@meeting/SET_LOCAL_PHASE';
+const CREATE_MEMBERS = '@@meeting/CREATE_MEMBERS';
+const RESET = '@@meeting/reset';
 
 const initialState = {
-  members: [],
-  localPhase: null,
-  localPhaseItem: null
+  members: []
 };
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
-    case SET_MEMBERS:
+    case CREATE_MEMBERS:
       return {
         ...state,
         members: action.payload.members
       };
-    case SET_LOCAL_PHASE:
-      return {
-        ...state,
-        localPhase: action.payload.localPhase || state.localPhase,
-        localPhaseItem: action.payload.localPhaseItem || state.localPhaseItem
-      };
+    case RESET:
+      return initialState;
     default:
       return state;
   }
@@ -27,7 +21,8 @@ export default function reducer(state = initialState, action = {}) {
 
 export function createMembers(teamMembers, presence, team, user) {
   const members = teamMembers.map((member) => {
-    const [userId, teamId] = member.id.split('::');
+    // member.id is of format 'userId::teamId'
+    const [userId] = member.id.split('::');
     return {
       ...member,
       isConnected: Boolean(presence.find(connection => connection.userId === userId)),
@@ -37,7 +32,14 @@ export function createMembers(teamMembers, presence, team, user) {
   }).sort((a, b) => b.checkInOrder <= a.checkInOrder);
 
   return {
-    type: SET_MEMBERS,
+    type: CREATE_MEMBERS,
     payload: {members}
+  };
+}
+
+export function reset() {
+  return {
+    type: RESET,
+    payload: {}
   };
 }


### PR DESCRIPTION
This new `RESET` action isn't even _really_ necessary. As the user params change, the subs would change and the `CREATE_MEMBERS` action would overwrite the members array in state. But, the reset action cleans up some global state if we have the opportunity to.

Will close #170.

Also included:

- Cleanup of unused action `SET_LOCAL_PHASE`
- Unit tests!

Note: will be merged back to `team-dash`.

GTG?