### PR TITLE
Added redux-raven-middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "redux": "3.6.0",
     "redux-form": "^6.0.5",
     "redux-logger": "2.6.1",
+    "redux-raven-middleware": "^1.1.0",
     "redux-segment": "^1.4.2",
     "redux-socket-cluster": "^0.10.1",
     "redux-storage-engine-localstorage": "^1.1.2",

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -25,14 +25,8 @@ const initialState = {};
      * During the production client bundle build, the server will need to be
      * stopped.
      */
-    /* eslint-disable no-underscore-dangle */
+    // eslint-disable-next-line no-underscore-dangle
     StyleSheet.rehydrate(window.__APHRODITE__);
-    /*
-     * Enable Sentry.io bug reporting. The Raven client is included during
-     * the SSR. See server/Html.js for how this is initialized.
-     */
-    Raven.config(window.__ACTION__.sentry).install(); // eslint-disable-line no-undef
-    /* eslint-enable */
     render(
       <Root store={store}/>,
       document.getElementById('root')

--- a/src/client/makeStore.js
+++ b/src/client/makeStore.js
@@ -1,4 +1,5 @@
 import {createStore, applyMiddleware, compose} from 'redux';
+import ravenMiddleware from 'redux-raven-middleware';
 import thunkMiddleware from 'redux-thunk';
 import {createMiddleware, createLoader} from 'redux-storage-whitelist-fn';
 import {createTracker} from 'redux-segment';
@@ -34,6 +35,8 @@ export default async initialState => {
   ];
 
   if (__PRODUCTION__) {
+    // add Sentry error reporting:
+    middlewares.unshift(ravenMiddleware(window.__ACTION__.sentry)); // eslint-disable-line no-underscore-dangle
     store = createStore(reducer, initialState, compose(applyMiddleware(...middlewares)));
   } else {
     // eslint-disable-next-line no-underscore-dangle

--- a/yarn.lock
+++ b/yarn.lock
@@ -5275,6 +5275,12 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raven-js@^3.1.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.7.0.tgz#1b848cd5043255af674af5260e48bc63d2c4edbb"
+  dependencies:
+    json-stringify-safe "^5.0.1"
+
 raven@^0.12.1:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/raven/-/raven-0.12.1.tgz#dad6b485e85bfac8f9af5fbb4c7a0d7c8350fbc7"
@@ -5599,6 +5605,12 @@ redux-form@^6.0.5:
 redux-logger@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-2.6.1.tgz#f558a40e3abd03feaf4e69ace4d71fec09803c74"
+
+redux-raven-middleware:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/redux-raven-middleware/-/redux-raven-middleware-1.1.0.tgz#0d35fd2b58a5e55c38cb225a6c52ff0eecfed421"
+  dependencies:
+    raven-js "^3.1.1"
 
 redux-segment@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
N.B. still requires raven to be included from a CDN or elsewhere.

Included as an aid for #437 and future issues.