### PR TITLE
Hotkey fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-dom": "15.3.1",
     "react-fontawesome": "^1.1.0",
     "react-helmet": "^3.1.0",
-    "react-hotkey-hoc": "https://github.com/jordanh/react-hotkey-hoc/tarball/2bcee0cd529ddca3d49ae2560aea827464656212",
+    "react-hotkey-hoc": "jordanh/react-hotkey-hoc#v0.3.2",
     "react-notification-system": "^0.2.10",
     "react-redux": "^4.4.5",
     "react-router": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-dom": "15.3.1",
     "react-fontawesome": "^1.1.0",
     "react-helmet": "^3.1.0",
-    "react-hotkey-hoc": "^0.2.1",
+    "react-hotkey-hoc": "https://github.com/jordanh/react-hotkey-hoc/tarball/2bcee0cd529ddca3d49ae2560aea827464656212",
     "react-notification-system": "^0.2.10",
     "react-redux": "^4.4.5",
     "react-router": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/action"

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
@@ -19,8 +19,20 @@ const iconStyle = {
   width: ui.fontSize,
   zIndex: 100
 };
+
+const stopHotKeyCallbackMw = (e, event, combo, next) => {
+  if (!(e.key === 'Escape' || e.key === '+')) {
+    /*
+     * Don't allow any other hotkey events to process
+     * *except* for Escape and '+'.
+     */
+    return true;
+  }
+  return next();
+};
+
 const AgendaInputField = (props) => {
-  const {bindHotkey, styles} = props;
+  const {addHotkeyStopMw, removeHotkeyStopMw, bindHotkey, styles} = props;
   let inputRef;
   const setRef = (c) => {
     inputRef = c;
@@ -42,6 +54,8 @@ const AgendaInputField = (props) => {
         autoCapitalize="off"
         autoComplete="off"
         className={`${css(styles.input)} mousetrap`}
+        onBlur={removeHotkeyStopMw(stopHotKeyCallbackMw)}
+        onFocus={addHotkeyStopMw(stopHotKeyCallbackMw)}
         placeholder="Add Agenda Item"
         ref={setRef}
         title="Add Agenda Item"
@@ -54,6 +68,8 @@ const AgendaInputField = (props) => {
 
 AgendaInputField.propTypes = {
   bindHotkey: PropTypes.func,
+  addHotkeyStopMw: PropTypes.func,
+  removeHotkeyStopMw: PropTypes.func,
   input: PropTypes.object,
   styles: PropTypes.object
 };

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
@@ -54,8 +54,8 @@ const AgendaInputField = (props) => {
         autoCapitalize="off"
         autoComplete="off"
         className={`${css(styles.input)} mousetrap`}
-        onBlur={removeHotkeyStopMw(stopHotKeyCallbackMw)}
-        onFocus={addHotkeyStopMw(stopHotKeyCallbackMw)}
+        onBlur={() => removeHotkeyStopMw(stopHotKeyCallbackMw)}
+        onFocus={() => addHotkeyStopMw(stopHotKeyCallbackMw)}
         placeholder="Add Agenda Item"
         ref={setRef}
         title="Add Agenda Item"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5446,9 +5446,9 @@ react-hot-loader@^3.0.0-beta.5:
     redbox-react "^1.2.5"
     source-map "^0.4.4"
 
-react-hotkey-hoc@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/react-hotkey-hoc/-/react-hotkey-hoc-0.2.1.tgz#b863f626f75c4bef4c7eeee6fe3c84fbd9802c65"
+"react-hotkey-hoc@https://github.com/jordanh/react-hotkey-hoc/tarball/2bcee0cd529ddca3d49ae2560aea827464656212":
+  version "0.3.1"
+  resolved "https://github.com/jordanh/react-hotkey-hoc/tarball/2bcee0cd529ddca3d49ae2560aea827464656212#8a2f2d90716e4b9959d0e426571d679f98d925a7"
   dependencies:
     mousetrap "^1.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3864,6 +3864,13 @@ joi@^6.10.1, joi@~6.10.1:
     moment "2.x.x"
     topo "1.x.x"
 
+jordanh/react-hotkey-hoc#v0.3.2:
+  name react-hotkey-hoc
+  version "0.3.2"
+  resolved "https://codeload.github.com/jordanh/react-hotkey-hoc/tar.gz/58508fd0c1fb3f50a9ecb5ea862dbb99930850c3"
+  dependencies:
+    mousetrap "^1.6.0"
+
 js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"


### PR DESCRIPTION
Isn't this elegant?

Here we're using an extended `react-hotkey-hoc` to register some custom middleware which will cause Mousetrap to ignore all hotkey events _except_ `Escape` or `+` while the input field is focused.

This is a pattern I am sure we'll repeat elsewhere.