### PR TITLE
fix #563

### DIFF
--- a/src/universal/components/AddProjectButton/AddProjectButton.js
+++ b/src/universal/components/AddProjectButton/AddProjectButton.js
@@ -4,14 +4,15 @@ import {css} from 'aphrodite-local-styles/no-important';
 import FontAwesome from 'react-fontawesome';
 import ui from 'universal/styles/ui';
 
+const iconStyle = {
+  fontSize: ui.iconSize2x,
+  height: '1.5rem',
+  lineHeight: '1.5rem',
+  paddingTop: '1px'
+};
+
 const AddProjectButton = (props) => {
   const {styles, toggleLabel, toggleClickHandler} = props;
-  const iconStyle = {
-    fontSize: ui.iconSize2x,
-    height: '1.5rem',
-    lineHeight: '1.5rem',
-    paddingTop: '1px'
-  };
   return (
     <FontAwesome
       className={css(styles.addIcon)}

--- a/src/universal/components/AddProjectButton/AddProjectButton.js
+++ b/src/universal/components/AddProjectButton/AddProjectButton.js
@@ -1,16 +1,23 @@
 import React, {PropTypes} from 'react';
 import withStyles from 'universal/styles/withStyles';
 import {css} from 'aphrodite-local-styles/no-important';
-import projectStatusStyles from 'universal/styles/helpers/projectStatusStyles';
 import FontAwesome from 'react-fontawesome';
+import ui from 'universal/styles/ui';
 
 const AddProjectButton = (props) => {
   const {styles, toggleLabel, toggleClickHandler} = props;
+  const iconStyle = {
+    fontSize: ui.iconSize2x,
+    height: '1.5rem',
+    lineHeight: '1.5rem',
+    paddingTop: '1px'
+  };
   return (
     <FontAwesome
-      className={css(styles.addIcon, styles[status])}
+      className={css(styles.addIcon)}
       name="plus-square-o"
       onClick={toggleClickHandler}
+      style={iconStyle}
       title={`Add a Project set to ${toggleLabel}`}
     />
   );
@@ -23,8 +30,16 @@ AddProjectButton.propTypes = {
 };
 
 const styleThunk = () => ({
-  ...projectStatusStyles('color'),
+  addIcon: {
+    ':hover': {
+      cursor: 'pointer',
+      opacity: '.5'
+    },
+    ':focus': {
+      cursor: 'pointer',
+      opacity: '.5'
+    }
+  }
 });
 
 export default withStyles(styleThunk)(AddProjectButton);
-

--- a/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumn.js
+++ b/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumn.js
@@ -81,7 +81,6 @@ const ProjectColumn = (props) => {
           menuWidth="10rem"
           toggle={AddProjectButton}
           toggleLabel={label}
-          toggleClassName={css(styles.addIcon, styles[status])}
           toggleHeight="1.5rem" label="Select Team:"
         >
           {menuItems.map((item, idx) =>
@@ -220,23 +219,6 @@ const styleThunk = () => ({
     fontSize: appTheme.typography.s3,
     fontWeight: 700,
     textTransform: 'uppercase'
-  },
-
-  addIcon: {
-    // #shame overriding FA
-    fontSize: '28px !important',
-    height: '1.5rem',
-    lineHeight: '1.5rem !important',
-    paddingTop: '1px',
-
-    ':hover': {
-      cursor: 'pointer',
-      opacity: '.5'
-    },
-    ':focus': {
-      cursor: 'pointer',
-      opacity: '.5'
-    }
   },
 
   ...projectStatusStyles('backgroundColor', 'Bg'),


### PR DESCRIPTION
There was a regression on the style for the ➕  buttons at the top of project columns. This restores sizing, layout and hover states.