### PR TITLE
Expanded requireAuthAndRole with optional args

### DIFF
--- a/src/universal/modules/admin/containers/Impersonate/Impersonate.js
+++ b/src/universal/modules/admin/containers/Impersonate/Impersonate.js
@@ -77,7 +77,7 @@ const showDucks = () => {
 
 @connect(mapStateToProps)
 @withRouter
-@requireAuthAndRole('su')
+@requireAuthAndRole('su', {silent: true})
 export default class Impersonate extends Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,


### PR DESCRIPTION
@mattkrick just a little somethin' somethin' that was bothering me.

I thought we could do without all the toasts when impersonating a user. I added some optional args to the `requireAuthAndRole` decorator.

If you like it, go ahead and merge it.