### PR TITLE
OutcomeCard timestamp refresh

### DIFF
--- a/src/universal/containers/EditingStatus/EditingStatusContainer.js
+++ b/src/universal/containers/EditingStatus/EditingStatusContainer.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react';
 import {connect} from 'react-redux';
 import {cashay} from 'cashay';
-import fromNow from '../../utils/fromNow';
+import getFromNowString from '../../utils/fromNow';
 import Ellipsis from '../../components/Ellipsis/Ellipsis';
 import EditingStatus from 'universal/components/EditingStatus/EditingStatus';
 
@@ -24,7 +24,7 @@ const makeEditingStatus = (editors, active, updatedAt) => {
     makeEditingStatus.active = active;
     // no one else is editing
     if (editors.length === 0) {
-      makeEditingStatus.cache = active ? <span>editing<Ellipsis/></span> : fromNow(updatedAt);
+      makeEditingStatus.cache = active ? <span>editing<Ellipsis/></span> : getFromNowString(updatedAt);
     } else {
       const editorNames = editors.map(e => e.teamMember.preferredName);
       // one other is editing

--- a/src/universal/containers/EditingStatus/EditingStatusContainer.js
+++ b/src/universal/containers/EditingStatus/EditingStatusContainer.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import {connect} from 'react-redux';
 import {cashay} from 'cashay';
-import {getFromNowString, getTimeoutDuration} from '../../utils/fromNow';
+import {fromNowString, refreshPeriod} from '../../utils/fromNow';
 import Ellipsis from '../../components/Ellipsis/Ellipsis';
 import EditingStatus from 'universal/components/EditingStatus/EditingStatus';
 
@@ -24,7 +24,7 @@ const makeEditingStatus = (editors, active, updatedAt) => {
     makeEditingStatus.active = active;
     // no one else is editing
     if (editors.length === 0) {
-      makeEditingStatus.cache = active ? <span>editing<Ellipsis/></span> : getFromNowString(updatedAt);
+      makeEditingStatus.cache = active ? <span>editing<Ellipsis/></span> : fromNowString(updatedAt);
     } else {
       const editorNames = editors.map(e => e.teamMember.preferredName);
       // one other is editing
@@ -77,15 +77,15 @@ export default class EditingStatusContainer extends Component {
   };
 
   componentWillUnmount() {
-    clearTimeout(this.timer);
+    clearTimeout(this.refreshTimer);
   }
 
   render() {
     const {active, editors, updatedAt} = this.props;
-    clearTimeout(this.timer);
-    this.timer = setTimeout(() => {
+    clearTimeout(this.refreshTimer);
+    this.refreshTimer = setTimeout(() => {
       this.forceUpdate();
-    }, getTimeoutDuration(updatedAt));
+    }, refreshPeriod(updatedAt));
     return <EditingStatus status={makeEditingStatus(editors, active, updatedAt)}/>;
   }
 }

--- a/src/universal/containers/EditingStatus/EditingStatusContainer.js
+++ b/src/universal/containers/EditingStatus/EditingStatusContainer.js
@@ -4,6 +4,7 @@ import {cashay} from 'cashay';
 import {fromNowString, refreshPeriod} from '../../utils/fromNow';
 import Ellipsis from '../../components/Ellipsis/Ellipsis';
 import EditingStatus from 'universal/components/EditingStatus/EditingStatus';
+import ms from 'ms';
 
 const editingStatusContainer = `
 query {
@@ -83,9 +84,12 @@ export default class EditingStatusContainer extends Component {
   render() {
     const {active, editors, updatedAt} = this.props;
     clearTimeout(this.refreshTimer);
-    this.refreshTimer = setTimeout(() => {
-      this.forceUpdate();
-    }, refreshPeriod(updatedAt));
+    const timeoutDuration = refreshPeriod(updatedAt);
+    if (refreshPeriod < ms('1 day')) {
+      this.refreshTimer = setTimeout(() => {
+        this.forceUpdate();
+      }, timeoutDuration);
+    }
     return <EditingStatus status={makeEditingStatus(editors, active, updatedAt)}/>;
   }
 }

--- a/src/universal/containers/EditingStatus/EditingStatusContainer.js
+++ b/src/universal/containers/EditingStatus/EditingStatusContainer.js
@@ -4,7 +4,6 @@ import {cashay} from 'cashay';
 import {getFromNowString, getRefreshPeriod} from '../../utils/fromNow';
 import Ellipsis from '../../components/Ellipsis/Ellipsis';
 import EditingStatus from 'universal/components/EditingStatus/EditingStatus';
-import ms from 'ms';
 
 const editingStatusContainer = `
 query {
@@ -94,13 +93,11 @@ export default class EditingStatusContainer extends Component {
     const {editingStatus} = this.state;
     clearTimeout(this.refreshTimer);
     const refreshPeriod = getRefreshPeriod(updatedAt);
-    if (refreshPeriod < ms('1 day')) {
-      this.refreshTimer = setTimeout(() => {
-        this.setState({
-          editingStatus: makeEditingStatus(editors, active, updatedAt)
-        });
-      }, refreshPeriod);
-    }
+    this.refreshTimer = setTimeout(() => {
+      this.setState({
+        editingStatus: makeEditingStatus(editors, active, updatedAt)
+      });
+    }, refreshPeriod);
     return <EditingStatus status={editingStatus}/>;
   }
 }

--- a/src/universal/modules/teamDashboard/components/TeamSettings/TeamSettings.js
+++ b/src/universal/modules/teamDashboard/components/TeamSettings/TeamSettings.js
@@ -6,7 +6,7 @@ import {overflowTouch} from 'universal/styles/helpers';
 import {reduxForm} from 'redux-form';
 import InviteUser from 'universal/components/InviteUser/InviteUser';
 import UserRow from 'universal/components/UserRow/UserRow';
-import fromNow from 'universal/utils/fromNow';
+import fromNowString from 'universal/utils/fromNow';
 import {cashay} from 'cashay';
 import {toggleLeaveModal, toggleRemoveModal, togglePromoteModal} from 'universal/modules/teamDashboard/ducks/teamSettingsDuck';
 import RemoveTeamMemberModal from 'universal/modules/teamDashboard/components/RemoveTeamMemberModal/RemoveTeamMemberModal';
@@ -130,7 +130,7 @@ const TeamSettings = (props) => {
                 <UserRow
                   {...invitation}
                   email={invitation.email}
-                  invitedAt={`invited ${fromNow(invitation.updatedAt)}`}
+                  invitedAt={`invited ${fromNowString(invitation.updatedAt)}`}
                   actions={invitationRowActions(invitation)}
                   key={`invitationKey${idx}`}
                 />

--- a/src/universal/utils/fromNow.js
+++ b/src/universal/utils/fromNow.js
@@ -23,8 +23,7 @@ export function fromNowString(time) {
     }
     prevThresh = thresh;
   }
-  // this is both for eslint, and for chuckles. It should never happen:
-  return 'infinitely long ago';
+  throw new Error('Infinite timestamp calculated!');
 }
 
 export function refreshPeriod(time) {
@@ -36,6 +35,5 @@ export function refreshPeriod(time) {
       return i === 1 ? 30 * thresholds.second : thresholds[threshKeys[i - 1]];
     }
   }
-  // this is both for eslint, and for further chuckling. It should never happen:
-  return Infinity;
+  throw new Error('Infinite timestamp calculated!');
 }

--- a/src/universal/utils/fromNow.js
+++ b/src/universal/utils/fromNow.js
@@ -36,4 +36,6 @@ export function getTimeoutDuration(time) {
       return i === 1 ? 30 * thresholds.second : thresholds[threshKeys[i - 1]];
     }
   }
+  // this is both for eslint, and for chuckles. It should never happen:
+  return 'infinitely long ago';
 }

--- a/src/universal/utils/fromNow.js
+++ b/src/universal/utils/fromNow.js
@@ -26,13 +26,16 @@ export function getFromNowString(time) {
   throw new Error('Infinite timestamp calculated!');
 }
 
+// For 2m20s returns 40s, for 4h15m returns 45m etc.
 export function getRefreshPeriod(time) {
   const msElapsed = (Date.now() - time) || 0;
   const threshKeys = Object.keys(thresholds);
   for (let i = 1; i < threshKeys.length; i++) {
-    const currentThresh = thresholds[threshKeys[i]];
-    if (msElapsed < currentThresh) {
-      return i === 1 ? 30 * thresholds.second : thresholds[threshKeys[i - 1]];
+    const thresh = thresholds[threshKeys[i]];
+    if (msElapsed < thresh) {
+      const largestUnit = thresholds[threshKeys[i - 1]];
+      return i === 1 ? 30 * thresholds.second :
+       largestUnit - msElapsed % largestUnit;
     }
   }
   throw new Error('Infinite timestamp calculated!');

--- a/src/universal/utils/fromNow.js
+++ b/src/universal/utils/fromNow.js
@@ -9,7 +9,7 @@ const thresholds = {
   inf: Infinity
 };
 
-export function getFromNowString(time) {
+export function fromNowString(time) {
   const distance = (Date.now() - time) || 0;
   if (distance < 1000) return 'just now';
   const threshKeys = Object.keys(thresholds);
@@ -27,7 +27,7 @@ export function getFromNowString(time) {
   return 'infinitely long ago';
 }
 
-export function getTimeoutDuration(time) {
+export function refreshPeriod(time) {
   const msElapsed = (Date.now() - time) || 0;
   const threshKeys = Object.keys(thresholds);
   for (let i = 1; i < threshKeys.length; i++) {
@@ -36,6 +36,6 @@ export function getTimeoutDuration(time) {
       return i === 1 ? 30 * thresholds.second : thresholds[threshKeys[i - 1]];
     }
   }
-  // this is both for eslint, and for chuckles. It should never happen:
-  return 'infinitely long ago';
+  // this is both for eslint, and for further chuckling. It should never happen:
+  return Infinity;
 }

--- a/src/universal/utils/fromNow.js
+++ b/src/universal/utils/fromNow.js
@@ -9,7 +9,7 @@ const thresholds = {
   inf: Infinity
 };
 
-export function fromNowString(time) {
+export function getFromNowString(time) {
   const distance = (Date.now() - time) || 0;
   if (distance < 1000) return 'just now';
   const threshKeys = Object.keys(thresholds);
@@ -26,7 +26,7 @@ export function fromNowString(time) {
   throw new Error('Infinite timestamp calculated!');
 }
 
-export function refreshPeriod(time) {
+export function getRefreshPeriod(time) {
   const msElapsed = (Date.now() - time) || 0;
   const threshKeys = Object.keys(thresholds);
   for (let i = 1; i < threshKeys.length; i++) {

--- a/src/universal/utils/fromNow.js
+++ b/src/universal/utils/fromNow.js
@@ -9,7 +9,7 @@ const thresholds = {
   inf: Infinity
 };
 
-export default function fromNow(time) {
+export function getFromNowString(time) {
   const distance = (Date.now() - time) || 0;
   if (distance < 1000) return 'just now';
   const threshKeys = Object.keys(thresholds);
@@ -25,4 +25,15 @@ export default function fromNow(time) {
   }
   // this is both for eslint, and for chuckles. It should never happen:
   return 'infinitely long ago';
+}
+
+export function getTimeoutDuration(time) {
+  const msElapsed = (Date.now() - time) || 0;
+  const threshKeys = Object.keys(thresholds);
+  for (let i = 1; i < threshKeys.length; i++) {
+    const currentThresh = thresholds[threshKeys[i]];
+    if (msElapsed < currentThresh) {
+      return i === 1 ? 30 * thresholds.second : thresholds[threshKeys[i - 1]];
+    }
+  }
 }


### PR DESCRIPTION
This PR is meant to address https://github.com/ParabolInc/action/issues/258

What it should do:
The timestamp displayed on the card should update:
- in 30 seconds if it is less than 1 minute old
- in 1 minute if (1 min < age < 1 hour)
- in 1 hour if (1 hour < age < 1 day)
and so on...

@mattkrick @ackernaut @jordanh 