### PR TITLE
Rejoin facilitator button cursor is pointer

### DIFF
--- a/src/universal/modules/meeting/components/RejoinFacilitatorButton/RejoinFacilitatorButton.js
+++ b/src/universal/modules/meeting/components/RejoinFacilitatorButton/RejoinFacilitatorButton.js
@@ -36,7 +36,7 @@ const styleThunk = () => ({
     borderRadius: '4px',
     fontSize: appTheme.typography.s4,
     boxShadow: '2px 2px 2px rgba(0, 0, 0, .2)',
-
+    cursor: 'pointer',
     ':hover': {
       opacity: '.65'
     }


### PR DESCRIPTION
@jordanh @mattkrick @ackernaut Now the cursor displays as a pointer when you hover over the rejoin facilitator button 👆 