### PR TITLE
ensure graphql gets a promise back from newly non-awaited calls

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,29 +1,16 @@
 {
   "env": {
     "production": {
-      "presets": ["react", "es2015", "stage-3"],
+      "presets": ["es2015", "stage-0", "react"],
       "plugins": [
-        ["transform-class-properties"],
-        ["transform-export-extensions"],
-        ["transform-decorators-legacy"],
-        ["transform-class-properties"],
-        ["transform-es2015-modules-commonjs"],
-        ["transform-es2015-destructuring"],
-        ["transform-es2015-classes"]
+        ["transform-decorators-legacy"]
       ]
     },
     "development": {
-      "presets": ["react"],
+      "presets": ["es2015", "stage-0", "react"],
       "plugins": [
-        ["transform-class-properties"],
-        ["transform-export-extensions"],
-        ["transform-object-rest-spread"],
         ["react-hot-loader/babel"],
-        ["transform-decorators-legacy"],
-        ["transform-class-properties"],
-        ["transform-es2015-modules-commonjs"],
-        ["transform-es2015-destructuring"],
-        ["transform-es2015-classes"]
+        ["transform-decorators-legacy"]
       ]
     },
     "test": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "6.23.0",
+    "babel-preset-stage-0": "^6.22.0",
     "babel-preset-stage-3": "^6.22.0",
     "babel-register": "6.24.0",
     "chance": "^1.0.6",

--- a/src/server/billing/helpers/adjustUserCount.js
+++ b/src/server/billing/helpers/adjustUserCount.js
@@ -29,7 +29,8 @@ const changePause = (inactive) => (orgIds, userId) => {
           }),
           updatedAt: new Date()
         }), {returnChanges: true});
-    });
+    })
+    .run()
 };
 
 const addUser = (orgIds, userId) => {
@@ -52,7 +53,8 @@ const addUser = (orgIds, userId) => {
           }),
           updatedAt: new Date()
         }), {returnChanges: true});
-    });
+    })
+    .run()
 };
 
 const deleteUser = (orgIds, userId) => {
@@ -68,7 +70,8 @@ const deleteUser = (orgIds, userId) => {
           orgUsers: org('orgUsers').filter((orgUser) => orgUser('id').ne(userId)),
           updatedAt: new Date()
         }), {returnChanges: true});
-    });
+    })
+    .run()
 };
 
 const typeLookup = {

--- a/src/server/graphql/models/Action/actionQuery.js
+++ b/src/server/graphql/models/Action/actionQuery.js
@@ -11,7 +11,7 @@ export default {
         description: 'userId that owns all the actions'
       }
     },
-    resolve(source, {userId}, {authToken}) {
+    async resolve(source, {userId}, {authToken}) {
       const r = getRethink();
 
       // AUTH
@@ -21,7 +21,9 @@ export default {
       return r.table('Action')
         .getAll(userId, {index: 'userId'})
         .filter({isComplete: false})
-        .count();
+        .count()
+        .default(0)
+        .run();
     }
   }
 };

--- a/src/server/graphql/models/IntranetJobs/intranetJobsQuery.js
+++ b/src/server/graphql/models/IntranetJobs/intranetJobsQuery.js
@@ -57,7 +57,8 @@ export default {
               .update({
                 inactive: true
               });
-          });
+          })
+          .run()
       });
       await Promise.all(updates);
       const adjustmentPromises = users.map((user) => {

--- a/src/server/graphql/models/Invitation/inviteTeamMembers/getInviterInfoAndTeamName.js
+++ b/src/server/graphql/models/Invitation/inviteTeamMembers/getInviterInfoAndTeamName.js
@@ -14,5 +14,6 @@ export default function getInviterInfoAndTeamName(teamId, userId) {
       inviterEmail: doc('email'),
       inviterName: doc('preferredName'),
       teamName: r.table('Team').get(teamId)('name')
-    }));
+    }))
+    .run();
 }

--- a/src/server/graphql/models/Invoice/invoiceQuery.js
+++ b/src/server/graphql/models/Invoice/invoiceQuery.js
@@ -46,7 +46,9 @@ export default {
         const stripeLineItems = await fetchAllLines('upcoming', stripeId);
         const upcomingInvoice = await stripe.invoices.retrieveUpcoming(stripeId);
         await generateInvoice(upcomingInvoice, stripeLineItems, orgId, invoiceId);
-        return r.table('Invoice').get(invoiceId);
+        return r.table('Invoice')
+          .get(invoiceId)
+          .run();
       }
       return currentInvoice;
     }
@@ -87,7 +89,8 @@ export default {
         .orderBy(r.desc('startAt'))
         // remove upcoming & trial invoices
         .filter((invoice) => invoice('status').ne(UPCOMING).and(invoice('total').ne(0)))
-        .limit(count);
+        .limit(count)
+        .run();
     }
   }
 };

--- a/src/server/graphql/models/Meeting/meetingSchema.js
+++ b/src/server/graphql/models/Meeting/meetingSchema.js
@@ -155,7 +155,9 @@ const MeetingInvitee = new GraphQLObjectType({
       description: 'All of the fields from the team member table',
       resolve({id}) {
         const r = getRethink();
-        return r.table('TeamMember').get(id);
+        return r.table('TeamMember')
+          .get(id)
+          .run();
       }
     }
   })
@@ -223,7 +225,9 @@ const Meeting = new GraphQLObjectType({
       description: 'All the team members associated who can join this team',
       resolve({teamId}) {
         const r = getRethink();
-        return r.table('TeamMember').getAll(teamId, {index: 'teamId'});
+        return r.table('TeamMember')
+          .getAll(teamId, {index: 'teamId'})
+          .run();
       }
     },
   })

--- a/src/server/graphql/models/Organization/addOrg/createNewOrg.js
+++ b/src/server/graphql/models/Organization/addOrg/createNewOrg.js
@@ -41,5 +41,6 @@ export default async function createNewOrg(orgId, orgName, leaderUserId, stripeT
     updatedAt: now,
     periodEnd: fromEpochSeconds(current_period_end),
     periodStart: fromEpochSeconds(current_period_start),
-  }, {returnChanges: true})('changes')(0)('new_val');
+  }, {returnChanges: true})('changes')(0)('new_val')
+    .run()
 }

--- a/src/server/graphql/models/Organization/organizationMutation.js
+++ b/src/server/graphql/models/Organization/organizationMutation.js
@@ -68,7 +68,8 @@ export default {
             type: PAUSE_USER,
             userId,
           })
-          .count();
+          .count()
+          .run()
       });
       const pausesByOrg = await Promise.all(hookPromises);
       const triggeredPauses = Math.max(...pausesByOrg);

--- a/src/server/graphql/models/Organization/organizationQuery.js
+++ b/src/server/graphql/models/Organization/organizationQuery.js
@@ -21,7 +21,8 @@ export default {
       // RESOLUTION
       return r.table('Organization')
         .getAll(userId, {index: 'orgUsers'})
-        .count();
+        .count()
+        .run()
     }
   },
   orgDetails: {
@@ -42,7 +43,8 @@ export default {
       return r.table('Team').get(teamId)('orgId')
         .do((orgId) => {
           return r.table('Organization').get(orgId);
-        });
+        })
+        .run();
     }
   }
 };

--- a/src/server/graphql/models/Organization/organizationSchema.js
+++ b/src/server/graphql/models/Organization/organizationSchema.js
@@ -136,7 +136,8 @@ export const Organization = new GraphQLObjectType({
         return r.table('User')
           .getAll(id, {index: 'userOrgs'})
           .filter((user) => user('userOrgs')
-            .contains((userOrg) => userOrg('id').eq(id).and(userOrg('role').eq(BILLING_LEADER))));
+            .contains((userOrg) => userOrg('id').eq(id).and(userOrg('role').eq(BILLING_LEADER))))
+          .run();
       }
     }
   })

--- a/src/server/graphql/models/Organization/rejectOrgApproval/removeOrgApprovalAndNotification.js
+++ b/src/server/graphql/models/Organization/rejectOrgApproval/removeOrgApprovalAndNotification.js
@@ -26,5 +26,6 @@ export default function removeOrgApprovalAndNotification(orgId, maybeEmails) {
           invitedTeamId: varList(3)
         }))
         .default([]);
-    });
+    })
+    .run()
 }

--- a/src/server/graphql/models/Project/projectQuery.js
+++ b/src/server/graphql/models/Project/projectQuery.js
@@ -31,7 +31,8 @@ export default {
       return r.table('Project')
         .between([teamId, cursor], [teamId, r.maxval], {index: 'teamIdCreatedAt', leftBound: 'open'})
         .filter({isArchived: true})
-        .limit(first);
+        .limit(first)
+        .run();
     }
   },
   getCurrentProject: {

--- a/src/server/graphql/models/Team/createFirstTeam/addSeedProjects.js
+++ b/src/server/graphql/models/Team/createFirstTeam/addSeedProjects.js
@@ -57,5 +57,6 @@ export default (userId, teamId) => {
           updatedAt: change('new_val')('updatedAt'),
         }))
       );
-    });
+    })
+    .run();
 };

--- a/src/server/graphql/models/Team/teamSchema.js
+++ b/src/server/graphql/models/Team/teamSchema.js
@@ -98,7 +98,9 @@ export const Team = new GraphQLObjectType({
       description: 'The agenda items for the upcoming or current meeting',
       resolve({id}) {
         const r = getRethink();
-        return r.table('AgendaItem').getAll(id, {index: 'teamId'});
+        return r.table('AgendaItem')
+          .getAll(id, {index: 'teamId'})
+          .run()
       }
     },
     teamMembers: {
@@ -106,7 +108,9 @@ export const Team = new GraphQLObjectType({
       description: 'All the team members associated who can join this team',
       resolve({id}) {
         const r = getRethink();
-        return r.table('TeamMember').getAll(id, {index: 'teamId'});
+        return r.table('TeamMember')
+          .getAll(id, {index: 'teamId'})
+          .run()
       }
     }
   })

--- a/src/server/graphql/models/TeamMember/teamMemberSchema.js
+++ b/src/server/graphql/models/TeamMember/teamMemberSchema.js
@@ -57,7 +57,9 @@ const TeamMember = new GraphQLObjectType({
       description: 'The team this team member belongs to',
       resolve({teamId}) {
         const r = getRethink();
-        return r.table('Team').get(teamId);
+        return r.table('Team')
+          .get(teamId)
+          .run();
       }
     },
     user: {
@@ -65,7 +67,9 @@ const TeamMember = new GraphQLObjectType({
       description: 'The user for the team member',
       resolve(source) {
         const r = getRethink();
-        return r.table('User').get(source.userId);
+        return r.table('User')
+          .get(source.userId)
+          .run();
       }
     },
     projects: {
@@ -73,7 +77,9 @@ const TeamMember = new GraphQLObjectType({
       description: 'Projects owned by the team member',
       resolve(source) {
         const r = getRethink();
-        return r.table('Project').getAll(source.id, {index: 'teamMemberId'});
+        return r.table('Project')
+          .getAll(source.id, {index: 'teamMemberId'})
+          .run();
       }
     }
   })

--- a/src/server/graphql/models/User/userSchema.js
+++ b/src/server/graphql/models/User/userSchema.js
@@ -173,7 +173,9 @@ export const User = new GraphQLObjectType({
       description: 'The memberships to different teams that the user has',
       resolve({id}) {
         const r = getRethink();
-        return r.table('TeamMember').getAll(id, {index: 'userId'});
+        return r.table('TeamMember')
+          .getAll(id, {index: 'userId'})
+          .run()
       }
     },
     jwt: {

--- a/src/server/utils/authorization.js
+++ b/src/server/utils/authorization.js
@@ -109,7 +109,8 @@ export const getUserOrgDoc = (userId, orgId) => {
   return r.table('User').get(userId)('userOrgs')
     .filter({id: orgId})
     .nth(0)
-    .default(null);
+    .default(null)
+    .run()
 };
 
 export const isBillingLeader = (userOrgDoc) => {

--- a/src/server/worker.js
+++ b/src/server/worker.js
@@ -51,7 +51,7 @@ export function run(worker) { // eslint-disable-line import/prefer-default-expor
 
   // setup middleware
   // sentry.io request handler capture middleware, must be first:
-  app.use(raven.middleware.express.requestHandler(process.env.SENTRY_DSN));
+  app.use(raven.requestHandler(process.env.SENTRY_DSN));
   app.use(bodyParser.json());
   app.use(cors({origin: true, credentials: true}));
   app.use('/static', express.static('static'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -511,6 +511,14 @@ babel-generator@^6.18.0, babel-generator@^6.24.0:
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+babel-helper-bindify-decorators@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.22.0.tgz#d7f5bc261275941ac62acfc4e20dacfb8a3fe952"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.22.0"
+    babel-types "^6.22.0"
+
 babel-helper-builder-binary-assignment-operator-visitor@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.22.0.tgz#29df56be144d81bdeac08262bfa41d2c5e91cdcd"
@@ -550,6 +558,15 @@ babel-helper-explode-assignable-expression@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.22.0.tgz#c97bf76eed3e0bae4048121f2b9dae1a4e7d0478"
   dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.22.0"
+    babel-types "^6.22.0"
+
+babel-helper-explode-class@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-class/-/babel-helper-explode-class-6.22.0.tgz#646304924aa6388a516843ba7f1855ef8dfeb69b"
+  dependencies:
+    babel-helper-bindify-decorators "^6.22.0"
     babel-runtime "^6.22.0"
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
@@ -688,13 +705,25 @@ babel-plugin-syntax-async-generators@^6.5.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
 
+babel-plugin-syntax-class-constructor-call@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz#9cb9d39fe43c8600bec8146456ddcbd4e1a76416"
+
 babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
-babel-plugin-syntax-decorators@^6.1.18:
+babel-plugin-syntax-decorators@^6.1.18, babel-plugin-syntax-decorators@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+
+babel-plugin-syntax-do-expressions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz#5747756139aa26d390d09410b03744ba07e4796d"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
@@ -707,6 +736,10 @@ babel-plugin-syntax-export-extensions@^6.8.0:
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+
+babel-plugin-syntax-function-bind@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz#48c495f177bdf31a981e732f55adc0bdd2601f46"
 
 babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
@@ -736,7 +769,15 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-class-properties@^6.23.0:
+babel-plugin-transform-class-constructor-call@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.22.0.tgz#11a4d2216abb5b0eef298b493748f4f2f4869120"
+  dependencies:
+    babel-plugin-syntax-class-constructor-call "^6.18.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.22.0, babel-plugin-transform-class-properties@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.23.0.tgz#187b747ee404399013563c993db038f34754ac3b"
   dependencies:
@@ -752,6 +793,23 @@ babel-plugin-transform-decorators-legacy@1.3.4:
     babel-plugin-syntax-decorators "^6.1.18"
     babel-runtime "^6.2.0"
     babel-template "^6.3.0"
+
+babel-plugin-transform-decorators@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.22.0.tgz#c03635b27a23b23b7224f49232c237a73988d27c"
+  dependencies:
+    babel-helper-explode-class "^6.22.0"
+    babel-plugin-syntax-decorators "^6.13.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.22.0"
+    babel-types "^6.22.0"
+
+babel-plugin-transform-do-expressions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz#28ccaf92812d949c2cd1281f690c8fdc468ae9bb"
+  dependencies:
+    babel-plugin-syntax-do-expressions "^6.8.0"
+    babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -943,6 +1001,13 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-function-bind@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz#c6fb8e96ac296a310b8cf8ea401462407ddf6a97"
+  dependencies:
+    babel-plugin-syntax-function-bind "^6.8.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-object-rest-spread@^6.22.0, babel-plugin-transform-object-rest-spread@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
@@ -1050,6 +1115,31 @@ babel-preset-react@6.23.0:
     babel-plugin-transform-react-jsx-self "^6.22.0"
     babel-plugin-transform-react-jsx-source "^6.22.0"
     babel-preset-flow "^6.23.0"
+
+babel-preset-stage-0@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-0/-/babel-preset-stage-0-6.22.0.tgz#707eeb5b415da769eff9c42f4547f644f9296ef9"
+  dependencies:
+    babel-plugin-transform-do-expressions "^6.22.0"
+    babel-plugin-transform-function-bind "^6.22.0"
+    babel-preset-stage-1 "^6.22.0"
+
+babel-preset-stage-1@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-1/-/babel-preset-stage-1-6.22.0.tgz#7da05bffea6ad5a10aef93e320cfc6dd465dbc1a"
+  dependencies:
+    babel-plugin-transform-class-constructor-call "^6.22.0"
+    babel-plugin-transform-export-extensions "^6.22.0"
+    babel-preset-stage-2 "^6.22.0"
+
+babel-preset-stage-2@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-2/-/babel-preset-stage-2-6.22.0.tgz#ccd565f19c245cade394b21216df704a73b27c07"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-plugin-transform-class-properties "^6.22.0"
+    babel-plugin-transform-decorators "^6.22.0"
+    babel-preset-stage-3 "^6.22.0"
 
 babel-preset-stage-3@^6.22.0:
   version "6.22.0"
@@ -2027,17 +2117,23 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@*, debug@2, debug@2.6.1, debug@^2.1.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+debug@*, debug@2, debug@^2.1.1, debug@^2.2.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
 
-debug@2.2.0, debug@^2.2.0, debug@~2.2.0:
+debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
+
+debug@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+  dependencies:
+    ms "0.7.2"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -4378,8 +4474,8 @@ loader-utils@^0.2.16:
     object-assign "^4.0.1"
 
 loader-utils@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.0.3.tgz#566c320c24c33cb3f02db4df83f3dbf60b253de3"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.0.4.tgz#13f56197f1523a305891248b4c7244540848426c"
   dependencies:
     big.js "^3.1.3"
     emojis-list "^2.0.0"
@@ -5831,7 +5927,7 @@ react-transform-hmr@1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@^15.0.1, react@^15.3.0, react@^15.4.2:
+react@^15.0.1, react@^15.4.2:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
   dependencies:
@@ -5880,8 +5976,8 @@ readable-stream@1.1.x, readable-stream@~1.1.9:
     string_decoder "~0.10.x"
 
 readable-stream@2, readable-stream@^2, readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.1.5, readable-stream@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz#9cf49463985df016c8ae8813097a9293a9b33729"
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.5.tgz#a0b187304e05bab01a4ce2b4cc9c607d5aa1d606"
   dependencies:
     buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
@@ -6017,11 +6113,11 @@ redux-segment@^1.6.1:
   resolved "https://registry.yarnpkg.com/redux-segment/-/redux-segment-1.6.1.tgz#813d0734ae7b5de14e863202afd20c24de79022e"
 
 redux-socket-cluster@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/redux-socket-cluster/-/redux-socket-cluster-0.10.1.tgz#76c1917f2b621d826e52b532235d04aa62485759"
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/redux-socket-cluster/-/redux-socket-cluster-0.10.2.tgz#33763c510d48919e77b3f2d55eebed386947bb41"
   dependencies:
     es6-promisify "^4.1.0"
-    react "^15.3.0"
+    react "^15.4.2"
 
 redux-storage-engine-localstorage@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
- fixes raven warning on server
- makes sure any call to rethinkdb returns a promise (regression from fixing the unnecessary await lint rule)
- goes back to plain jane babelrc for dev so we can work on safari 9 (i guess the extra work isn't _that_ slow, but it was nice debugging without a new closure for every use of `const` and `await`. someday....)

