### PR TITLE
Team dash header (Lobby button! Team settings! and more!)

### DIFF
--- a/src/universal/components/Button/Button.js
+++ b/src/universal/components/Button/Button.js
@@ -211,7 +211,8 @@ const styleThunk = (theme, props) => ({
 
   buttonInner: {
     display: 'block',
-    fontSize: 0
+    fontSize: 0,
+    whiteSpace: 'nowrap'
   },
 
   label: {

--- a/src/universal/components/Dashboard/DashHeaderInfo.js
+++ b/src/universal/components/Dashboard/DashHeaderInfo.js
@@ -31,7 +31,7 @@ const styleThunk = () => ({
 
   title: {
     ...ui.dashHeaderTitleStyles,
-    marginRight: '1.5rem'
+    marginRight: '2rem'
   }
 });
 

--- a/src/universal/components/Dashboard/DashHeaderInfo.js
+++ b/src/universal/components/Dashboard/DashHeaderInfo.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react';
 import withStyles from 'universal/styles/withStyles';
 import {css} from 'aphrodite-local-styles/no-important';
-import appTheme from 'universal/styles/theme/appTheme';
+import ui from 'universal/styles/ui';
 
 const DashHeaderInfo = (props) => {
   const {children, styles, title} = props;
@@ -10,11 +10,7 @@ const DashHeaderInfo = (props) => {
       <div className={css(styles.title)}>
         {title}
       </div>
-      {children &&
-        <div className={css(styles.children)}>
-          {children}
-        </div>
-      }
+      {children}
     </div>
   );
 };
@@ -28,23 +24,14 @@ DashHeaderInfo.propTypes = {
 
 const styleThunk = () => ({
   root: {
+    alignItems: 'center',
+    display: 'flex',
     width: '100%'
   },
 
   title: {
-    color: appTheme.palette.dark10d,
-    // @terry, had to do this to bump down the children for the error message when it comes
-    display: 'inline-block',
-    fontSize: appTheme.typography.s5,
-    height: appTheme.typography.s6,
-    lineHeight: appTheme.typography.s6
-  },
-
-  children: {
-    color: appTheme.palette.dark70l,
-    fontSize: appTheme.typography.s2,
-    lineHeight: appTheme.typography.sBase,
-    marginTop: '.125rem'
+    ...ui.dashHeaderTitleStyles,
+    marginRight: '1.5rem'
   }
 });
 

--- a/src/universal/components/DashboardAvatars/DashboardAvatars.js
+++ b/src/universal/components/DashboardAvatars/DashboardAvatars.js
@@ -35,17 +35,13 @@ DashboardAvatars.propTypes = {
 
 const styleThunk = () => ({
   root: {
-    fontSize: 0,
-    position: 'relative',
-    textAlign: 'right',
+    display: 'flex',
     width: '100%'
   },
 
   item: {
-    display: 'inline-block',
-    margin: '0 .75rem',
-    position: 'relative',
-    verticalAlign: 'middle'
+    margin: '0 0 0 1rem',
+    position: 'relative'
   }
 });
 

--- a/src/universal/components/Editable/Editable.js
+++ b/src/universal/components/Editable/Editable.js
@@ -47,9 +47,10 @@ class Editable extends Component {
       styles.input
     );
 
-    const submitAndSet = (e) => {
+    const submitAndSet = async (e) => {
       e.preventDefault();
-      if (!handleSubmit()) {
+      const didSubmit = await handleSubmit();
+      if (!didSubmit) {
         this.unsetEditing();
       }
     };

--- a/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
@@ -188,7 +188,7 @@ export default class MeetingContainer extends Component {
     const {dispatch, isFacilitating, team: {id: teamId}} = this.props;
     // if we call router.push
     if (safeRoute === false && Date.now() - infiniteLoopTimer < 1000) {
-      if (++infiniteloopCounter >= 100) {
+      if (++infiniteloopCounter >= 10) {
         // if we're changing locations 10 times in a second, it's probably infinite
         if (isFacilitating) {
           const variables = {

--- a/src/universal/modules/teamDashboard/components/EditTeamName/EditTeamName.js
+++ b/src/universal/modules/teamDashboard/components/EditTeamName/EditTeamName.js
@@ -2,13 +2,12 @@ import React, {PropTypes} from 'react';
 import Editable from 'universal/components/Editable/Editable';
 import {cashay} from 'cashay';
 import {reduxForm, Field} from 'redux-form';
+import ui from 'universal/styles/ui';
 import appTheme from 'universal/styles/theme/appTheme';
 import editTeamNameValidation from './editTeamNameValidation';
 
 const fieldStyles = {
-  color: appTheme.palette.dark10d,
-  fontSize: appTheme.typography.s5,
-  lineHeight: appTheme.typography.s6,
+  ...ui.dashHeaderTitleStyles,
   placeholderColor: appTheme.palette.mid70l
 };
 

--- a/src/universal/modules/teamDashboard/components/Team/Team.js
+++ b/src/universal/modules/teamDashboard/components/Team/Team.js
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react';
-import FontAwesome from 'react-fontawesome';
+import withStyles from 'universal/styles/withStyles';
+import {css} from 'aphrodite-local-styles/no-important';
 import EditTeamName from 'universal/modules/teamDashboard/components/EditTeamName/EditTeamName';
 import {
   DashContent,
@@ -7,61 +8,12 @@ import {
   DashHeaderInfo,
   DashMain,
 } from 'universal/components/Dashboard';
-import {Link, withRouter} from 'react-router';
+import {withRouter} from 'react-router';
+import Button from 'universal/components/Button/Button';
 import DashboardAvatars from 'universal/components/DashboardAvatars/DashboardAvatars';
 import UnpaidTeamModalContainer from 'universal/modules/teamDashboard/containers/UnpaidTeamModal/UnpaidTeamModalContainer';
 import ui from 'universal/styles/ui';
 import MeetingInProgressModal from '../MeetingInProgressModal/MeetingInProgressModal';
-
-const faIconStyle = {
-  fontSize: '14px',
-  lineHeight: 'inherit',
-  marginRight: '.25rem'
-};
-
-const linkStyle = {
-  display: 'inline-block',
-  height: '15px',
-  lineHeight: '15px',
-  marginRight: '1.5rem',
-  textDecoration: 'none'
-};
-
-const standardLinks = (teamId) => {
-  return (
-    <div>
-      <Link
-        to={`/meeting/${teamId}`}
-        style={linkStyle}
-        title="Meeting Lobby"
-      >
-        <FontAwesome name="arrow-circle-right" style={faIconStyle} /> Meeting Lobby
-      </Link>
-      <Link
-        to={`/team/${teamId}/settings`}
-        style={linkStyle}
-        title="Team Settings"
-      >
-        <FontAwesome name="cog" style={faIconStyle} /> Team Settings
-      </Link>
-    </div>
-  );
-};
-
-const settingsLinks = (teamId) => {
-  return (
-    <div>
-      <Link
-        to={`/team/${teamId}`}
-        style={linkStyle}
-        title="Back to Team Dashboard"
-      >
-        <FontAwesome name="arrow-circle-left" style={faIconStyle} /> Back to Team Dashboard
-      </Link>
-    </div>
-  );
-};
-
 
 // use the same object so the EditTeamName doesn't rerender so gosh darn always
 const initialValues = {teamName: ''};
@@ -71,6 +23,7 @@ const Team = (props) => {
     children,
     hasDashAlert,
     router,
+    styles,
     team,
     teamMembers
   } = props;
@@ -81,6 +34,12 @@ const Team = (props) => {
   initialValues.teamName = teamName;
   const DashHeaderInfoTitle = isSettings ? <EditTeamName initialValues={initialValues} teamName={teamName} teamId={teamId} /> : teamName;
   const modalLayout = hasDashAlert ? ui.modalLayoutMainWithDashAlert : ui.modalLayoutMain;
+  const goToMeetingLobby = () =>
+    router.push(`/meeting/${teamId}/`);
+  const goToTeamSettings = () =>
+    router.push(`/team/${teamId}/settings/`);
+  const goToTeamDashboard = () =>
+    router.push(`/team/${teamId}`);
   return (
     <DashMain>
       <MeetingInProgressModal
@@ -98,9 +57,44 @@ const Team = (props) => {
       />
       <DashHeader hasOverlay={hasOverlay}>
         <DashHeaderInfo title={DashHeaderInfoTitle}>
-          {isSettings ? settingsLinks(teamId) : standardLinks(teamId)}
+          {!isSettings &&
+            <Button
+              buttonStyle="solid"
+              colorPalette="warm"
+              icon="users"
+              iconPlacement="left"
+              label="Meeting Lobby"
+              onClick={goToMeetingLobby}
+              raised
+              size="smallest"
+            />
+          }
         </DashHeaderInfo>
-        <DashboardAvatars teamMembers={teamMembers} />
+        <div className={css(styles.teamLinks)}>
+          {isSettings ?
+            <Button
+              buttonStyle="flat"
+              colorPalette="cool"
+              icon="arrow-circle-left"
+              iconPlacement="left"
+              isBlock
+              label="Back to Team Dashboard"
+              onClick={goToTeamDashboard}
+              size="smallest"
+            /> :
+            <Button
+              buttonStyle="flat"
+              colorPalette="cool"
+              icon="cog"
+              iconPlacement="left"
+              isBlock
+              label="Team Settings"
+              onClick={goToTeamSettings}
+              size="smallest"
+            />
+          }
+          <DashboardAvatars teamMembers={teamMembers} />
+        </div>
       </DashHeader>
       <DashContent hasOverlay={hasOverlay} padding="0">
         {children}
@@ -113,8 +107,16 @@ Team.propTypes = {
   children: PropTypes.any,
   hasDashAlert: PropTypes.bool,
   router: PropTypes.object,
+  styles: PropTypes.object,
   team: PropTypes.object.isRequired,
   teamMembers: PropTypes.array.isRequired
 };
 
-export default withRouter(Team);
+const styleThunk = () => ({
+  teamLinks: {
+    display: 'flex',
+    flexWrap: 'nowrap'
+  }
+});
+
+export default withRouter(withStyles(styleThunk)(Team));

--- a/src/universal/modules/teamDashboard/components/Team/Team.js
+++ b/src/universal/modules/teamDashboard/components/Team/Team.js
@@ -73,6 +73,7 @@ const Team = (props) => {
         <div className={css(styles.teamLinks)}>
           {isSettings ?
             <Button
+              key="1"
               buttonStyle="flat"
               colorPalette="cool"
               icon="arrow-circle-left"
@@ -83,6 +84,7 @@ const Team = (props) => {
               size="smallest"
             /> :
             <Button
+              key="2"
               buttonStyle="flat"
               colorPalette="cool"
               icon="cog"

--- a/src/universal/modules/userDashboard/components/SettingsHeader/SettingsHeader.js
+++ b/src/universal/modules/userDashboard/components/SettingsHeader/SettingsHeader.js
@@ -4,7 +4,6 @@ import {css} from 'aphrodite-local-styles/no-important';
 import {withRouter} from 'react-router';
 import {SETTINGS, ORGANIZATIONS, NOTIFICATIONS} from 'universal/utils/constants';
 import ui from 'universal/styles/ui';
-import appTheme from 'universal/styles/theme/appTheme';
 
 const heading = {
   [SETTINGS]: {

--- a/src/universal/modules/userDashboard/components/SettingsHeader/SettingsHeader.js
+++ b/src/universal/modules/userDashboard/components/SettingsHeader/SettingsHeader.js
@@ -3,6 +3,7 @@ import withStyles from 'universal/styles/withStyles';
 import {css} from 'aphrodite-local-styles/no-important';
 import {withRouter} from 'react-router';
 import {SETTINGS, ORGANIZATIONS, NOTIFICATIONS} from 'universal/utils/constants';
+import ui from 'universal/styles/ui';
 import appTheme from 'universal/styles/theme/appTheme';
 
 const heading = {
@@ -41,11 +42,7 @@ const styleThunk = () => ({
   },
 
   heading: {
-    color: appTheme.palette.dark10d,
-    fontSize: appTheme.typography.s5,
-    fontWeight: 400,
-    height: appTheme.typography.s6,
-    lineHeight: appTheme.typography.s6,
+    ...ui.dashHeaderTitleStyles,
     margin: 0,
     padding: 0
   }

--- a/src/universal/modules/userDashboard/components/UserDashMain/UserDashMain.js
+++ b/src/universal/modules/userDashboard/components/UserDashMain/UserDashMain.js
@@ -17,14 +17,15 @@ import getRallyLink from 'universal/modules/userDashboard/helpers/getRallyLink';
 
 const UserDashMain = (props) => {
   const {styles} = props;
-  const makeSeparator = () =>
-    <span className={css(styles.separator)}>{' // '}</span>;
   return (
     <DashMain>
       <DashHeader>
         <DashHeaderInfo title="My Dashboard">
           <div className={css(styles.headerCopy)}>
-            {makeDateString()}{makeSeparator()}<span className={css(styles.hover)}>{getRallyLink()}!</span>
+            {makeDateString()}<br />
+            <span className={css(styles.rallyLink)}>
+              <i>{getRallyLink()}</i>
+            </span>
           </div>
         </DashHeaderInfo>
       </DashHeader>
@@ -64,28 +65,25 @@ const styleThunk = () => ({
     width: ui.dashActionsWidth
   },
 
-  hover: {
-    color: 'inherit'
-  },
-
   projectsLayout: {
     display: 'flex',
     flex: 1,
     flexDirection: 'column'
   },
 
-  separator: {
-    paddingLeft: '.5em',
-    paddingRight: '.5em'
-  },
-
   headerCopy: {
     color: appTheme.palette.mid,
     flex: 1,
     fontSize: appTheme.typography.sBase,
-    lineHeight: '1.5',
+    fontWeight: 700,
+    lineHeight: '1.25',
     textAlign: 'right'
-  }
+  },
+
+  rallyLink: {
+    color: 'inherit',
+    fontWeight: 400
+  },
 });
 
 export default withStyles(styleThunk)(UserDashMain);

--- a/src/universal/modules/userDashboard/components/UserDashMain/UserDashMain.js
+++ b/src/universal/modules/userDashboard/components/UserDashMain/UserDashMain.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react';
 import withStyles from 'universal/styles/withStyles';
 import {css} from 'aphrodite-local-styles/no-important';
 import ui from 'universal/styles/ui';
+import appTheme from 'universal/styles/theme/appTheme';
 import UserActions from 'universal/modules/userDashboard/components/UserActions/UserActions';
 import UserColumnsContainer from 'universal/modules/userDashboard/containers/UserColumns/UserColumnsContainer';
 import UserProjectsHeaderContainer from 'universal/modules/userDashboard/containers/UserProjectsHeader/UserProjectsHeaderContainer';
@@ -22,7 +23,9 @@ const UserDashMain = (props) => {
     <DashMain>
       <DashHeader>
         <DashHeaderInfo title="My Dashboard">
-          {makeDateString()}{makeSeparator()}<span className={css(styles.crayCrayHover)}>{getRallyLink()}!</span>
+          <div className={css(styles.headerCopy)}>
+            {makeDateString()}{makeSeparator()}<span className={css(styles.hover)}>{getRallyLink()}!</span>
+          </div>
         </DashHeaderInfo>
       </DashHeader>
       <DashContent padding="0">
@@ -61,7 +64,7 @@ const styleThunk = () => ({
     width: ui.dashActionsWidth
   },
 
-  crayCrayHover: {
+  hover: {
     color: 'inherit'
   },
 
@@ -74,6 +77,14 @@ const styleThunk = () => ({
   separator: {
     paddingLeft: '.5em',
     paddingRight: '.5em'
+  },
+
+  headerCopy: {
+    color: appTheme.palette.mid,
+    flex: 1,
+    fontSize: appTheme.typography.sBase,
+    lineHeight: '1.5',
+    textAlign: 'right'
   }
 });
 

--- a/src/universal/styles/ui.js
+++ b/src/universal/styles/ui.js
@@ -227,6 +227,12 @@ const ui = {
   dashGutter: '1rem',
   // Note: property 'dashMinWidth' prevents layout from collapsing in Safari
   //       in a better future we may be more adaptive/responsive (TA)
+  dashHeaderTitleStyles: {
+    color: appTheme.palette.dark,
+    fontSize: '1.75rem',
+    fontWeight: 400,
+    lineHeight: '1.5'
+  },
   dashMinWidth: '79rem',
   dashAlertHeight: '2.625rem',
   dashSectionHeaderLineHeight: '2rem',


### PR DESCRIPTION
- Adds a raised button to *Meeting Lobby*
- New *Team Settings* flat button is over by the team avatars
- Main dash header title is larger
- My Dashboard header, moved the Date and Easter Egg to the far right

[record.it](http://recordit.co/M3lXqqwOVh)
![GIF](http://g.recordit.co/M3lXqqwOVh.gif)