### PR TITLE
Toggle updated/created timestamp

### DIFF
--- a/src/universal/components/EditingStatus/EditingStatus.js
+++ b/src/universal/components/EditingStatus/EditingStatus.js
@@ -5,13 +5,18 @@ import appTheme from 'universal/styles/theme/appTheme';
 import ui from 'universal/styles/ui';
 
 const EditingStatus = (props) => {
-  const {status, styles} = props;
-  return <div className={css(styles.timestamp)}>{status}</div>;
+  const {status, styles, handleClick} = props;
+  return (
+    <div className={css(styles.timestamp)} onClick={handleClick}>
+      {status}
+    </div>
+  );
 };
 
 EditingStatus.propTypes = {
-  status: PropTypes.any,
-  styles: PropTypes.object
+  handleClick: PropTypes.func.isRequired,
+  status: PropTypes.string.isRequired,
+  styles: PropTypes.object.isRequired
 };
 
 const styleThunk = () => ({

--- a/src/universal/containers/EditingStatus/EditingStatusContainer.js
+++ b/src/universal/containers/EditingStatus/EditingStatusContainer.js
@@ -19,12 +19,12 @@ query {
 }
 `;
 
-const makeEditingStatus = (editors, active, updatedAt) => {
+const makeEditingStatus = (editors, active, timestamp, timestampType) => {
   let editingStatus = null;
   // no one else is editing
   if (editors.length === 0) {
     editingStatus = active ? <span>editing<Ellipsis /></span> :
-      fromNow(updatedAt);
+      ((timestampType === 'updatedAt' ? 'Updated ' : 'Created ') + fromNow(timestamp));
   } else {
     const editorNames = editors.map((e) => e.teamMember.preferredName);
     // one other is editing
@@ -79,22 +79,29 @@ export default class EditingStatusContainer extends Component {
     className: PropTypes.object,
     editors: PropTypes.any,
     outcomeId: PropTypes.string,
-    updatedAt: PropTypes.instanceOf(Date)
+    updatedAt: PropTypes.instanceOf(Date),
+    createdAt: PropTypes.instanceOf(Date)
   };
 
   constructor(props) {
     super(props);
     const {active, editors, updatedAt, createdAt} = this.props;
+    const timestampType = 'updatedAt'; // Should pull this default from storage instead
+    const timestamp = timestampType === 'updatedAt' ? updatedAt : createdAt;
     this.state = {
-      editingStatus: makeEditingStatus(editors, active, updatedAt)
+      timestampType,
+      editingStatus: makeEditingStatus(editors, active, timestamp, timestampType)
     };
+    this.toggleTimestamp = this.toggleTimestamp.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    const {active, editors, updatedAt} = nextProps;
+    const {active, editors, updatedAt, createdAt} = nextProps;
+    const {timestampType} = this.state;
+    const timestamp = timestampType === 'updatedAt' ? updatedAt : createdAt;
     if (this.props.active !== active || this.props.editors !== editors) {
       this.setState({
-        editingStatus: makeEditingStatus(editors, active, updatedAt)
+        editingStatus: makeEditingStatus(editors, active, timestamp, timestampType)
       });
     }
   }
@@ -104,19 +111,28 @@ export default class EditingStatusContainer extends Component {
   }
 
   toggleTimestamp() {
-    console.log('toggle timestamp');
+    const {timestampType} = this.state;
+    const {editors, active, updatedAt, createdAt} = this.props;
+    const newTimestampType = timestampType === 'updatedAt' ? 'createdAt' : 'updatedAt';
+    const timestamp = newTimestampType === 'updatedAt' ? updatedAt : createdAt;
+    this.setState({
+      timestampType: newTimestampType,
+      editingStatus: makeEditingStatus(editors, active, timestamp, newTimestampType)
+    });
+    clearTimeout(this.refreshTimer);
   }
 
   render() {
-    const {active, editors, updatedAt} = this.props;
-    const {editingStatus} = this.state;
+    const {active, editors, updatedAt, createdAt} = this.props;
+    const {editingStatus, timestampType} = this.state;
+    const timestamp = timestampType === 'updatedAt' ? updatedAt : createdAt;
     clearTimeout(this.refreshTimer);
-    const refreshPeriod = getRefreshPeriod(updatedAt);
+    const refreshPeriod = getRefreshPeriod(timestamp);
     this.refreshTimer = setTimeout(() => {
       this.setState({
-        editingStatus: makeEditingStatus(editors, active, updatedAt)
+        editingStatus: makeEditingStatus(editors, active, timestamp, timestampType)
       });
     }, refreshPeriod);
-    return <EditingStatus status={editingStatus} handleClick={this.toggleTimestamp}/>;
+    return <EditingStatus status={editingStatus} handleClick={this.toggleTimestamp} />;
   }
 }

--- a/src/universal/containers/EditingStatus/EditingStatusContainer.js
+++ b/src/universal/containers/EditingStatus/EditingStatusContainer.js
@@ -84,7 +84,7 @@ export default class EditingStatusContainer extends Component {
 
   constructor(props) {
     super(props);
-    const {active, editors, updatedAt} = this.props;
+    const {active, editors, updatedAt, createdAt} = this.props;
     this.state = {
       editingStatus: makeEditingStatus(editors, active, updatedAt)
     };
@@ -103,6 +103,10 @@ export default class EditingStatusContainer extends Component {
     clearTimeout(this.refreshTimer);
   }
 
+  toggleTimestamp() {
+    console.log('toggle timestamp');
+  }
+
   render() {
     const {active, editors, updatedAt} = this.props;
     const {editingStatus} = this.state;
@@ -113,6 +117,6 @@ export default class EditingStatusContainer extends Component {
         editingStatus: makeEditingStatus(editors, active, updatedAt)
       });
     }, refreshPeriod);
-    return <EditingStatus status={editingStatus} />;
+    return <EditingStatus status={editingStatus} handleClick={this.toggleTimestamp}/>;
   }
 }

--- a/src/universal/containers/EditingStatus/EditingStatusContainer.js
+++ b/src/universal/containers/EditingStatus/EditingStatusContainer.js
@@ -99,7 +99,11 @@ export default class EditingStatusContainer extends Component {
     const {active, editors, updatedAt, createdAt} = nextProps;
     const {timestampType} = this.state;
     const timestamp = timestampType === 'updatedAt' ? updatedAt : createdAt;
-    if (this.props.active !== active || this.props.editors !== editors) {
+    if (this.props.active !== active
+        || this.props.editors !== editors
+        || this.props.updatedAt !== updatedAt
+        || this.props.createdAt !== createdAt
+      ) {
       this.setState({
         editingStatus: makeEditingStatus(editors, active, timestamp, timestampType)
       });
@@ -119,7 +123,6 @@ export default class EditingStatusContainer extends Component {
       timestampType: newTimestampType,
       editingStatus: makeEditingStatus(editors, active, timestamp, newTimestampType)
     });
-    clearTimeout(this.refreshTimer);
   }
 
   render() {

--- a/src/universal/containers/ProjectCard/ProjectCardContainer.js
+++ b/src/universal/containers/ProjectCard/ProjectCardContainer.js
@@ -28,6 +28,7 @@ query {
     status
     teamMemberId
     updatedAt
+    createdAt
     teamMember @cached(type: "TeamMember") {
       id
       picture

--- a/src/universal/modules/outcomeCard/components/OutcomeCard/OutcomeCard.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCard/OutcomeCard.js
@@ -63,6 +63,7 @@ const OutcomeCard = (props) => {
             form={form}
             outcomeId={outcome.id}
             updatedAt={outcome.updatedAt}
+            createdAt={outcome.createdAt}
           />
           <form>
             <Field


### PR DESCRIPTION
This PR addresses https://github.com/ParabolInc/action/issues/551 :)

Clicking the timestamp will toggle between displaying createdAt or updatedAt as shown below:
![screen shot 2017-04-06 at 11 53 19 pm](https://cloud.githubusercontent.com/assets/10405248/24784980/4633b04e-1b24-11e7-8f33-c0c822144833.png)
![screen shot 2017-04-06 at 11 53 29 pm](https://cloud.githubusercontent.com/assets/10405248/24784982/464fb9e2-1b24-11e7-8dd6-47d2ce1ef955.png)

Currently it will display the updatedAt timestamp by default unless you click on a timestamp.