### PR TITLE
Keyboard shortcuts for markdown

### DIFF
--- a/src/universal/modules/outcomeCard/components/OutcomeCardTextarea/OutcomeCardTextarea.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardTextarea/OutcomeCardTextarea.js
@@ -139,11 +139,6 @@ class OutcomeCardTextArea extends Component {
     );
   }
 
-  /* Works in ES5 onwards
-     But planning to make edits to match React code structure (use this. refs instead of document. ...)
-      - open to take the risk for now but uncertain on "correctness" for submission 
-  */
-
   function replaceIt(markdown) {
 	//get start and finish points of selected text in active textarea element
     var start = document.activeElement.selectionStart;
@@ -187,9 +182,7 @@ class OutcomeCardTextArea extends Component {
       }
   }
   document.onkeydown = KeyPress;
-
-  //Working on code to re-place caret depending on markdown (better usability)... 
-
+  
   render() {
     const {input: {value}} = this.props;
     return (

--- a/src/universal/modules/outcomeCard/components/OutcomeCardTextarea/OutcomeCardTextarea.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardTextarea/OutcomeCardTextarea.js
@@ -138,7 +138,6 @@ class OutcomeCardTextArea extends Component {
       </div>
     );
   }
- 
 
   /* Works in ES5 onwards
      But planning to make edits to match React code structure (use this. refs instead of document. ...)

--- a/src/universal/modules/outcomeCard/components/OutcomeCardTextarea/OutcomeCardTextarea.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardTextarea/OutcomeCardTextarea.js
@@ -138,6 +138,58 @@ class OutcomeCardTextArea extends Component {
       </div>
     );
   }
+ 
+
+  /* Works in ES5 onwards
+     But planning to make edits to match React code structure (use this. refs instead of document. ...)
+      - open to take the risk for now but uncertain on "correctness" for submission 
+  */
+
+  function replaceIt(markdown) {
+	//get start and finish points of selected text in active textarea element
+    var start = document.activeElement.selectionStart;
+    var end = document.activeElement.selectionEnd;
+
+    //select and remove text for markdown replacement 
+    var selectedText = document.activeElement.value.slice(start, end);
+    var before = document.activeElement.value.slice(0, start);
+    var after = document.activeElement.value.slice(end);
+    var text;
+
+    //depending on which shortcut used, edit text 
+    switch(markdown) {
+        case "cmdk":
+        	text = before + ("[" + selectedText + "]()") + after;
+        	document.activeElement.value = text; break;
+        case "cmdb":
+        	text = before + ("**" + selectedText + "**") + after;
+        	document.activeElement.value = text; break;
+        case "cmdi": 
+        	text = before + ("_" + selectedText + "_") + after;
+        	document.activeElement.value = text; break;
+    }
+  }
+
+  function KeyPress(e) {
+    //onKeyDown handler
+    //only enable markdown shortcuts if user within text area & card is in edit mode (class content_fhpdck)
+    if (((document.activeElement.tagName === "TEXTAREA") || (document.activeElement.tagName === "INPUT" && document.activeElement.type === "text")) && (document.activeElement.classList.contains("content_fhpdck"))) {
+          var evtobj = window.event ? event : e
+          //check which key pressed, run corresponding edit
+          if (evtobj.keyCode == 75 && evtobj.metaKey) {
+            replaceIt("cmdk");
+          } else if (evtobj.keyCode == 66 && evtobj.metaKey) {
+            replaceIt("cmdb");
+          } else if (evtobj.keyCode == 73 && evtobj.metaKey) {
+            replaceIt("cmdi");
+        } else {
+          null;
+        }
+      }
+  }
+  document.onkeydown = KeyPress;
+
+  //Working on code to re-place caret depending on markdown (better usability)... 
 
   render() {
     const {input: {value}} = this.props;


### PR DESCRIPTION
- Code works from regular ES5 JavaScript framework onwards
   - But aiming to make edits to match React code structure 
      (i.e. use this. refs instead of document. ...)
   - open to take the risk with my best attempt for now but uncertain on "correctness" for submission 
  
- Currently working on code to re-place caret depending on markdown (better usability for client)... 
