### PR TITLE
force add build directory

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -88,7 +88,7 @@ stages:
                 echo ${BASH_REMATCH[1]})"
             git config --global user.name "Parabol CircleCI"
             git config --global user.email "admin+circleci@parabol.co"
-            git add build
+            git add build -f
             git commit -m "build $ACTION_VERSION" build
           fi
 


### PR DESCRIPTION
let's force add the build directory instead of ignoring it. this should clean up our git status immensely while working. 