### PR TITLE
fix getKey

### DIFF
--- a/src/server/database/migrations/20170714185201-removeEmptyContent.js
+++ b/src/server/database/migrations/20170714185201-removeEmptyContent.js
@@ -1,6 +1,6 @@
 exports.up = async (r) => {
   r.table('Project')
-    .filter((doc) => doc('content').match('"?blocks"?:\s*\\[\s*]'))
+    .filter((doc) => doc('content').match('"?blocks"?:\\s*\\[\\s*]'))
     .delete()
     .run();
 };

--- a/src/server/database/migrations/20170714185201-removeEmptyContent.js
+++ b/src/server/database/migrations/20170714185201-removeEmptyContent.js
@@ -1,6 +1,6 @@
 exports.up = async (r) => {
   r.table('Project')
-    .filter((doc) => doc('content').match('"blocks":\\[]'))
+    .filter((doc) => doc('content').match('"?blocks"?:\s*\\[\s*]'))
     .delete()
     .run();
 };

--- a/src/server/database/migrations/20170714185201-removeEmptyContent.js
+++ b/src/server/database/migrations/20170714185201-removeEmptyContent.js
@@ -1,0 +1,10 @@
+exports.up = async (r) => {
+  r.table('Project')
+    .filter((doc) => doc('content').match('"blocks":\\[]'))
+    .delete()
+    .run();
+};
+
+exports.down = async () => {
+  // noop
+};

--- a/src/universal/validation/legitify.js
+++ b/src/universal/validation/legitify.js
@@ -54,7 +54,7 @@ class Legitity {
   }
 
   trim() {
-    this.value = this.value && this.value.trim();
+    this.value = this.value && this.value.trim ? this.value.trim() : this.value;
     return this;
   }
 
@@ -65,6 +65,7 @@ class Legitity {
         this.error = msg;
       }
     }
+    return this;
   }
 
   test(check) {

--- a/src/universal/validation/makeProjectSchema.js
+++ b/src/universal/validation/makeProjectSchema.js
@@ -1,7 +1,9 @@
+import {ContentState, convertToRaw} from 'draft-js';
+import {columnArray, PROJECT_MAX_CHARS} from 'universal/utils/constants';
 import {compositeId} from 'universal/validation/templates';
-import {columnArray} from 'universal/utils/constants';
 import legitify from './legitify';
-import {PROJECT_MAX_CHARS} from 'universal/utils/constants';
+
+const makeEmptyStr = () => JSON.stringify(convertToRaw(ContentState.createFromText('')));
 
 export default function makeProjectSchema() {
   return legitify({
@@ -9,9 +11,25 @@ export default function makeProjectSchema() {
     agendaId: compositeId,
     content: (value) => value
       .trim()
+      .normalize((str) => {
+        let parsedContent;
+        try {
+          parsedContent = JSON.parse(str);
+        } catch (e) {
+          return makeEmptyStr();
+        }
+        const keys = Object.keys(parsedContent);
+        if (keys.length !== 2 ||
+          typeof parsedContent.entityMap !== 'object' ||
+          !Array.isArray(parsedContent.blocks ||
+          parsedContent.blocks.length === 0)) {
+          return makeEmptyStr();
+        }
+        return str;
+      })
       .max(PROJECT_MAX_CHARS, 'Whoa! That looks like 2 projects'),
     status: (value) => value
-      // status may be empty eg unarchive card
+    // status may be empty eg unarchive card
       .test((str) => str && !columnArray.includes(str) && 'That isn’t a status!'),
     teamMemberId: compositeId,
     sortOrder: (value) => value.float()


### PR DESCRIPTION
This nukes bad records in the DB & makes it so no more bad records can enter the DB.
fixes #1243 fixes #1228

Problem:
The draft-js raw state had an empty block array. So, when you go to retrieve a block like `.first()` it will return undefined instead of an object. We could fix the rehydration function to always give it at least 1 block, but then the state on the client doesn't match what's in the DB, plus we'd have to be careful every time we did a rehydrate.

the simpler solution is to ensure that the blocks array has at least 1 block before writing it to the DB.
