### PR TITLE
add an adminUserId to every github integration

### DIFF
--- a/src/server/graphql/mutations/addGitHubRepo.js
+++ b/src/server/graphql/mutations/addGitHubRepo.js
@@ -73,6 +73,7 @@ export default {
           r.table(GITHUB)
             .insert({
               id: shortid.generate(),
+              adminUserId: userId,
               createdAt: now,
               updatedAt: now,
               isActive: true,
@@ -83,6 +84,7 @@ export default {
           r.table(GITHUB)
             .get(integrationId)
             .update({
+              adminUserId: userId,
               isActive: true,
               userIds,
               updatedAt: now

--- a/src/server/graphql/types/GitHubIntegration.js
+++ b/src/server/graphql/types/GitHubIntegration.js
@@ -13,6 +13,10 @@ const GitHubIntegration = new GraphQLObjectType({
   fields: () => ({
     // shortid
     id: globalIdField(GITHUB, ({id}) => id),
+    adminUserId: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'The parabol userId of the admin for this repo (usually the creator)'
+    },
     createdAt: {
       type: new GraphQLNonNull(GraphQLISO8601Type),
       description: 'The datetime the integration was created'


### PR DESCRIPTION
@jordanh 
since we haven't pushed github to master, i'd like to sneak this guy in. very simple, very basic. but if i can get it in now it means i don't have to write a migration later.