### PR TITLE
Quick update to ISSUE_TEMPLATE.md for OS Naming conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 [Describe the bug here, remove this section if issue is a feature enhancement request]
 
-- **OS:** OSX / Linux / Windows / ?
+- **OS:** macOS / Linux / Windows / ?
 - **Browser:** Chrome / Safari / Lynx / ? + version
 - **Node version:** `node --version`
 - **NPM version:** `npm --version`


### PR DESCRIPTION
It bothers me to see OSX in locations when it should be macOS for anything modern.