### PR TITLE
Fix Outcome Card editing state to reflect open modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Additional dependencies include [redis](https://redis.io/), and
 ```bash
 $ git clone https://github.com/ParabolInc/action.git
 $ cd action
+$ cp .env.example .env # be sure to verify the API keys have useful values
 $ rethinkdb # in a separate window
 $ yarn
 $ npm run quickstart

--- a/src/universal/components/EditorLinkChanger/EditorLinkChanger.js
+++ b/src/universal/components/EditorLinkChanger/EditorLinkChanger.js
@@ -46,6 +46,16 @@ class EditorLinkChanger extends Component {
     }
   };
 
+  componentWillMount() {
+    const {setEditingMeta} = this.props;
+    setEditingMeta(true);
+  }
+
+  componentWillUnmount() {
+    const {setEditingMeta} = this.props;
+    setEditingMeta(false);
+  }
+
   render() {
     const {
       isClosing,
@@ -121,6 +131,7 @@ EditorLinkChanger.propTypes = {
   removeModal: PropTypes.func.isRequired,
   selectionState: PropTypes.object.isRequired,
   setEditorState: PropTypes.func.isRequired,
+  setEditingMeta: PropTypes.func.isRequired,
   setRef: PropTypes.func,
   styles: PropTypes.object,
   text: PropTypes.string,

--- a/src/universal/components/EditorLinkChanger/EditorLinkChanger.js
+++ b/src/universal/components/EditorLinkChanger/EditorLinkChanger.js
@@ -47,13 +47,13 @@ class EditorLinkChanger extends Component {
   };
 
   componentWillMount() {
-    const {setEditingMeta} = this.props;
-    setEditingMeta(true);
+    const {trackEditingClient} = this.props;
+    trackEditingClient('editor-link-changer', true);
   }
 
   componentWillUnmount() {
-    const {setEditingMeta} = this.props;
-    setEditingMeta(false);
+    const {trackEditingClient} = this.props;
+    trackEditingClient('editor-link-changer', false);
   }
 
   render() {
@@ -131,7 +131,7 @@ EditorLinkChanger.propTypes = {
   removeModal: PropTypes.func.isRequired,
   selectionState: PropTypes.object.isRequired,
   setEditorState: PropTypes.func.isRequired,
-  setEditingMeta: PropTypes.func.isRequired,
+  trackEditingClient: PropTypes.func.isRequired,
   setRef: PropTypes.func,
   styles: PropTypes.object,
   text: PropTypes.string,

--- a/src/universal/components/ProjectEditor/ProjectEditor.js
+++ b/src/universal/components/ProjectEditor/ProjectEditor.js
@@ -18,6 +18,7 @@ class ProjectEditor extends Component {
     editorRef: PropTypes.any,
     editorState: PropTypes.object,
     setEditorState: PropTypes.func,
+    setEditingMeta: PropTypes.func,
     handleBeforeInput: PropTypes.func,
     handleChange: PropTypes.func,
     handleUpArrow: PropTypes.func,

--- a/src/universal/components/ProjectEditor/ProjectEditor.js
+++ b/src/universal/components/ProjectEditor/ProjectEditor.js
@@ -18,7 +18,7 @@ class ProjectEditor extends Component {
     editorRef: PropTypes.any,
     editorState: PropTypes.object,
     setEditorState: PropTypes.func,
-    setEditingMeta: PropTypes.func,
+    trackEditingClient: PropTypes.func,
     handleBeforeInput: PropTypes.func,
     handleChange: PropTypes.func,
     handleUpArrow: PropTypes.func,

--- a/src/universal/components/ProjectEditor/withLinks.js
+++ b/src/universal/components/ProjectEditor/withLinks.js
@@ -57,7 +57,8 @@ const withLinks = (ComposedComponent) => {
       keyBindingFn: PropTypes.func,
       removeModal: PropTypes.func,
       renderModal: PropTypes.func,
-      setEditorState: PropTypes.func.isRequired
+      setEditorState: PropTypes.func.isRequired,
+      setEditingMeta: PropTypes.func.isRequired
     };
     state = {};
 
@@ -241,7 +242,7 @@ const withLinks = (ComposedComponent) => {
     renderChangerModal = () => {
       const {linkChangerData} = this.state;
       const {text, link, selectionState} = linkChangerData;
-      const {editorState, setEditorState, editorRef} = this.props;
+      const {editorState, setEditorState, setEditingMeta, editorRef} = this.props;
       return (
         <EditorLinkChanger
           isOpen
@@ -251,6 +252,7 @@ const withLinks = (ComposedComponent) => {
           editorState={editorState}
           selectionState={selectionState}
           setEditorState={setEditorState}
+          setEditingMeta={setEditingMeta}
           removeModal={this.removeModal}
           text={text}
           initialValues={{text, link}}

--- a/src/universal/components/ProjectEditor/withLinks.js
+++ b/src/universal/components/ProjectEditor/withLinks.js
@@ -58,7 +58,7 @@ const withLinks = (ComposedComponent) => {
       removeModal: PropTypes.func,
       renderModal: PropTypes.func,
       setEditorState: PropTypes.func.isRequired,
-      setEditingMeta: PropTypes.func.isRequired
+      trackEditingClient: PropTypes.func.isRequired
     };
     state = {};
 
@@ -242,7 +242,7 @@ const withLinks = (ComposedComponent) => {
     renderChangerModal = () => {
       const {linkChangerData} = this.state;
       const {text, link, selectionState} = linkChangerData;
-      const {editorState, setEditorState, setEditingMeta, editorRef} = this.props;
+      const {editorState, setEditorState, trackEditingClient, editorRef} = this.props;
       return (
         <EditorLinkChanger
           isOpen
@@ -252,7 +252,7 @@ const withLinks = (ComposedComponent) => {
           editorState={editorState}
           selectionState={selectionState}
           setEditorState={setEditorState}
-          setEditingMeta={setEditingMeta}
+          trackEditingClient={trackEditingClient}
           removeModal={this.removeModal}
           text={text}
           initialValues={{text, link}}

--- a/src/universal/modules/outcomeCard/components/OutcomeCard/OutcomeCard.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCard/OutcomeCard.js
@@ -29,6 +29,7 @@ const OutcomeCard = (props) => {
     outcome,
     setEditorRef,
     setEditorState,
+    setEditingMeta,
     styles,
     teamMembers,
     toggleMenuState
@@ -65,6 +66,7 @@ const OutcomeCard = (props) => {
           readOnly={Boolean(isArchived || isDragging || service)}
           setEditorRef={setEditorRef}
           setEditorState={setEditorState}
+          setEditingMeta={setEditingMeta}
           teamMembers={teamMembers}
         />
         <ProjectIntegrationLink integration={integration} />
@@ -105,6 +107,7 @@ OutcomeCard.propTypes = {
   }),
   setEditorRef: PropTypes.func.isRequired,
   setEditorState: PropTypes.func,
+  setEditingMeta: PropTypes.func,
   styles: PropTypes.object,
   teamMembers: PropTypes.array,
   toggleMenuState: PropTypes.func.isRequired

--- a/src/universal/modules/outcomeCard/components/OutcomeCard/OutcomeCard.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCard/OutcomeCard.js
@@ -29,7 +29,7 @@ const OutcomeCard = (props) => {
     outcome,
     setEditorRef,
     setEditorState,
-    setEditingMeta,
+    trackEditingClient,
     styles,
     teamMembers,
     toggleMenuState
@@ -66,7 +66,7 @@ const OutcomeCard = (props) => {
           readOnly={Boolean(isArchived || isDragging || service)}
           setEditorRef={setEditorRef}
           setEditorState={setEditorState}
-          setEditingMeta={setEditingMeta}
+          trackEditingClient={trackEditingClient}
           teamMembers={teamMembers}
         />
         <ProjectIntegrationLink integration={integration} />
@@ -107,7 +107,7 @@ OutcomeCard.propTypes = {
   }),
   setEditorRef: PropTypes.func.isRequired,
   setEditorState: PropTypes.func,
-  setEditingMeta: PropTypes.func,
+  trackEditingClient: PropTypes.func,
   styles: PropTypes.object,
   teamMembers: PropTypes.array,
   toggleMenuState: PropTypes.func.isRequired

--- a/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
+++ b/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
@@ -85,9 +85,7 @@ class OutcomeCardContainer extends Component {
     });
   };
 
-  isEditing = () => {
-    return !this.state.activeEditingClients.isEmpty()
-  }
+  isEditing = () => !this.state.activeEditingClients.isEmpty();
 
   trackEditingClient = (uid, isEditing) => {
     this.setState((curState) => {
@@ -97,7 +95,7 @@ class OutcomeCardContainer extends Component {
         : currentClients.remove(uid);
       return {activeEditingClients: updatedClients};
     });
-  }
+  };
 
   setEditorRef = (c) => {
     this.setState({

--- a/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
+++ b/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
@@ -136,7 +136,7 @@ class OutcomeCardContainer extends Component {
   };
 
   render() {
-    const {cardHasFocus, cardHasHover, isEditingText, isEditingMeta, editorRef, editorState, editorHasModal} = this.state;
+    const {cardHasFocus, cardHasHover, isEditingText, isEditingMeta, editorRef, editorState} = this.state;
     const {area, hasDragStyles, isAgenda, outcome, teamMembers, isDragging} = this.props;
     return (
       <div

--- a/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
+++ b/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
@@ -64,7 +64,7 @@ class OutcomeCardContainer extends Component {
     const wasFocused = this.state.editorState.getSelection().getHasFocus();
     const isFocused = editorState.getSelection().getHasFocus();
     if (wasFocused !== isFocused) {
-      this.setState({isEditingText: isFocused})
+      this.setState({isEditingText: isFocused});
       this.announceEditing(isFocused);
       if (!isFocused) {
         this.handleCardUpdate();

--- a/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
+++ b/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
@@ -63,10 +63,7 @@ class OutcomeCardContainer extends Component {
   componentDidUpdate(prevProps, prevState) {
     const curEditingClients = this.state.activeEditingClients;
     const prevEditingClients = prevState.activeEditingClients;
-    const shouldAnnounceEditing =
-      (curEditingClients.isEmpty() && !prevEditingClients.isEmpty()) ||
-      (!curEditingClients.isEmpty() && prevEditingClients.isEmpty());
-    if (shouldAnnounceEditing) {
+    if (curEditingClients.isEmpty() !== prevEditingClients.isEmpty()) {
       this.announceEditing(!curEditingClients.isEmpty());
     }
   }
@@ -155,7 +152,7 @@ class OutcomeCardContainer extends Component {
 
   render() {
     const {isEditing} = this;
-    const {cardHasFocus, cardHasHover, editorRef, editorState, editorHasModal} = this.state;
+    const {activeEditingClients, cardHasFocus, cardHasHover, editorRef, editorState, editorHasModal} = this.state;
     const {area, hasDragStyles, isAgenda, outcome, teamMembers, isDragging} = this.props;
     return (
       <div
@@ -178,7 +175,7 @@ class OutcomeCardContainer extends Component {
           hasDragStyles={hasDragStyles}
           isAgenda={isAgenda}
           isDragging={isDragging}
-          isEditing={isEditing()}
+          isEditing={!activeEditingClients.isEmpty()}
           outcome={outcome}
           setEditorRef={this.setEditorRef}
           setEditorState={this.setEditorState}

--- a/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
+++ b/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
@@ -36,6 +36,8 @@ class OutcomeCardContainer extends Component {
     super(props);
     const {contentState} = props;
     this.state = {
+      isEditingText: false,
+      isEditingMeta: false,
       cardHasHover: false,
       cardHasFocus: false,
       editorState: EditorState.createWithContent(contentState, editorDecorators),
@@ -62,7 +64,8 @@ class OutcomeCardContainer extends Component {
     const wasFocused = this.state.editorState.getSelection().getHasFocus();
     const isFocused = editorState.getSelection().getHasFocus();
     if (wasFocused !== isFocused) {
-      this.annouceEditing(isFocused);
+      this.setState({isEditingText: isFocused})
+      this.announceEditing(isFocused);
       if (!isFocused) {
         this.handleCardUpdate();
       }
@@ -72,6 +75,9 @@ class OutcomeCardContainer extends Component {
     });
   };
 
+  setEditingMeta = (isEditingMeta) => {
+    this.setState({isEditingMeta});
+  }
 
   setEditorRef = (c) => {
     this.setState({
@@ -118,10 +124,7 @@ class OutcomeCardContainer extends Component {
 
   handleCardFocus = () => this.setState({cardHasFocus: true});
 
-  annouceEditing = (isEditing) => {
-    this.setState({
-      isEditing
-    });
+  announceEditing = (isEditing) => {
     const {outcome: {id: projectId}} = this.props;
     const [teamId] = projectId.split('::');
     cashay.mutate('edit', {
@@ -133,7 +136,7 @@ class OutcomeCardContainer extends Component {
   };
 
   render() {
-    const {cardHasFocus, cardHasHover, isEditing, editorRef, editorState} = this.state;
+    const {cardHasFocus, cardHasHover, isEditingText, isEditingMeta, editorRef, editorState, editorHasModal} = this.state;
     const {area, hasDragStyles, isAgenda, outcome, teamMembers, isDragging} = this.props;
     return (
       <div
@@ -156,10 +159,11 @@ class OutcomeCardContainer extends Component {
           hasDragStyles={hasDragStyles}
           isAgenda={isAgenda}
           isDragging={isDragging}
-          isEditing={isEditing}
+          isEditing={isEditingText || isEditingMeta}
           outcome={outcome}
           setEditorRef={this.setEditorRef}
           setEditorState={this.setEditorState}
+          setEditingMeta={this.setEditingMeta}
           teamMembers={teamMembers}
           toggleMenuState={this.toggleMenuState}
         />


### PR DESCRIPTION
Fixes https://github.com/ParabolInc/action/issues/1258

Todo:
- tests! I'll ask about this in slack...

Note that I thought it would be useful to distinguish between "I'm editing some text on the card" state and "I'm editing something else about the card" state in order to usefully reason about "overall editing state".

