### PR TITLE
Epic6.5 hotfix

### DIFF
--- a/src/server/graphql/models/Team/notifySlack/notifySlack.js
+++ b/src/server/graphql/models/Team/notifySlack/notifySlack.js
@@ -16,7 +16,11 @@ const notifySlack = async (integrations, teamId, slackText) => {
   const provider = await r.table('Provider')
     .getAll(teamId, {index: 'teamId'})
     .filter({service: SLACK, isActive: true})
-    .nth(0);
+    .nth(0)
+    .default(null);
+  if (!provider) {
+    throw new Error('SlackIntegration exists without Provider! Something is fishy');
+  }
   // for each slack channel, send a notification
   for (let i = 0; i < integrations.length; i++) {
     const integration = integrations[i];

--- a/src/server/safeMutations/addProviderGitHub.js
+++ b/src/server/safeMutations/addProviderGitHub.js
@@ -103,10 +103,10 @@ const addProviderGitHub = async (code, teamId, userId) => {
           }, {returnChanges: true})('changes')(0)
       );
     });
-  const provider = providerChange.new_val;
+  const {new_val: provider, old_val: oldProvider} = providerChange;
 
   const rowDetails = await getProviderRowData(GITHUB, teamId);
-  const isUpdate = providerChange.old_val.isActive;
+  const isUpdate = oldProvider && oldProvider.isActive;
   const joinedIntegrationIds = await getJoinedIntegrationIds(teamId, provider, rowDetails.integrationCount, isUpdate);
   const teamMemberId = `${userId}::${teamId}`;
   const teamMember = await getTeamMember(joinedIntegrationIds, teamMemberId);

--- a/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
@@ -328,9 +328,10 @@ export default class MeetingContainer extends Component {
       || ((localPhase === CHECKIN || localPhase === UPDATES) && members.length < localPhaseItem)) {
       return <LoadingView />;
     }
-    const phasesAlwaysInSync = ['lobby', 'firstcall', 'lastcall'];
-    const inSync = isFacilitating || phasesAlwaysInSync.includes(meetingPhase) ? true :
-      localPhase + localPhaseItem === facilitatorPhase + facilitatorPhaseItem;
+
+    const inSync = isFacilitating || facilitatorPhase === localPhase &&
+      // FIXME remove || when changing to relay. right now it's a null & an undefined
+      (facilitatorPhaseItem === localPhaseItem || !facilitatorPhaseItem && !localPhaseItem);
     const rejoinFacilitator = () => {
       const pushURL = makePushURL(teamId, facilitatorPhase, facilitatorPhaseItem);
       history.push(pushURL);


### PR DESCRIPTION
it
- [ ] shows rejoin facilitator button when the facilitator is on firstCall & the follower is on checkin
- [ ] let's you create a brand new GitHub integration (wipe the Providers table in the DB & revoke all token on GitHub to simulate a "brand new" integration) 