### PR TITLE
Issue #854: MailChimp API integration - Sync users with a MailChimp list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,12 @@ GITHUB_CLIENT_ID="smellslikemeat"
 GITHUB_CLIENT_SECRET="rottenmeat"
 SLACK_CLIENT_ID="iWaNnAKiSsYoUAlLOvAh"
 SLACK_CLIENT_SECRET="aNdOvAhAnDAgAiNTiLThEnIgHTClOsEsIn"
+
+# MailChimp user sync support. Uncomment to:
+# Keep users in sync with a MailChimp mailing list
+# Users are synced during sign up and when profile edits are made
+# MAILCHIMP_LIST_ID is the MailChimp list to add/update members to
+# MAILCHIMP_NAME_MERGE_KEY is the MailChimp field to sync `preferredName` to
+MAILCHIMP_API_KEY="secretpotatoes-us8"
+MAILCHIMP_LIST_ID="2652429778"
+MAILCHIMP_NAME_MERGE_KEY="PREFNAME"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .env
 .idea/
+.vscode/
 build/
 coverage/
 dll/

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "isomorphic-fetch": "2.2.1",
     "jsonwebtoken": "^7.4.2",
     "jwt-decode": "^2.1.0",
+    "mailchimp-api-v3": "^1.7.0",
     "mailcomposer": "^4.0.1",
     "mailgun-js": "^0.13.1",
     "markdown-it": "^8.3.1",

--- a/src/server/__tests__/utils/mailchimpHelpers.test.js
+++ b/src/server/__tests__/utils/mailchimpHelpers.test.js
@@ -1,0 +1,16 @@
+import { emailHash, getAddOrUpdateMemberPath } from '../../utils/mailchimpHelpers';
+
+describe('mailchimp', () => {
+  it('generates an md5 hash from an email', () => {
+    expect(emailHash('burin@example.com')).toBe('37c9841fb76c8c7089219053056f502a');
+  });
+
+  it('generates the same md5 hash from an email, ignoring case', () => {
+    expect(emailHash('burin@EXAMPLE.com')).toBe('37c9841fb76c8c7089219053056f502a');
+  });
+
+  it('generates the proper url, given a list ID and email', () => {
+    const expectedPath = '/lists/123/members/37c9841fb76c8c7089219053056f502a';
+    expect(getAddOrUpdateMemberPath(123, 'burin@EXAMPLE.com')).toBe(expectedPath);
+  });
+});

--- a/src/server/graphql/models/User/userMutation.js
+++ b/src/server/graphql/models/User/userMutation.js
@@ -16,6 +16,7 @@ import makeUserServerSchema from 'universal/validation/makeUserServerSchema';
 import tmsSignToken from 'server/utils/tmsSignToken';
 import {GraphQLURLType} from '../../types';
 import segmentIo from 'server/utils/segmentIo';
+import mailchimp from 'server/utils/mailchimp';
 import addFeatureFlag from './addFeatureFlag/addFeatureFlag';
 
 export default {
@@ -142,6 +143,7 @@ export default {
           name: newUser.preferredName
         }
       });
+      mailchimp.addOrUpdateMemberToList(newUser.email, newUser);
       // don't await
       setTimeout(() => sendEmail(newUser.email, 'welcomeEmail', newUser), 0);
       return newUser;
@@ -196,6 +198,7 @@ export default {
           name: dbProfile.preferredName
         }
       });
+      mailchimp.addOrUpdateMemberToList(dbProfile.email, dbProfile);
       return dbProfile;
     }
   }

--- a/src/server/utils/mailchimp.js
+++ b/src/server/utils/mailchimp.js
@@ -1,0 +1,57 @@
+import Mailchimp from 'mailchimp-api-v3';
+import getDotenv from '../../universal/utils/dotenv';
+import { getAddOrUpdateMemberPath } from './mailchimpHelpers';
+
+getDotenv();
+
+const {
+  MAILCHIMP_LIST_ID,
+  MAILCHIMP_API_KEY,
+  MAILCHIMP_NAME_MERGE_KEY
+} = process.env;
+const isConfigured =
+  MAILCHIMP_LIST_ID && MAILCHIMP_API_KEY && MAILCHIMP_NAME_MERGE_KEY;
+if (!isConfigured) {
+  console.log('mailchimp api integration not configured, not syncing users');
+  console.log('MAILCHIMP_API_KEY: ', MAILCHIMP_API_KEY);
+  console.log('MAILCHIMP_LIST_ID: ', MAILCHIMP_LIST_ID);
+  console.log('MAILCHIMP_NAME_MERGE_KEY: ', MAILCHIMP_NAME_MERGE_KEY);
+}
+
+function notSetUpFn() {
+  return true;
+}
+
+const MailChimpAPI = isConfigured ? new Mailchimp(MAILCHIMP_API_KEY) : {
+  put: notSetUpFn
+};
+
+const mailchimpWrapper = {
+  addOrUpdateMemberToList: (email, { preferredName }) => {
+    const endpoint = getAddOrUpdateMemberPath(MAILCHIMP_LIST_ID, email);
+    const mergeFields = {};
+    mergeFields[MAILCHIMP_NAME_MERGE_KEY] = preferredName;
+    const requestBody = {
+      email_address: email,
+      status_if_new: 'subscribed',
+      merge_fields: mergeFields
+    };
+
+    MailChimpAPI.put(endpoint, requestBody)
+      .then(() => {
+        // console.log(response);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }
+};
+
+const mailchimpMock = {
+  addOrUpdateMemberToList: notSetUpFn,
+  createMember: notSetUpFn
+};
+
+const mailchimp = isConfigured ? mailchimpWrapper : mailchimpMock;
+
+export default mailchimp;

--- a/src/server/utils/mailchimpHelpers.js
+++ b/src/server/utils/mailchimpHelpers.js
@@ -1,0 +1,16 @@
+import crypto from 'crypto';
+
+function emailHash(email) {
+  return crypto.createHash('md5').update(email.toLowerCase()).digest('hex');
+}
+
+function getAddOrUpdateMemberPath(listId, email) {
+  const subscriberHash = emailHash(email);
+  const addOrUpdateMemberURL = `/lists/${listId}/members/${subscriberHash}`;
+  return addOrUpdateMemberURL;
+}
+
+export {
+  getAddOrUpdateMemberPath,
+  emailHash
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,7 +1413,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-"bluebird@>= 3.0.1", bluebird@^3.3.3, bluebird@^3.3.4, bluebird@^3.5.0:
+"bluebird@>= 3.0.1", bluebird@^3.3.3, bluebird@^3.3.4, bluebird@^3.4.0, bluebird@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
@@ -5444,6 +5444,15 @@ macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
+mailchimp-api-v3@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/mailchimp-api-v3/-/mailchimp-api-v3-1.7.0.tgz#ce56e341ad9661da5cfc673f6f1173d747f2e35c"
+  dependencies:
+    bluebird "^3.4.0"
+    lodash "^3.10.1"
+    request "^2.67.0"
+    tar "^2.2.1"
+
 mailcomposer@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/mailcomposer/-/mailcomposer-4.0.2.tgz#b635402cc7f2eedb10130d3d09ad88b1c2d7e101"
@@ -7419,7 +7428,7 @@ request-promise-native@^1.0.3:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.0"
 
-request@2.81.0, request@^2.79.0, request@^2.81.0:
+request@2.81.0, request@^2.67.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:


### PR DESCRIPTION
This addresses issue #854.

### What does this do?

After this gets merged, we don't have to run a query, get a list of emails+names since the last time, and paste them into MailChimp. Over and over. 

This integration allows us to automatically sync users with a MailChimp list when users sign up or update their profile.  🤖🤖🤖

### Technical details

It uses this API endpoint that allows you to use one endpoint for adds and updates. If the user exists, it'll update it, if they don't, it'll add the user.

http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#edit-put_lists_list_id_members_subscriber_hash

Brought in this npm package, but I also have a (not as nice) version without it. https://www.npmjs.com/package/mailchimp-api-v3

### How do I set it up?

Sign up for a MailChimp account.

You'll need 3 things added to your `.env`:

`MAILCHIMP_API_KEY, MAILCHIMP_LIST_ID, MAILCHIMP_NAME_MERGE_KEY`

### MAILCHIMP_API_KEY

Create an API key here: https://admin.mailchimp.com/account/api/

### MAILCHIMP_LIST_ID

Go to your list and get the list ID (it's not the one in the URL when you click on a list. I learned the hard way).

https://admin.mailchimp.com/lists/

Click the dropdown next to a list -> Settings -> Scroll down to `Unique id for list xyz`

### MAILCHIMP_NAME_MERGE_KEY

From that same list settings page, go to `List fields and *|MERGE|* tags`.

You may have a `FNAME` and `LNAME` field. You'll want to create a field for where Parabol's preferredName will get synced. I called mine "PREFNAME", with a long label of "Preferred Name". If you have one already, you can use the existing key, or `MERGE3`, etc.

### Testing Scenarios

#### Prereq

- Configure those keys
- Restart/deploy

#### Signing up

Signing up should add a new member to your list if they don't already exist. If they do, it'll just update their name.

#### Profile edits

Changing your preferred name from the profile settings page should update the preferred name in MailChimp.

#### Without it configured (no keys, or not all keys configured)

I spent a lot of time testing whether this works fine without having the keys configured, and wrote a lot of defensive code in case people don't want this integration. 

#### Things to watch out for

- MailChimp sometimes takes a few seconds to update, so if it doesn't update, refresh the list after a few seconds.

- Since this touches the sign up flow, I'm looking for any weird cases that could make this blow up and am looking for extra eyes there. I don't want sign ups to fail because of some failure here!

- No migration of existing users. This only adds folks when they sign up or when they edit their profile. We can run a script to import existing users outside of this PR IMO.

### Misc stuff I did already

- Manually tested the two main scenarios end to end (sign up, profile edit)
- `npm run lint`
- ran just the tests I added in `mailchimp.test.js`



