### PR TITLE
Epic6.5 Summary Email Sprint (TA)

### DIFF
--- a/src/universal/modules/email/components/QuickStats/QuickStats.js
+++ b/src/universal/modules/email/components/QuickStats/QuickStats.js
@@ -55,7 +55,6 @@ const QuickStats = (props) => {
 
   return (
     <div>
-      <EmptySpace height={32} />
       <div style={headingStyles}>
         Quick Stats
       </div>

--- a/src/universal/modules/email/components/SummaryEmail/SummaryEmail.js
+++ b/src/universal/modules/email/components/SummaryEmail/SummaryEmail.js
@@ -161,7 +161,13 @@ const SummaryEmail = (props) => {
           <tbody>
             <tr>
               <td align="center" style={{padding: 0}}>
-                <SummaryHeader createdAt={createdAt} referrer={referrer} teamDashUrl={teamDashUrl} teamName={teamName} />
+                <SummaryHeader
+                  createdAt={createdAt}
+                  meetingNumber={meetingNumber}
+                  referrer={referrer}
+                  teamDashUrl={teamDashUrl}
+                  teamName={teamName}
+                />
               </td>
             </tr>
           </tbody>

--- a/src/universal/modules/email/components/SummaryEmail/SummaryEmail.js
+++ b/src/universal/modules/email/components/SummaryEmail/SummaryEmail.js
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import appTheme from 'universal/styles/theme/appTheme';
 import ui from 'universal/styles/ui';
+import appTheme from 'universal/styles/theme/appTheme';
 import {createGoogleCalendarInviteURL, makeIcsUrl} from 'universal/utils/makeCalendarInvites';
-
 import Body from '../../components/Body/Body';
 import ContactUs from '../../components/ContactUs/ContactUs';
 import EmptySpace from '../../components/EmptySpace/EmptySpace';
@@ -13,8 +12,7 @@ import QuickStats from '../../components/QuickStats/QuickStats';
 import SummaryHeader from '../../components/SummaryHeader/SummaryHeader';
 import UserProjects from '../UserProjects/UserProjects';
 import UserNoNewOutcomes from '../../components/UserNoNewOutcomes/UserNoNewOutcomes';
-
-import {makeSuccessExpression, makeSuccessStatement} from 'universal/utils/makeSuccessCopy';
+import {makeSuccessExpression} from 'universal/utils/makeSuccessCopy';
 
 const ruleStyle = {
   backgroundColor: ui.emailRuleColor,
@@ -28,7 +26,7 @@ const message = {
   color: appTheme.palette.dark,
   fontFamily: ui.emailFontFamily,
   fontSize: '18px',
-  lineHeight: '28px',
+  lineHeight: '27px',
   padding: '0 16px',
   textAlign: 'center',
   whiteSpace: 'pre-line'
@@ -41,8 +39,11 @@ const linkStyles = {
 };
 
 const greetingStyles = {
+  color: appTheme.palette.cool,
+  fontWeight: 700,
   fontSize: '27px',
-  lineHeight: '40px'
+  lineHeight: '40px',
+  textAlign: 'inherit'
 };
 
 const bannerStyle = {
@@ -155,96 +156,17 @@ const SummaryEmail = (props) => {
         </tbody>
       </table>
       <Body verticalGutter={0}>
+        {/* Summary Header */}
         <table align="center" style={ui.emailTableBase} width="100%">
           <tbody>
             <tr>
               <td align="center" style={{padding: 0}}>
-                {/* Summary Header */}
                 <SummaryHeader createdAt={createdAt} referrer={referrer} teamDashUrl={teamDashUrl} teamName={teamName} />
-                {/* Message */}
-                {meetingNumber === 1 ?
-                  <div>
-                    <div style={message}>
-                      <b style={greetingStyles}>{makeSuccessExpression()}!</b><br />
-                      {`
-                      Way to go on your first Action Meeting!
-                      You are unlocking new superpowers.
-                      High-performing teams have regular habits!
-                      Create a 30-minute meeting at the start of each week.
-                      `}
-                      <br />
-                      <div>
-                        <span>{'Tap here to schedule:'}</span>
-                        <br />
-                        <div style={iconLinkBlock}>
-                          <a
-                            href={createGoogleCalendarInviteURL(createdAt, meetingUrl, teamName)}
-                            rel="noopener noreferrer"
-                            style={iconLink}
-                            target="_blank"
-                          >
-                            <img
-                              style={iconLinkIcon}
-                              src="/static/images/icons/google@5x.png"
-                              height={iconSize}
-                              width={iconSize}
-                            />
-                            <span style={iconLinkLabel}>Google Calendar</span>
-                          </a>
-                        </div>
-                        <div style={iconLinkBlock}>
-                          <a
-                            href={makeIcsUrl(createdAt, meetingUrl, teamName)}
-                            rel="noopener noreferrer"
-                            style={iconLink}
-                            target="_blank"
-                          >
-                            <img
-                              style={iconLinkIcon}
-                              src="/static/images/icons/calendar-plus-o@5x.png"
-                              height={iconSize}
-                              width={iconSize}
-                            />
-                            <span style={iconLinkLabel}>Outlook, etc.</span>
-                          </a>
-                        </div>
-                      </div>
-                      {'Or, make your own and include this link as the location:'}
-                      <EmptySpace height={8} />
-                      <table align="center" style={meetingLinkTable} width="80%">
-                        <tbody>
-                          <tr>
-                            <td align="center" style={meetingLinkBlock}>
-                              <a href={meetingUrl} style={meetingLink}>
-                                {meetingUrl}
-                              </a>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div> :
-                  <div>
-                    {agendaItemsCompleted === 0 ?
-                      <div style={message}>
-                        <b style={greetingStyles}>{'Hey there!'}</b><br />
-                        {'It looks like there weren’t any agenda items.'}<br />
-                        {'Did our software give you trouble?'}<br />
-                        {'Let us know: '}
-                        <a href="mailto:love@parabol.co" style={linkStyles} title="Email us at: love@parabol.co">love@parabol.co</a>
-                      </div> :
-                      <div style={message}>
-                        <b style={greetingStyles}>{makeSuccessExpression()}!</b><br />
-                        {makeSuccessStatement()}
-                      </div>
-                    }
-                  </div>
-                }
-                <EmptySpace height={8} />
               </td>
             </tr>
           </tbody>
         </table>
+        {/* Quick Stats */}
         <table align="center" style={ui.emailTableBase} width="100%">
           <tbody>
             <tr>
@@ -268,14 +190,94 @@ const SummaryEmail = (props) => {
         <EmptySpace height={0} />
         <hr style={ruleStyle} />
         <EmptySpace height={48} />
-        <ContactUs
-          fontSize={18}
-          hasLearningLink
-          lineHeight={1.5}
-          prompt="How’d your meeting go?"
-          tagline="We’re eager for your feedback!"
-          vSpacing={0}
-        />
+        {/* First-time prompt to schedule recurring meeting */}
+        {meetingNumber === 1 ?
+          <table align="center" style={ui.emailTableBase} width="100%">
+            <tbody>
+              <tr>
+                <td align="center" style={{padding: 0}}>
+                  <div style={message}>
+                    <div style={greetingStyles}>{makeSuccessExpression()}!</div>
+                    {`Way to go on your first Action Meeting!
+                      You are unlocking new superpowers.
+                      High-performing teams have regular habits!
+                      Create a 30-minute meeting at the start of each week.`}
+                    <br />
+                    <div>
+                      <span>{'Tap here to schedule:'}</span>
+                      <br />
+                      <div style={iconLinkBlock}>
+                        <a
+                          href={createGoogleCalendarInviteURL(createdAt, meetingUrl, teamName)}
+                          rel="noopener noreferrer"
+                          style={iconLink}
+                          target="_blank"
+                        >
+                          <img
+                            style={iconLinkIcon}
+                            src="/static/images/icons/google@5x.png"
+                            height={iconSize}
+                            width={iconSize}
+                          />
+                          <span style={iconLinkLabel}>Google Calendar</span>
+                        </a>
+                      </div>
+                      <div style={iconLinkBlock}>
+                        <a
+                          href={makeIcsUrl(createdAt, meetingUrl, teamName)}
+                          rel="noopener noreferrer"
+                          style={iconLink}
+                          target="_blank"
+                        >
+                          <img
+                            style={iconLinkIcon}
+                            src="/static/images/icons/calendar-plus-o@5x.png"
+                            height={iconSize}
+                            width={iconSize}
+                          />
+                          <span style={iconLinkLabel}>Outlook, etc.</span>
+                        </a>
+                      </div>
+                    </div>
+                    {'Or, make your own and include this link as the location:'}
+                    <EmptySpace height={8} />
+                    <table align="center" style={meetingLinkTable} width="80%">
+                      <tbody>
+                        <tr>
+                          <td align="center" style={meetingLinkBlock}>
+                            <a href={meetingUrl} style={meetingLink}>
+                              {meetingUrl}
+                            </a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table> :
+          <div>
+            {agendaItemsCompleted === 0 ?
+              <div style={message}>
+                {/* No agenda items? */}
+                <div style={greetingStyles}>{'Hey there!'}</div>
+                {`It looks like there weren’t any agenda items.
+                  Did our software give you trouble?
+                  Let us know: `}
+                <a href="mailto:love@parabol.co" style={linkStyles} title="Email us at: love@parabol.co">love@parabol.co</a>
+              </div> :
+              <ContactUs
+                fontSize={18}
+                hasLearningLink
+                lineHeight={1.5}
+                prompt="How’d your meeting go?"
+                tagline="We’re eager for your feedback!"
+                vSpacing={0}
+              />
+            }
+          </div>
+        }
         <EmptySpace height={32} />
       </Body>
       <Footer color={appTheme.palette.dark} />

--- a/src/universal/modules/email/components/SummaryHeader/SummaryHeader.js
+++ b/src/universal/modules/email/components/SummaryHeader/SummaryHeader.js
@@ -7,7 +7,7 @@ import makeDateString from 'universal/utils/makeDateString';
 import {Link} from 'react-router-dom';
 
 const SummaryHeader = (props) => {
-  const {createdAt, referrer, teamDashUrl, teamName} = props;
+  const {createdAt, meetingNumber, referrer, teamDashUrl, teamName} = props;
   const blockStyle = {
     backgroundColor: '#fff',
     border: '2px solid #D2D3DC',
@@ -60,7 +60,7 @@ const SummaryHeader = (props) => {
           <tr>
             <td style={blockStyle}>
               <div style={teamNameStyle}>{teamName}</div>
-              <div style={meetingDateStyle}>Meeting Summary • {meetingDate}</div>
+              <div style={meetingDateStyle}>{`Action Meeting #${meetingNumber}`} • {meetingDate}</div>
               {referrer === 'email' ?
                 <a
                   href={teamDashUrl}
@@ -90,6 +90,7 @@ SummaryHeader.propTypes = {
     700
   ]),
   lineHeight: PropTypes.number,
+  meetingNumber: PropTypes.number,
   padding: PropTypes.number,
   referrer: PropTypes.oneOf([
     'meeting',


### PR DESCRIPTION
This PR:

- [x] fixes #1283 Move summary “Quick Stats” above the fold
- [x] fixes #1056 Moves scheduling prompt below new projects
- [x] fixes #788 Adds meeting count stat to summary header

## Test plan

- [ ] Create a new team locally, then start and end a meeting. At the end of the email there should be a prompt to schedule a recurring meeting.
- [ ] Start and end a meeting with count 2+ for any given team. Process at least 1 agenda item. At the end of the email there is a general call-out for feedback.
- [ ] Start and end a meeting (2+) with 0 agenda items. The agenda item stat should be 0, there should be no new projects for any team member, and there is a call-out for help about the lack of agenda items at the end of the email.

## Screenshots

![screenshot 2017-09-01 14 04 45](https://user-images.githubusercontent.com/307286/29984444-1d0a5176-8f20-11e7-90b5-65a60ef3ca46.png)
![screenshot 2017-09-01 14 04 46](https://user-images.githubusercontent.com/307286/29984445-1d0c3766-8f20-11e7-97ef-6e52e7df00e2.png)
![screenshot 2017-09-01 14 04 49](https://user-images.githubusercontent.com/307286/29984446-1d0d1302-8f20-11e7-886c-a8b02fa72ca3.png)
