### PR TITLE
Epic 6.5 Sprint “Updates; No Projects” [WIP]

### DIFF
--- a/src/universal/components/Dashboard/DashModal.js
+++ b/src/universal/components/Dashboard/DashModal.js
@@ -61,6 +61,8 @@ DashModal.propTypes = {
   styles: PropTypes.object
 };
 
+// TODO: move common modal animations to ui.js
+
 const animateIn = {
   '0%': {
     opacity: '0',

--- a/src/universal/components/FieldArrayRow/FieldArrayRow.js
+++ b/src/universal/components/FieldArrayRow/FieldArrayRow.js
@@ -89,7 +89,7 @@ const highlightEmail = {
   '20%': {
     color: appTheme.palette.warm,
     fontSize: appTheme.typography.s4,
-    fontWeight: 800
+    fontWeight: 700
   },
   '100%': {
     color: appTheme.palette.dark,

--- a/src/universal/components/ProjectEditor/Hashtag.js
+++ b/src/universal/components/ProjectEditor/Hashtag.js
@@ -5,7 +5,7 @@ import appTheme from 'universal/styles/theme/appTheme';
 // inline styles so oy-vey doesn't barf when making emails using draft-js cards
 const style = {
   color: appTheme.palette.cool,
-  fontWeight: 800
+  fontWeight: 700
 };
 
 const Hashtag = (props) => {

--- a/src/universal/components/ProjectEditor/Mention.js
+++ b/src/universal/components/ProjectEditor/Mention.js
@@ -4,7 +4,7 @@ import appTheme from 'universal/styles/theme/appTheme';
 
 const style = {
   color: appTheme.palette.cool,
-  fontWeight: 800
+  fontWeight: 700
 };
 
 const Mention = (props) => {

--- a/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
+++ b/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import withStyles from 'universal/styles/withStyles';
 import {css} from 'aphrodite-local-styles/no-important';
+import ui from 'universal/styles/ui';
+import appTheme from 'universal/styles/theme/appTheme';
 import Button from 'universal/components/Button/Button';
 import MeetingMain from 'universal/modules/meeting/components/MeetingMain/MeetingMain';
 import MeetingSection from 'universal/modules/meeting/components/MeetingSection/MeetingSection';
@@ -9,6 +11,7 @@ import MeetingFacilitationHint from 'universal/modules/meeting/components/Meetin
 import {MEETING} from 'universal/utils/constants';
 import ProjectColumns from 'universal/components/ProjectColumns/ProjectColumns';
 import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
+import checkForProjects from 'universal/utils/checkForProjects';
 
 const MeetingUpdates = (props) => {
   const {
@@ -24,21 +27,25 @@ const MeetingUpdates = (props) => {
   const self = members.find((m) => m.isSelf);
   const currentTeamMember = members[localPhaseItem - 1];
   const isLastMember = localPhaseItem === members.length;
+  const hasProjects = checkForProjects(projects);
+  const advanceButton = () => (
+    <Button
+      buttonStyle="flat"
+      colorPalette="cool"
+      icon="arrow-circle-right"
+      iconPlacement="right"
+      key={`update${localPhaseItem}`}
+      label={isLastMember ? 'Move on to the Agenda' : 'Next team member '}
+      onClick={gotoNext}
+      size="small"
+    />
+  );
   return (
     <MeetingMain>
       <MeetingSection flexToFill>
         <div className={css(styles.layout)}>
           {showMoveMeetingControls ?
-            <Button
-              buttonStyle="flat"
-              colorPalette="cool"
-              icon="arrow-circle-right"
-              iconPlacement="right"
-              key={`update${localPhaseItem}`}
-              label={isLastMember ? 'Move on to the Agenda' : 'Next team member '}
-              onClick={gotoNext}
-              size="small"
-            /> :
+            advanceButton() :
             <MeetingFacilitationHint>
               {isLastMember ?
                 <span>{'Waiting for '}<b>{getFacilitatorName(team, members)}</b> {'to advance to the Agenda'}</span> :
@@ -48,6 +55,21 @@ const MeetingUpdates = (props) => {
           }
         </div>
         <div className={css(styles.body)}>
+          {!hasProjects &&
+            <div className={css(styles.noProjectsMessage)}>
+              <div className={css(styles.noProjectsHeading)}>
+                {'No projects; any updates?'}
+              </div>
+              <p>{'We’re not currently tracking any projects for'} <b>{currentTeamMember.preferredName}</b>.</p>
+              <p>{'You can add projects during the Agenda.'}</p>
+              <p>{'Just press “'}<b>{'+'}</b>{'” to add an Agenda Item.'}</p>
+              {showMoveMeetingControls &&
+                <div className={css(styles.noProjectsButtonBlock)}>
+                  {advanceButton()}
+                </div>
+              }
+            </div>
+          }
           <ProjectColumns alignColumns="center" myTeamMemberId={self && self.id} projects={projects} queryKey={queryKey} area={MEETING} />
         </div>
       </MeetingSection>
@@ -79,8 +101,39 @@ const styleThunk = () => ({
   body: {
     display: 'flex',
     flex: 1,
+    flexDirection: 'column',
     padding: '1rem 1rem 0',
+    position: 'relative',
     width: '100%'
+  },
+
+  noProjectsMessage: {
+    backgroundColor: appTheme.palette.light50l,
+    borderRadius: ui.modalBorderRadius,
+    boxShadow: ui.modalBoxShadow,
+    color: appTheme.palette.dark,
+    fontSize: appTheme.typography.s4,
+    left: '50%',
+    lineHeight: '1.5',
+    maxWidth: '36rem',
+    padding: '1.5rem',
+    position: 'absolute',
+    textAlign: 'center',
+    top: '6rem',
+    transform: 'translate3d(-50%, 0, 0)',
+    width: '100%',
+    zIndex: 200
+  },
+
+  noProjectsHeading: {
+    fontSize: appTheme.typography.s6,
+    fontWeight: 700,
+    lineHeight: '2',
+    margin: '0 0 1rem'
+  },
+
+  noProjectsButtonBlock: {
+    marginTop: '1rem'
   }
 });
 

--- a/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
+++ b/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
@@ -16,6 +16,7 @@ import checkForProjects from 'universal/utils/checkForProjects';
 const MeetingUpdates = (props) => {
   const {
     gotoNext,
+    canShowEmptyState,
     localPhaseItem,
     members,
     queryKey,
@@ -55,7 +56,7 @@ const MeetingUpdates = (props) => {
           }
         </div>
         <div className={css(styles.body)}>
-          {!hasProjects &&
+          {(!hasProjects && canShowEmptyState) &&
             <div className={css(styles.noProjectsMessage)}>
               <div className={css(styles.noProjectsHeading)}>
                 {'No projects; any updates?'}
@@ -80,6 +81,7 @@ const MeetingUpdates = (props) => {
 MeetingUpdates.propTypes = {
   gotoItem: PropTypes.func.isRequired,
   gotoNext: PropTypes.func.isRequired,
+  canShowEmptyState: PropTypes.bool,
   localPhaseItem: PropTypes.number.isRequired,
   members: PropTypes.array.isRequired,
   onFacilitatorPhase: PropTypes.bool,
@@ -122,7 +124,7 @@ const styleThunk = () => ({
     top: '6rem',
     transform: 'translate3d(-50%, 0, 0)',
     width: '100%',
-    zIndex: 200
+    zIndex: ui.zi7
   },
 
   noProjectsHeading: {

--- a/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
+++ b/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
@@ -11,12 +11,11 @@ import MeetingFacilitationHint from 'universal/modules/meeting/components/Meetin
 import {MEETING} from 'universal/utils/constants';
 import ProjectColumns from 'universal/components/ProjectColumns/ProjectColumns';
 import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
-import checkForProjects from 'universal/utils/checkForProjects';
 
 const MeetingUpdates = (props) => {
   const {
     gotoNext,
-    canShowEmptyState,
+    showEmpty,
     localPhaseItem,
     members,
     queryKey,
@@ -28,7 +27,6 @@ const MeetingUpdates = (props) => {
   const self = members.find((m) => m.isSelf);
   const currentTeamMember = members[localPhaseItem - 1];
   const isLastMember = localPhaseItem === members.length;
-  const hasProjects = checkForProjects(projects);
   const advanceButton = () => (
     <Button
       buttonStyle="flat"
@@ -56,7 +54,7 @@ const MeetingUpdates = (props) => {
           }
         </div>
         <div className={css(styles.body)}>
-          {(!hasProjects && canShowEmptyState) &&
+          {showEmpty &&
             <div className={css(styles.noProjectsMessage)}>
               <div className={css(styles.noProjectsHeading)}>
                 {'No projects; any updates?'}
@@ -81,7 +79,7 @@ const MeetingUpdates = (props) => {
 MeetingUpdates.propTypes = {
   gotoItem: PropTypes.func.isRequired,
   gotoNext: PropTypes.func.isRequired,
-  canShowEmptyState: PropTypes.bool,
+  showEmpty: PropTypes.bool,
   localPhaseItem: PropTypes.number.isRequired,
   members: PropTypes.array.isRequired,
   onFacilitatorPhase: PropTypes.bool,

--- a/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
+++ b/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
@@ -2,8 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import withStyles from 'universal/styles/withStyles';
 import {css} from 'aphrodite-local-styles/no-important';
-import ui from 'universal/styles/ui';
-import appTheme from 'universal/styles/theme/appTheme';
 import Button from 'universal/components/Button/Button';
 import MeetingMain from 'universal/modules/meeting/components/MeetingMain/MeetingMain';
 import MeetingSection from 'universal/modules/meeting/components/MeetingSection/MeetingSection';
@@ -11,6 +9,7 @@ import MeetingFacilitationHint from 'universal/modules/meeting/components/Meetin
 import {MEETING} from 'universal/utils/constants';
 import ProjectColumns from 'universal/components/ProjectColumns/ProjectColumns';
 import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
+import MeetingUpdatesEmptyModal from 'universal/modules/meeting/components/MeetingUpdatesEmptyModal/MeetingUpdatesEmptyModal';
 
 const MeetingUpdates = (props) => {
   const {
@@ -54,22 +53,18 @@ const MeetingUpdates = (props) => {
           }
         </div>
         <div className={css(styles.body)}>
-          {showEmpty &&
-            <div className={css(styles.noProjectsMessage)}>
-              <div className={css(styles.noProjectsHeading)}>
-                {'No projects; any updates?'}
-              </div>
-              <p>{'We’re not currently tracking any projects for'} <b>{currentTeamMember.preferredName}</b>.</p>
-              <p>{'You can add projects during the Agenda.'}</p>
-              <p>{'Just press “'}<b>{'+'}</b>{'” to add an Agenda Item.'}</p>
-              {showMoveMeetingControls &&
-                <div className={css(styles.noProjectsButtonBlock)}>
-                  {advanceButton()}
-                </div>
-              }
-            </div>
-          }
-          <ProjectColumns alignColumns="center" myTeamMemberId={self && self.id} projects={projects} queryKey={queryKey} area={MEETING} />
+          <MeetingUpdatesEmptyModal
+            advanceButton={showMoveMeetingControls && advanceButton}
+            currentTeamMemberName={currentTeamMember.preferredName}
+            isOpen={showEmpty}
+          />
+          <ProjectColumns
+            alignColumns="center"
+            area={MEETING}
+            myTeamMemberId={self && self.id}
+            projects={projects}
+            queryKey={queryKey}
+          />
         </div>
       </MeetingSection>
     </MeetingMain>
@@ -103,37 +98,7 @@ const styleThunk = () => ({
     flex: 1,
     flexDirection: 'column',
     padding: '1rem 1rem 0',
-    position: 'relative',
     width: '100%'
-  },
-
-  noProjectsMessage: {
-    backgroundColor: appTheme.palette.light50l,
-    borderRadius: ui.modalBorderRadius,
-    boxShadow: ui.modalBoxShadow,
-    color: appTheme.palette.dark,
-    fontSize: appTheme.typography.s4,
-    left: '50%',
-    lineHeight: '1.5',
-    maxWidth: '36rem',
-    padding: '1.5rem',
-    position: 'absolute',
-    textAlign: 'center',
-    top: '6rem',
-    transform: 'translate3d(-50%, 0, 0)',
-    width: '100%',
-    zIndex: ui.zi7
-  },
-
-  noProjectsHeading: {
-    fontSize: appTheme.typography.s6,
-    fontWeight: 700,
-    lineHeight: '2',
-    margin: '0 0 1rem'
-  },
-
-  noProjectsButtonBlock: {
-    marginTop: '1rem'
   }
 });
 

--- a/src/universal/modules/meeting/components/MeetingUpdatesEmptyModal/MeetingUpdatesEmptyModal.js
+++ b/src/universal/modules/meeting/components/MeetingUpdatesEmptyModal/MeetingUpdatesEmptyModal.js
@@ -42,6 +42,8 @@ MeetingUpdatesEmptyModal.propTypes = {
   styles: PropTypes.object
 };
 
+// TODO: move common modal animations to ui.js
+
 const animateIn = {
   '0%': {
     opacity: '0',

--- a/src/universal/modules/meeting/components/MeetingUpdatesEmptyModal/MeetingUpdatesEmptyModal.js
+++ b/src/universal/modules/meeting/components/MeetingUpdatesEmptyModal/MeetingUpdatesEmptyModal.js
@@ -1,0 +1,118 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import withStyles from 'universal/styles/withStyles';
+import {css} from 'aphrodite-local-styles/no-important';
+import ui from 'universal/styles/ui';
+import appTheme from 'universal/styles/theme/appTheme';
+import portal from 'react-portal-hoc';
+
+const MeetingUpdatesEmptyModal = (props) => {
+  const {
+    advanceButton,
+    currentTeamMemberName,
+    isClosing,
+    styles
+  } = props;
+  const modalStyles = css(
+    styles.modal,
+    isClosing && styles.closing
+  );
+  return (
+    <div className={modalStyles}>
+      <div className={css(styles.heading)}>
+        {'No projects; any updates?'}
+      </div>
+      <p>{'We’re not currently tracking any projects for'} <b>{currentTeamMemberName}</b>{'.'}</p>
+      <p>{'You can add projects during the Agenda.'}</p>
+      <p>{'Just press “'}<b>{'+'}</b>{'” to add an Agenda Item.'}</p>
+      {advanceButton &&
+        <div className={css(styles.buttonBlock)}>
+          {advanceButton()}
+        </div>
+      }
+    </div>
+  );
+};
+
+MeetingUpdatesEmptyModal.propTypes = {
+  advanceButton: PropTypes.func,
+  currentTeamMemberName: PropTypes.string,
+  closeAfter: PropTypes.number,
+  isClosing: PropTypes.bool,
+  styles: PropTypes.object
+};
+
+const animateIn = {
+  '0%': {
+    opacity: '0',
+    transform: 'translate3d(0, -50px, 0)'
+
+  },
+  '100%': {
+    opacity: '1',
+    transform: 'translate3d(0, 0, 0)'
+  }
+};
+
+const animateOut = {
+  '0%': {
+    opacity: '1',
+    transform: 'translate3d(0, 0, 0)'
+
+  },
+  '100%': {
+    opacity: '0',
+    transform: 'translate3d(0, -50px, 0)'
+  }
+};
+
+const styleThunk = (theme, {closeAfter}) => ({
+  backdrop: {
+    bottom: 0,
+    left: 0,
+    position: 'fixed',
+    right: 0,
+    top: 0
+  },
+
+  modal: {
+    animationDuration: '200ms',
+    animationIterationCount: 1,
+    animationName: animateIn,
+    backgroundColor: appTheme.palette.light50l,
+    borderRadius: ui.modalBorderRadius,
+    boxShadow: ui.modalBoxShadow,
+    color: appTheme.palette.dark,
+    fontSize: appTheme.typography.s4,
+    left: `calc((100% - ${ui.meetingSidebarWidth}) / 2)`,
+    lineHeight: '1.5',
+    marginLeft: '-3rem', // (36rem / 2) - ui.meetingSidebarWidth ?
+    maxWidth: '36rem',
+    padding: '1.5rem',
+    position: 'absolute',
+    textAlign: 'center',
+    top: '15rem',
+    width: '100%',
+    zIndex: ui.zi7
+  },
+
+  closing: {
+    animationDuration: `${closeAfter}ms`,
+    animationName: animateOut
+  },
+
+  heading: {
+    fontSize: appTheme.typography.s6,
+    fontWeight: 700,
+    lineHeight: '2',
+    margin: '0 0 1rem'
+  },
+
+  buttonBlock: {
+    marginTop: '1rem'
+  }
+});
+
+export default portal({escToClose: false, closeAfter: 100})(
+  withStyles(styleThunk)(MeetingUpdatesEmptyModal)
+);

--- a/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
@@ -356,8 +356,6 @@ export default class MeetingContainer extends Component {
 
     const isBehindMeeting = phaseArray.indexOf(localPhase) < phaseArray.indexOf(meetingPhase);
     const isLastPhaseItem = isLastItemOfPhase(localPhase, localPhaseItem, members, agenda);
-    console.log(`isBehindMeeting: ${isBehindMeeting}`);
-    console.log(`isLastPhaseItem: ${isLastPhaseItem}`);
     const hideMoveMeetingControls = isFacilitating ? false : (!isBehindMeeting && isLastPhaseItem);
     const showMoveMeetingControls = isFacilitating || isBehindMeeting;
 

--- a/src/universal/modules/meeting/containers/MeetingUpdates/MeetingUpdatesContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingUpdates/MeetingUpdatesContainer.js
@@ -5,6 +5,7 @@ import {cashay} from 'cashay';
 import makeProjectsByStatus from 'universal/utils/makeProjectsByStatus';
 import MeetingUpdates from 'universal/modules/meeting/components/MeetingUpdates/MeetingUpdates';
 import LoadingView from 'universal/components/LoadingView/LoadingView';
+import checkForProjects from 'universal/utils/checkForProjects';
 
 const meetingUpdatesQuery = `
 query {
@@ -78,8 +79,7 @@ const mapStateToProps = (state, props) => {
   const projects = makeProjectsByStatus(memberProjects);
   return {
     projects,
-    queryKey: teamMemberId,
-    canShowEmptyState: false
+    queryKey: teamMemberId
   };
 };
 
@@ -88,7 +88,7 @@ export default class MeetingUpdatesContainer extends Component {
   static propTypes = {
     gotoItem: PropTypes.func.isRequired,
     gotoNext: PropTypes.func.isRequired,
-    canShowEmptyState: PropTypes.bool,
+    showEmpty: PropTypes.bool,
     localPhaseItem: PropTypes.number.isRequired,
     members: PropTypes.array.isRequired,
     projects: PropTypes.object.isRequired,
@@ -99,22 +99,25 @@ export default class MeetingUpdatesContainer extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      canShowEmptyState: false
+      hasWaited: false,
+      showEmpty: false
     };
   }
 
-  componentDidMount() {
-    setTimeout(() => {
-      if (!this.state.canShowEmptyState) {
-        this.setState({canShowEmptyState: true});
-      }
-    }, 1000);
+  componentWillMount() {
+    setTimeout(() => {this.setState({hasWaited: true})}, 1000);
+  }
+
+  componentWillReceiveProps() {
+    if (this.state.hasWaited) {
+      this.setState({showEmpty: !checkForProjects(this.props.projects)});
+    }
   }
 
   render() {
     if (!this.props.projects) {
       return <LoadingView />;
     }
-    return <MeetingUpdates {...this.props} />;
+    return <MeetingUpdates {...this.props} showEmpty={this.state.showEmpty} />;
   }
 }

--- a/src/universal/modules/meeting/containers/MeetingUpdates/MeetingUpdatesContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingUpdates/MeetingUpdatesContainer.js
@@ -105,7 +105,9 @@ export default class MeetingUpdatesContainer extends Component {
   }
 
   componentWillMount() {
-    setTimeout(() => {this.setState({hasWaited: true})}, 1000);
+    setTimeout(() => {
+      this.setState({hasWaited: true});
+    }, 1000);
   }
 
   componentWillReceiveProps() {

--- a/src/universal/modules/meeting/containers/MeetingUpdates/MeetingUpdatesContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingUpdates/MeetingUpdatesContainer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {cashay} from 'cashay';
 import makeProjectsByStatus from 'universal/utils/makeProjectsByStatus';
@@ -78,25 +78,43 @@ const mapStateToProps = (state, props) => {
   const projects = makeProjectsByStatus(memberProjects);
   return {
     projects,
-    queryKey: teamMemberId
+    queryKey: teamMemberId,
+    canShowEmptyState: false
   };
 };
 
-const MeetingUpdatesContainer = (props) => {
-  if (!props.projects) {
-    return <LoadingView />;
+@connect(mapStateToProps)
+export default class MeetingUpdatesContainer extends Component {
+  static propTypes = {
+    gotoItem: PropTypes.func.isRequired,
+    gotoNext: PropTypes.func.isRequired,
+    canShowEmptyState: PropTypes.bool,
+    localPhaseItem: PropTypes.number.isRequired,
+    members: PropTypes.array.isRequired,
+    projects: PropTypes.object.isRequired,
+    queryKey: PropTypes.string,
+    team: PropTypes.object.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      canShowEmptyState: false
+    };
   }
-  return <MeetingUpdates {...props} />;
-};
 
-MeetingUpdatesContainer.propTypes = {
-  gotoItem: PropTypes.func.isRequired,
-  gotoNext: PropTypes.func.isRequired,
-  localPhaseItem: PropTypes.number.isRequired,
-  members: PropTypes.array.isRequired,
-  projects: PropTypes.object.isRequired,
-  queryKey: PropTypes.string,
-  team: PropTypes.object.isRequired
-};
+  componentDidMount() {
+    setTimeout(() => {
+      if (!this.state.canShowEmptyState) {
+        this.setState({canShowEmptyState: true});
+      }
+    }, 1000);
+  }
 
-export default connect(mapStateToProps)(MeetingUpdatesContainer);
+  render() {
+    if (!this.props.projects) {
+      return <LoadingView />;
+    }
+    return <MeetingUpdates {...this.props} />;
+  }
+}

--- a/src/universal/utils/checkForProjects.js
+++ b/src/universal/utils/checkForProjects.js
@@ -1,0 +1,12 @@
+
+const checkForProjects = (projects) => {
+  // projects is an object that has arrays of projects for each status
+  const statusesWithProjects = [];
+  const projectsByStatus = Object.keys(projects);
+  projectsByStatus.map((status) =>
+    ((projects[status].length !== 0) && statusesWithProjects.push(status))
+  );
+  return Boolean(statusesWithProjects.length);
+};
+
+export default checkForProjects;


### PR DESCRIPTION
This PR addresses #246 “Meeting Project Updates empty state per team member” …

**The basics**:

- [x] A modal-like facilitation helper displays during Updates when a team member doesn’t have any projects on this team. The visual design and copy can be improved as we iterate. We could use another UI element other than a modal, etc.

**Bonus points, but probably essential**:

- [ ] Project Columns could use a loading state?
- [ ] The modal-like facilitation helper shouldn’t flash while the view is loading and will eventually show that the team member does have projects.
- [ ] The modal doesn’t show suddenly if the last project per team member were to be archived.
- [ ] Perhaps we store a `Boolean` per team member, per team called `hasProjects`? That doesn’t sound very clean but it starts the thought process.
- [ ] Yet another nuance to solve for eventually: if multiple people onboard at once on a new team, the modal will show over and over (assuming they go straight for a meeting without adding projects). For brand new orgs (first team leader, first team), I believe the only person who gets any seed projects is the Team Leader (but my memory may be fuzzy). I think we can get smarter on initial empty states over time, and should seek user feedback when possible.

**In the future**:

- [ ] We may decide to allow users the ability to add projects only during their Updates round. We can revisit the UX of this empty state when we work on that.

**Latest visual**:

![screenshot 2017-09-08 16 35 36](https://user-images.githubusercontent.com/307286/30232307-e987af0c-94b4-11e7-95c8-d90add91e8ff.png)