### PR TITLE
Epic 6.5 Meeting Sprint (TA)

### DIFF
--- a/src/server/emailSSR.js
+++ b/src/server/emailSSR.js
@@ -1,5 +1,6 @@
 import sendEmail from 'server/email/sendEmail';
 import templates from 'server/email/templates';
+import {MEETING_NAME, MEETING_SUMMARY_LABEL} from 'universal/utils/constants';
 
 // erica.seldin.contractor@pepsico.com
 // jordan@parabol.co
@@ -8,8 +9,8 @@ const EMAIL_DESTINATION = 'terry@parabol.co, terry_acker@yahoo.com';
 const EMAIL_TEMPLATE = 'summaryEmail';
 const EMAIL_ALL_PROPS = {
   summaryEmail: {
-    title: 'Action Meeting Summary from Parabol',
-    previewText: 'Action Meeting Summary from Parabol'
+    title: `${MEETING_NAME} ${MEETING_SUMMARY_LABEL} from Parabol`,
+    previewText: `${MEETING_NAME} ${MEETING_SUMMARY_LABEL} from Parabol`
   }
 };
 

--- a/src/universal/components/CreateCard/CreateCard.js
+++ b/src/universal/components/CreateCard/CreateCard.js
@@ -6,7 +6,6 @@ import appTheme from 'universal/styles/theme/appTheme';
 import ui from 'universal/styles/ui';
 import CreateCardRootStyles from './CreateCardRootStyles';
 import {cardBorderTop} from 'universal/styles/helpers';
-import FontAwesome from 'react-fontawesome';
 
 const CreateCard = (props) => {
   const {
@@ -20,25 +19,16 @@ const CreateCard = (props) => {
     (hasControls) && styles.hasControls
   );
 
-  const iconStyle = {
-    display: 'block',
-    fontSize: ui.iconSize2x,
-    lineHeight: ui.iconSize2x,
-    margin: '0 auto'
-  };
-
   return (
     <div className={cardStyles}>
       {hasControls &&
-        <div className={css(styles.controlsBlock)} onClick={handleAddProject} title="Add a Project or Task (just press “p”)">
-          <FontAwesome
-            name="plus-square-o"
-            style={iconStyle}
-          />
-          <span>
-            <b>{'Add a Project or Task'}</b><br />
-            {'(tag '}<b>{'#private'}</b>{' for personal Tasks)'}
-          </span>
+        <div className={css(styles.controlsBlock)} onClick={handleAddProject} title="Add a Project (just press “p”)">
+          <div className={css(styles.label)}>
+            {'Add a '}<u>{'P'}</u>{'roject'}
+          </div>
+          <div className={css(styles.hint)}>
+            {'(tag '}<b>{'#private'}</b>{' for personal Projects)'}
+          </div>
         </div>
       }
     </div>
@@ -81,9 +71,8 @@ const styleThunk = () => ({
     color: appTheme.palette.cool,
     display: 'flex',
     flexDirection: 'column',
-    fontSize: appTheme.typography.s2,
     justifyContent: 'center',
-    lineHeight: appTheme.typography.s5,
+    lineHeight: '1.5',
     textAlign: 'center',
     width: '100%',
 
@@ -95,6 +84,15 @@ const styleThunk = () => ({
       color: appTheme.palette.cool80d,
       cursor: 'pointer'
     }
+  },
+
+  label: {
+    fontSize: appTheme.typography.s4,
+    fontWeight: 700
+  },
+
+  hint: {
+    fontSize: appTheme.typography.s2
   }
 });
 

--- a/src/universal/modules/email/components/ContactUs/ContactUs.js
+++ b/src/universal/modules/email/components/ContactUs/ContactUs.js
@@ -3,6 +3,7 @@ import React from 'react';
 import EmptySpace from '../EmptySpace/EmptySpace';
 import appTheme from 'universal/styles/theme/appTheme';
 import ui from 'universal/styles/ui';
+import {MEETING_NAME} from 'universal/utils/constants';
 
 const ContactUs = (props) => {
   const cellStyle = {
@@ -35,9 +36,9 @@ const ContactUs = (props) => {
               {props.prompt}
             </span><br />
             {props.tagline}<br />
-            Email us:&nbsp;
+            {'Email us:'}&nbsp;
             <a href="mailto:love@parabol.co" style={linkStyle} title="Email us: love@parabol.co">
-              love@parabol.co
+              {'love@parabol.co'}
             </a>
             {props.hasLearningLink &&
               <span>
@@ -50,7 +51,7 @@ const ContactUs = (props) => {
                   title="How to Navigate Uncertainty using the Action Rhythm"
                 >
                   Learn More
-                </a> about the Action Meeting Process.
+                </a> {`about the ${MEETING_NAME} Process.`}
               </span>
             }
             <EmptySpace height={props.vSpacing} />

--- a/src/universal/modules/email/components/QuickStats/QuickStats.js
+++ b/src/universal/modules/email/components/QuickStats/QuickStats.js
@@ -4,6 +4,7 @@ import appTheme from 'universal/styles/theme/appTheme';
 import ui from 'universal/styles/ui';
 import EmptySpace from '../EmptySpace/EmptySpace';
 import plural from 'universal/utils/plural';
+import {AGENDA_ITEM_LABEL} from 'universal/utils/constants';
 
 const QuickStats = (props) => {
   const {
@@ -64,7 +65,7 @@ const QuickStats = (props) => {
             <td style={cellStyles}>
               <div style={statStyles}>
                 <div style={statValue}>{agendaItems}</div>
-                <div style={statLabel}>Agenda {plural(agendaItems, 'Item')}</div>
+                <div style={statLabel}>{plural(agendaItems, AGENDA_ITEM_LABEL)}</div>
               </div>
             </td>
             <td style={cellStyles}>

--- a/src/universal/modules/email/components/SummaryEmail/SummaryEmail.js
+++ b/src/universal/modules/email/components/SummaryEmail/SummaryEmail.js
@@ -13,6 +13,7 @@ import SummaryHeader from '../../components/SummaryHeader/SummaryHeader';
 import UserProjects from '../UserProjects/UserProjects';
 import UserNoNewOutcomes from '../../components/UserNoNewOutcomes/UserNoNewOutcomes';
 import {makeSuccessExpression} from 'universal/utils/makeSuccessCopy';
+import {MEETING_NAME, AGENDA_ITEM_LABEL} from 'universal/utils/constants';
 
 const ruleStyle = {
   backgroundColor: ui.emailRuleColor,
@@ -88,13 +89,13 @@ const quickStatsBlock = {
 
 const makeBannerMessage = (referrer, url) => {
   if (referrer === 'meeting') {
-    return <span>All team members will receive this summary in their inbox.</span>;
+    return <span>{'All team members will receive this summary in their inbox.'}</span>;
   }
   if (referrer === 'email') {
-    return <span><a href={url} style={bannerLink}>View this summary in your web browser</a></span>;
+    return <span><a href={url} style={bannerLink}>{'View this summary in your web browser'}</a></span>;
   }
   if (referrer === 'history') {
-    return <span><a href={url} style={bannerLink}>See all meeting summaries here</a></span>;
+    return <span><a href={url} style={bannerLink}>{'See all meeting summaries here'}</a></span>;
   }
   return null;
 };
@@ -204,7 +205,7 @@ const SummaryEmail = (props) => {
                 <td align="center" style={{padding: 0}}>
                   <div style={message}>
                     <div style={greetingStyles}>{makeSuccessExpression()}!</div>
-                    {`Way to go on your first Action Meeting!
+                    {`Way to go on your first ${MEETING_NAME}!
                       You are unlocking new superpowers.
                       High-performing teams have regular habits!
                       Create a 30-minute meeting at the start of each week.`}
@@ -225,7 +226,7 @@ const SummaryEmail = (props) => {
                             height={iconSize}
                             width={iconSize}
                           />
-                          <span style={iconLinkLabel}>Google Calendar</span>
+                          <span style={iconLinkLabel}>{'Google Calendar'}</span>
                         </a>
                       </div>
                       <div style={iconLinkBlock}>
@@ -241,7 +242,7 @@ const SummaryEmail = (props) => {
                             height={iconSize}
                             width={iconSize}
                           />
-                          <span style={iconLinkLabel}>Outlook, etc.</span>
+                          <span style={iconLinkLabel}>{'Outlook, etc.'}</span>
                         </a>
                       </div>
                     </div>
@@ -266,9 +267,9 @@ const SummaryEmail = (props) => {
           <div>
             {agendaItemsCompleted === 0 ?
               <div style={message}>
-                {/* No agenda items? */}
+                {/* No Agenda Items? */}
                 <div style={greetingStyles}>{'Hey there!'}</div>
-                {`It looks like there weren’t any agenda items.
+                {`It looks like there weren’t any ${AGENDA_ITEM_LABEL}s.
                   Did our software give you trouble?
                   Let us know: `}
                 <a href="mailto:love@parabol.co" style={linkStyles} title="Email us at: love@parabol.co">love@parabol.co</a>
@@ -277,7 +278,7 @@ const SummaryEmail = (props) => {
                 fontSize={18}
                 hasLearningLink
                 lineHeight={1.5}
-                prompt="How’d your meeting go?"
+                prompt={`How’d your ${MEETING_NAME} go?`}
                 tagline="We’re eager for your feedback!"
                 vSpacing={0}
               />

--- a/src/universal/modules/email/components/SummaryEmail/index.js
+++ b/src/universal/modules/email/components/SummaryEmail/index.js
@@ -3,12 +3,12 @@ import Oy from 'oy-vey';
 import {summaryEmailText} from './SummaryEmail';
 import SummaryEmailContainer from 'universal/modules/email/containers/SummaryEmail/SummaryEmailContainer';
 import makeDateString from 'universal/utils/makeDateString';
-
+import {MEETING_NAME} from 'universal/utils/constants';
 
 export default (props) => {
   const {meeting: {teamName, endedAt}} = props;
   const dateStr = makeDateString(endedAt, false);
-  const subject = `${teamName} ${dateStr} Action Meeting Summary`;
+  const subject = `${teamName} ${dateStr} ${MEETING_NAME} Summary`;
   return {
     subject,
     body: summaryEmailText(props),

--- a/src/universal/modules/email/components/SummaryEmail/index.js
+++ b/src/universal/modules/email/components/SummaryEmail/index.js
@@ -3,12 +3,12 @@ import Oy from 'oy-vey';
 import {summaryEmailText} from './SummaryEmail';
 import SummaryEmailContainer from 'universal/modules/email/containers/SummaryEmail/SummaryEmailContainer';
 import makeDateString from 'universal/utils/makeDateString';
-import {MEETING_NAME} from 'universal/utils/constants';
+import {MEETING_NAME, MEETING_SUMMARY_LABEL} from 'universal/utils/constants';
 
 export default (props) => {
   const {meeting: {teamName, endedAt}} = props;
   const dateStr = makeDateString(endedAt, false);
-  const subject = `${teamName} ${dateStr} ${MEETING_NAME} Summary`;
+  const subject = `${teamName} ${dateStr} ${MEETING_NAME} ${MEETING_SUMMARY_LABEL}`;
   return {
     subject,
     body: summaryEmailText(props),

--- a/src/universal/modules/email/components/SummaryHeader/SummaryHeader.js
+++ b/src/universal/modules/email/components/SummaryHeader/SummaryHeader.js
@@ -5,6 +5,7 @@ import appTheme from 'universal/styles/theme/appTheme';
 import ui from 'universal/styles/ui';
 import makeDateString from 'universal/utils/makeDateString';
 import {Link} from 'react-router-dom';
+import {MEETING_NAME} from 'universal/utils/constants';
 
 const SummaryHeader = (props) => {
   const {createdAt, meetingNumber, referrer, teamDashUrl, teamName} = props;
@@ -52,6 +53,7 @@ const SummaryHeader = (props) => {
     fontSize: '36px'
   };
   const meetingDate = makeDateString(createdAt);
+  const teamDashLabel = 'Go to Team Dashboard';
   return (
     <div style={{padding: '0 16px'}}>
       <EmptySpace height={props.vSpacing} />
@@ -60,16 +62,21 @@ const SummaryHeader = (props) => {
           <tr>
             <td style={blockStyle}>
               <div style={teamNameStyle}>{teamName}</div>
-              <div style={meetingDateStyle}>{`Action Meeting #${meetingNumber}`} • {meetingDate}</div>
+              <div style={meetingDateStyle}>{`${MEETING_NAME} #${meetingNumber}`}{' • '}{meetingDate}</div>
               {referrer === 'email' ?
                 <a
                   href={teamDashUrl}
                   style={teamDashLinkStyle}
-                  title="Go to Team Dashboard"
-                >Go to Team Dashboard
+                  title={teamDashLabel}
+                >
+                  {teamDashLabel}
                 </a> :
-                <Link to={teamDashUrl} style={teamDashLinkStyle} title="Go to Team Dashboard">
-                  Go to Team Dashboard
+                <Link
+                  to={teamDashUrl}
+                  style={teamDashLinkStyle}
+                  title={teamDashLabel}
+                >
+                  {teamDashLabel}
                 </Link>
               }
             </td>

--- a/src/universal/modules/meeting/components/AgendaShortcutHint/AgendaShortcutHint.js
+++ b/src/universal/modules/meeting/components/AgendaShortcutHint/AgendaShortcutHint.js
@@ -6,6 +6,7 @@ import FontAwesome from 'react-fontawesome';
 import appTheme from 'universal/styles/theme/appTheme';
 import ui from 'universal/styles/ui';
 import {textOverflow} from 'universal/styles/helpers';
+import {AGENDA_ITEM_LABEL} from 'universal/utils/constants';
 
 const inlineBlock = {
   display: 'inline-block',
@@ -24,7 +25,9 @@ const AgendaShortcutHint = (props) => {
           style={inlineBlock}
         />
       </span>
-      <span className={css(styles.linkText)}>Press “<b>+</b>” to add an agenda item to the left column.</span>
+      <span className={css(styles.linkText)}>
+        {'Press “'}<b>{'+'}</b>{`” to add an ${AGENDA_ITEM_LABEL} to the left column.`}
+      </span>
     </div>
   );
 };

--- a/src/universal/modules/meeting/components/CheckInControls/CheckInControls.js
+++ b/src/universal/modules/meeting/components/CheckInControls/CheckInControls.js
@@ -6,6 +6,7 @@ import ui from 'universal/styles/ui';
 import appTheme from 'universal/styles/theme/appTheme';
 import FontAwesome from 'react-fontawesome';
 import withHotkey from 'react-hotkey-hoc';
+import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 
 const CheckInControls = (props) => {
   const {
@@ -34,23 +35,23 @@ const CheckInControls = (props) => {
     fontSize: ui.iconSize2x
   };
 
+  const nextPhaseName = actionMeeting.updates.name;
+
   bindHotkey('h', handleOnClickPresent);
   bindHotkey('n', handleOnClickAbsent);
 
   return (
     <div className={css(styles.controlBlock)}>
-
       <div className={css(styles.control, styles.nextControl)} onClick={handleOnClickPresent}>
         <FontAwesome name="check-circle" style={nextIcon} />
         <span className={css(styles.label)}>
-          <u>H</u>ere – {nextMember ? `move to ${nextMember.preferredName}` : 'move to Updates'}
+          <u>{'H'}</u>{'ere – '}{nextMember ? `move to ${nextMember.preferredName}` : `move to ${nextPhaseName}`}
         </span>
       </div>
-
       <div className={css(styles.control, styles.skipControl)} onClick={handleOnClickAbsent}>
         <FontAwesome name="minus-circle" style={skipIcon} />
         <span className={css(styles.label)}>
-          <u>N</u>ot here – {nextMember ? `skip to ${nextMember.preferredName}` : 'skip to Updates'}
+          <u>{'N'}</u>{'ot here – '}{nextMember ? `skip to ${nextMember.preferredName}` : `skip to ${nextPhaseName}`}
         </span>
       </div>
     </div>

--- a/src/universal/modules/meeting/components/MeetingAgendaCards/MeetingAgendaCards.js
+++ b/src/universal/modules/meeting/components/MeetingAgendaCards/MeetingAgendaCards.js
@@ -60,7 +60,7 @@ const MeetingAgendaCards = (props) => {
   const {agendaId, bindHotkey, dispatch, myTeamMemberId, outcomes, styles} = props;
   const handleAddProject = handleAddProjectFactory(myTeamMemberId, agendaId);
   const addBlankProject = handleAddProject();
-  bindHotkey('p', handleAddProject);
+  bindHotkey('p', addBlankProject);
   return (
     <div className={css(styles.root)}>
       {/* Get Cards */}

--- a/src/universal/modules/meeting/components/MeetingAgendaFirstCall/MeetingAgendaFirstCall.js
+++ b/src/universal/modules/meeting/components/MeetingAgendaFirstCall/MeetingAgendaFirstCall.js
@@ -11,6 +11,8 @@ import withStyles from 'universal/styles/withStyles';
 import appTheme from 'universal/styles/theme/appTheme';
 import {css} from 'aphrodite-local-styles/no-important';
 import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
+import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
+import {AGENDA_ITEM_LABEL} from 'universal/utils/constants';
 
 const MeetingAgendaFirstCall = (props) => {
   const {
@@ -20,6 +22,7 @@ const MeetingAgendaFirstCall = (props) => {
     hideMoveMeetingControls,
     styles
   } = props;
+  const phaseName = actionMeeting.agendaitems.name;
   return (
     <MeetingMain>
       <MeetingSection flexToFill paddingBottom="2rem">
@@ -28,7 +31,7 @@ const MeetingAgendaFirstCall = (props) => {
             {'Now, what do you need?'}
           </MeetingPhaseHeading>
           <Type align="center" bold marginBottom="2.5rem" marginTop=".5rem" scale="s5" colorPalette="black">
-            (Time to add your agenda items to the list.)
+            {`(Time to add your ${AGENDA_ITEM_LABEL}s to the list.)`}
           </Type>
 
           <AgendaShortcutHint />
@@ -40,12 +43,12 @@ const MeetingAgendaFirstCall = (props) => {
                 colorPalette="cool"
                 icon="arrow-circle-right"
                 iconPlacement="right"
-                label="Let’s begin: Agenda"
+                label={`Let’s begin: ${phaseName}`}
                 onClick={gotoNext}
                 size="largest"
               /> :
               <MeetingFacilitationHint>
-                {'Waiting for'} <b>{getFacilitatorName(team, members)}</b> {'to start the Agenda'}
+                {'Waiting for'} <b>{getFacilitatorName(team, members)}</b> {`to start the ${phaseName}`}
               </MeetingFacilitationHint>
             }
           </div>

--- a/src/universal/modules/meeting/components/MeetingAgendaItems/MeetingAgendaItems.js
+++ b/src/universal/modules/meeting/components/MeetingAgendaItems/MeetingAgendaItems.js
@@ -11,6 +11,8 @@ import MeetingAgendaCardsContainer from 'universal/modules/meeting/containers/Me
 import MeetingFacilitationHint from 'universal/modules/meeting/components/MeetingFacilitationHint/MeetingFacilitationHint';
 import LoadingView from 'universal/components/LoadingView/LoadingView';
 import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
+import {AGENDA_ITEM_LABEL} from 'universal/utils/constants';
+import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 
 const MeetingAgendaItems = (props) => {
   const {
@@ -48,7 +50,7 @@ const MeetingAgendaItems = (props) => {
             <div className={css(styles.nav)}>
               {hideMoveMeetingControls ?
                 <MeetingFacilitationHint>
-                  {'Waiting for'} <b>{getFacilitatorName(team, members)}</b> {'to wrap up the Agenda'}
+                  {'Waiting for'} <b>{getFacilitatorName(team, members)}</b> {`to wrap up the ${actionMeeting.agendaitems.name}`}
                 </MeetingFacilitationHint> :
                 <Button
                   buttonStyle="flat"
@@ -56,7 +58,7 @@ const MeetingAgendaItems = (props) => {
                   icon="arrow-circle-right"
                   iconPlacement="right"
                   key={`agendaItem${localPhaseItem}`}
-                  label={isLast ? 'Wrap up the meeting' : 'Next Agenda Item'}
+                  label={isLast ? 'Wrap up the meeting' : `Next ${AGENDA_ITEM_LABEL}`}
                   onClick={gotoNext}
                   size="small"
                 />

--- a/src/universal/modules/meeting/components/MeetingAgendaLastCall/MeetingAgendaLastCall.js
+++ b/src/universal/modules/meeting/components/MeetingAgendaLastCall/MeetingAgendaLastCall.js
@@ -6,11 +6,13 @@ import appTheme from 'universal/styles/theme/appTheme';
 import plural from 'universal/utils/plural';
 import Button from 'universal/components/Button/Button';
 import Type from 'universal/components/Type/Type';
+import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 import MeetingMain from 'universal/modules/meeting/components/MeetingMain/MeetingMain';
 import MeetingSection from 'universal/modules/meeting/components/MeetingSection/MeetingSection';
 import MeetingPhaseHeading from 'universal/modules/meeting/components/MeetingPhaseHeading/MeetingPhaseHeading';
 import MeetingFacilitationHint from 'universal/modules/meeting/components/MeetingFacilitationHint/MeetingFacilitationHint';
 import AgendaShortcutHint from 'universal/modules/meeting/components/AgendaShortcutHint/AgendaShortcutHint';
+import {AGENDA_ITEM_LABEL} from 'universal/utils/constants';
 
 const MeetingAgendaLastCall = (props) => {
   const {
@@ -21,14 +23,16 @@ const MeetingAgendaLastCall = (props) => {
     styles
   } = props;
 
+  const labelAgendaItems = plural(0, AGENDA_ITEM_LABEL);
+
   return (
     <MeetingMain>
       <MeetingSection flexToFill paddingBottom="2rem">
         <MeetingSection paddingBottom="2rem">
           <MeetingPhaseHeading>
             {agendaItemCount === 0 ?
-              <span>{'No agenda items?'}</span> :
-              <span>{'That wraps up the agenda!'}</span>
+              <span>{`No ${labelAgendaItems}?`}</span> :
+              <span>{`That wraps up the ${actionMeeting.agendaitems.name}!`}</span>
             }
           </MeetingPhaseHeading>
           {agendaItemCount === 0 ?
@@ -40,9 +44,9 @@ const MeetingAgendaLastCall = (props) => {
               colorPalette="black"
             >
               <span>
-                {'Looks like you didn’t process any agenda items.'}
+                {`Looks like you didn’t process any ${labelAgendaItems}.`}
                 <br />
-                {'You can add agenda items in the left sidebar before ending the meeting.'}
+                {`You can add ${labelAgendaItems} in the left sidebar before ending the meeting.`}
                 <br />
                 {'Simply tap on any items you create to process them.'}
               </span>
@@ -55,7 +59,10 @@ const MeetingAgendaLastCall = (props) => {
               scale="s5"
               colorPalette="black"
             >
-              We worked on <span className={css(styles.highlight)}>{`${agendaItemCount} ${plural(agendaItemCount, 'Agenda Item')}`}</span>
+              {'We worked on '}
+              <span className={css(styles.highlight)}>
+                {`${agendaItemCount} ${plural(agendaItemCount, AGENDA_ITEM_LABEL)}`}
+              </span>
               {'—need anything else?'}
             </Type>
           }

--- a/src/universal/modules/meeting/components/MeetingCheckin/MeetingCheckin.js
+++ b/src/universal/modules/meeting/components/MeetingCheckin/MeetingCheckin.js
@@ -12,6 +12,7 @@ import LoadingView from 'universal/components/LoadingView/LoadingView';
 import ui from 'universal/styles/ui';
 import appTheme from 'universal/styles/theme/appTheme';
 import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
+import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 
 const MeetingCheckin = (props) => {
   const {
@@ -90,7 +91,7 @@ const MeetingCheckin = (props) => {
               <MeetingFacilitationHint>
                 {nextMember ?
                   <span>{'Waiting for'} <b>{currentMember.preferredName}</b> {'to share with the team'}</span> :
-                  <span>{'Waiting for'} <b>{getFacilitatorName(team, members)}</b> {'to advance to Updates'}</span>
+                  <span>{'Waiting for'} <b>{getFacilitatorName(team, members)}</b> {`to advance to ${actionMeeting.updates.name}`}</span>
                 }
               </MeetingFacilitationHint>
             </div>

--- a/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
+++ b/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
@@ -7,6 +7,7 @@ import appTheme from 'universal/styles/theme/appTheme';
 import {cashay} from 'cashay';
 import makeHref from 'universal/utils/makeHref';
 import Button from 'universal/components/Button/Button';
+import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 import CopyShortLink from 'universal/modules/meeting/components/CopyShortLink/CopyShortLink';
 import MeetingMain from 'universal/modules/meeting/components/MeetingMain/MeetingMain';
 import MeetingPhaseHeading from 'universal/modules/meeting/components/MeetingPhaseHeading/MeetingPhaseHeading';
@@ -29,14 +30,16 @@ const MeetingLobby = (props) => {
     <MeetingMain>
       {/* */}
       <div className={css(styles.root)}>
-        <MeetingPhaseHeading>Hi, {teamName} Team!</MeetingPhaseHeading>
-        <div className={css(styles.helpText)}>Is the whole team here?</div>
+        <MeetingPhaseHeading>{`Hi, ${teamName} Team!`}</MeetingPhaseHeading>
+        <div className={css(styles.helpText)}>
+          {'Is the whole team here?'}
+        </div>
         <div className={css(styles.prompt)}>
-          The person who presses “Start Meeting” will facilitate the meeting.<br />
-          Everyone’s display automatically follows the Facilitator.
+          {'The person who presses “Start Meeting” will facilitate the meeting.'}<br />
+          {'Everyone’s display automatically follows the Facilitator.'}
         </div>
         <div className={css(styles.helpText)}>
-          <b>Today’s Facilitator</b>: begin the Check-In Round!
+          <b>{'Today’s Facilitator'}</b>{`: begin the ${actionMeeting.checkin.name}!`}
         </div>
         <div className={css(styles.buttonBlock)}>
           <Button
@@ -49,7 +52,7 @@ const MeetingLobby = (props) => {
             textTransform="uppercase"
           />
         </div>
-        <p className={css(styles.label)}>MEETING LINK:</p>
+        <p className={css(styles.label)}>{'Meeting Link:'}</p>
         <div className={css(styles.urlBlock)}>
           <CopyShortLink url={shortUrl} />
         </div>

--- a/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
+++ b/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
@@ -9,6 +9,7 @@ import MeetingFacilitationHint from 'universal/modules/meeting/components/Meetin
 import {MEETING} from 'universal/utils/constants';
 import ProjectColumns from 'universal/components/ProjectColumns/ProjectColumns';
 import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
+import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 
 const MeetingUpdates = (props) => {
   const {
@@ -24,6 +25,7 @@ const MeetingUpdates = (props) => {
   const self = members.find((m) => m.isSelf);
   const currentTeamMember = members[localPhaseItem - 1];
   const isLastMember = localPhaseItem === members.length;
+  const nextPhaseName = actionMeeting.agendaitems.name;
   return (
     <MeetingMain>
       <MeetingSection flexToFill>
@@ -35,14 +37,14 @@ const MeetingUpdates = (props) => {
               icon="arrow-circle-right"
               iconPlacement="right"
               key={`update${localPhaseItem}`}
-              label={isLastMember ? 'Move on to the Agenda' : 'Next team member '}
+              label={isLastMember ? `Move on to the ${nextPhaseName}` : 'Next team member '}
               onClick={gotoNext}
               size="small"
             /> :
             <MeetingFacilitationHint>
               {isLastMember ?
-                <span>{'Waiting for '}<b>{getFacilitatorName(team, members)}</b> {'to advance to the Agenda'}</span> :
-                <span>{'Waiting for '}<b>{currentTeamMember.preferredName}</b> {'to give Updates'}</span>
+                <span>{'Waiting for '}<b>{getFacilitatorName(team, members)}</b> {`to advance to the ${nextPhaseName}`}</span> :
+                <span>{'Waiting for '}<b>{currentTeamMember.preferredName}</b> {`to give ${actionMeeting.updates.name}`}</span>
               }
             </MeetingFacilitationHint>
           }

--- a/src/universal/modules/meeting/components/Sidebar/Sidebar.js
+++ b/src/universal/modules/meeting/components/Sidebar/Sidebar.js
@@ -11,7 +11,6 @@ import makeHref from 'universal/utils/makeHref';
 import {Link} from 'react-router-dom';
 import AgendaListAndInputContainer from 'universal/modules/teamDashboard/containers/AgendaListAndInput/AgendaListAndInputContainer';
 import inAgendaGroup from 'universal/modules/meeting/helpers/inAgendaGroup';
-import labels from 'universal/styles/theme/labels';
 import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 
 const Sidebar = (props) => {
@@ -58,6 +57,11 @@ const Sidebar = (props) => {
   const agendaNavItemStyles = css(styles.navListItem, inAgendaGroup(facilitatorPhase) && styles.navListItemMeetingMarker);
   const agendaListCanNavigate = canNavigateTo(AGENDA_ITEMS);
   const agendaListDisabled = meetingPhase === CHECKIN;
+  // Phase labels
+  const checkinLabel = actionMeeting.checkin.name;
+  const updatesLabel = actionMeeting.updates.name;
+  const agendaitemsLabel = actionMeeting.agendaitems.name;
+  const summaryLabel = actionMeeting.summary.name;
   return (
     <div className={css(styles.sidebar)}>
       <div className={css(styles.sidebarHeader)}>
@@ -73,30 +77,30 @@ const Sidebar = (props) => {
             <div
               className={checkInLinkStyles}
               onClick={() => gotoItem(null, CHECKIN)}
-              title={labels.meetingPhase.checkIn.label}
+              title={checkinLabel}
             >
               <span className={css(styles.bullet)}>i.</span>
-              <span className={css(styles.label)}>{labels.meetingPhase.checkIn.label}</span>
+              <span className={css(styles.label)}>{checkinLabel}</span>
             </div>
           </li>
           <li className={updatesNavItemStyles}>
             <div
               className={updatesLinkStyles}
               onClick={() => gotoItem(null, UPDATES)}
-              title={labels.meetingPhase.updates.label}
+              title={updatesLabel}
             >
               <span className={css(styles.bullet)}>ii.</span>
-              <span className={css(styles.label)}>{labels.meetingPhase.updates.label}</span>
+              <span className={css(styles.label)}>{updatesLabel}</span>
             </div>
           </li>
           <li className={agendaNavItemStyles}>
             <div
               className={agendaLinkStyles}
               onClick={() => gotoItem(null, FIRST_CALL)}
-              title={labels.meetingPhase.agenda.label}
+              title={agendaitemsLabel}
             >
               <span className={css(styles.bullet)}>iii.</span>
-              <span className={css(styles.label)}>{labels.meetingPhase.agenda.label}</span>
+              <span className={css(styles.label)}>{agendaitemsLabel}</span>
             </div>
           </li>
           {localPhase === SUMMARY &&
@@ -104,10 +108,10 @@ const Sidebar = (props) => {
               <div
                 className={css(styles.navListItemLink, styles.navListItemLinkActive)}
                 onClick={() => gotoItem(null, SUMMARY)}
-                title={labels.meetingPhase.summary.label}
+                title={summaryLabel}
               >
                 <span className={css(styles.bullet)}>{' '}</span>
-                <span className={css(styles.label)}>{labels.meetingPhase.summary.label}</span>
+                <span className={css(styles.label)}>{summaryLabel}</span>
               </div>
             </li>
           }

--- a/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
@@ -356,8 +356,6 @@ export default class MeetingContainer extends Component {
 
     const isBehindMeeting = phaseArray.indexOf(localPhase) < phaseArray.indexOf(meetingPhase);
     const isLastPhaseItem = isLastItemOfPhase(localPhase, localPhaseItem, members, agenda);
-    console.log(`isBehindMeeting: ${isBehindMeeting}`);
-    console.log(`isLastPhaseItem: ${isLastPhaseItem}`);
     const hideMoveMeetingControls = isFacilitating ? false : (!isBehindMeeting && isLastPhaseItem);
     const showMoveMeetingControls = isFacilitating || isBehindMeeting;
 

--- a/src/universal/modules/meeting/helpers/actionMeeting.js
+++ b/src/universal/modules/meeting/helpers/actionMeeting.js
@@ -1,4 +1,4 @@
-import {LOBBY, CHECKIN, UPDATES, FIRST_CALL, AGENDA_ITEMS, LAST_CALL, SUMMARY} from 'universal/utils/constants';
+import {LOBBY, CHECKIN, UPDATES, FIRST_CALL, AGENDA_ITEMS, LAST_CALL, SUMMARY, MEETING_SUMMARY_LABEL} from 'universal/utils/constants';
 
 export default {
   [LOBBY]: {
@@ -14,7 +14,7 @@ export default {
       countName: 'teamMemberCount',
       arrayName: 'members'
     },
-    name: 'Check-In',
+    name: 'Social Check-In',
     next: UPDATES,
     route: 'checkin',
     visitOnce: false
@@ -25,7 +25,7 @@ export default {
       countName: 'teamMemberCount',
       arrayName: 'members'
     },
-    name: 'Updates',
+    name: 'Solo Updates',
     next: FIRST_CALL,
     route: 'updates',
     visitOnce: false
@@ -43,7 +43,7 @@ export default {
       countName: 'agendaCount',
       arrayName: 'agenda'
     },
-    name: 'Agenda Items',
+    name: 'Team Agenda',
     next: LAST_CALL,
     route: 'agenda',
     visitOnce: false
@@ -57,7 +57,7 @@ export default {
   },
   [SUMMARY]: {
     index: 6,
-    name: 'Summary',
+    name: MEETING_SUMMARY_LABEL,
     route: 'summary',
     visitOnce: false
   }

--- a/src/universal/modules/summary/containers/MeetingSummary/MeetingSummaryContainer.js
+++ b/src/universal/modules/summary/containers/MeetingSummary/MeetingSummaryContainer.js
@@ -7,7 +7,7 @@ import SummaryEmail from 'universal/modules/email/components/SummaryEmail/Summar
 import LoadingView from 'universal/components/LoadingView/LoadingView';
 import makeHref from 'universal/utils/makeHref';
 import {maintainSocket} from 'redux-socket-cluster';
-import {MEETING_NAME} from 'universal/utils/constants';
+import {MEETING_NAME, MEETING_SUMMARY_LABEL} from 'universal/utils/constants';
 
 const meetingSummaryQuery = `
 query{
@@ -90,7 +90,7 @@ export default class MeetingSummaryContainer extends Component {
       return <LoadingView />;
     }
     const {teamId} = meeting;
-    const title = `${MEETING_NAME} #${meeting.meetingNumber} Summary for ${meeting.teamName}`;
+    const title = `${MEETING_NAME} #${meeting.meetingNumber} ${MEETING_SUMMARY_LABEL} for ${meeting.teamName}`;
     const meetingUrl = makeHref(`/meeting/${teamId}`);
     const teamDashUrl = `/team/${teamId}`;
 

--- a/src/universal/modules/summary/containers/MeetingSummary/MeetingSummaryContainer.js
+++ b/src/universal/modules/summary/containers/MeetingSummary/MeetingSummaryContainer.js
@@ -7,6 +7,7 @@ import SummaryEmail from 'universal/modules/email/components/SummaryEmail/Summar
 import LoadingView from 'universal/components/LoadingView/LoadingView';
 import makeHref from 'universal/utils/makeHref';
 import {maintainSocket} from 'redux-socket-cluster';
+import {MEETING_NAME} from 'universal/utils/constants';
 
 const meetingSummaryQuery = `
 query{
@@ -89,7 +90,7 @@ export default class MeetingSummaryContainer extends Component {
       return <LoadingView />;
     }
     const {teamId} = meeting;
-    const title = `Action Meeting #${meeting.meetingNumber} Summary for ${meeting.teamName}`;
+    const title = `${MEETING_NAME} #${meeting.meetingNumber} Summary for ${meeting.teamName}`;
     const meetingUrl = makeHref(`/meeting/${teamId}`);
     const teamDashUrl = `/team/${teamId}`;
 

--- a/src/universal/modules/userDashboard/helpers/getRallyLink.js
+++ b/src/universal/modules/userDashboard/helpers/getRallyLink.js
@@ -158,6 +158,10 @@ const rallyList = [
   {
     phrase: 'Time To Set Up Shop',
     link: 'https://youtu.be/tvy5TGLUls8'
+  },
+  {
+    phrase: 'Just Do It',
+    link: 'https://youtu.be/ZXsQAXx_ao0'
   }
 ];
 
@@ -165,16 +169,12 @@ const rally = rallyList[Math.floor(Math.random() * rallyList.length)];
 
 const rallyPhrase = `${rally.phrase}!`;
 
-const style = {
-  color: 'inherit'
-};
-
-export default function getRallyLink(hasStyle = true) {
+export default function getRallyLink() {
   return (
     <a
       href={rally.link}
       rel="noopener noreferrer"
-      style={hasStyle ? style : null}
+      style={{color: 'inherit'}}
       target="_blank"
       title={rallyPhrase}
     >

--- a/src/universal/styles/theme/labels.js
+++ b/src/universal/styles/theme/labels.js
@@ -1,30 +1,7 @@
-import React from 'react';
 import appTheme from 'universal/styles/theme/appTheme';
 import {ACTIVE, STUCK, DONE, FUTURE} from 'universal/utils/constants';
 
 const labels = {
-  meetingPhase: {
-    lobby: {
-      label: 'Lobby',
-      slug: 'lobby'
-    },
-    checkIn: {
-      label: 'Check-In',
-      slug: 'checkIn'
-    },
-    updates: {
-      label: 'Updates',
-      slug: 'updates'
-    },
-    agenda: {
-      label: 'Agenda',
-      slug: 'agenda'
-    },
-    summary: {
-      label: 'Summary',
-      slug: 'summary'
-    }
-  },
   projectStatus: {
     slugs: [
       DONE,
@@ -35,58 +12,44 @@ const labels = {
     [ACTIVE]: {
       color: appTheme.palette.cool,
       icon: 'arrow-right',
-      keystroke: 'a',
       label: 'Active',
-      shortcutLabel: <span><u>A</u>ctive</span>,
       slug: ACTIVE
     },
     [STUCK]: {
       color: appTheme.palette.warm,
       icon: 'exclamation-triangle',
-      keystroke: 's',
       label: 'Stuck',
-      shortcutLabel: <span><u>S</u>tuck</span>,
       slug: STUCK
     },
     [DONE]: {
       color: appTheme.palette.dark,
       icon: 'check',
-      keystroke: 'd',
       label: 'Done',
-      shortcutLabel: <span><u>D</u>one</span>,
       slug: DONE
     },
     [FUTURE]: {
       color: appTheme.palette.mid,
       icon: 'clock-o',
-      keystroke: 'f',
       label: 'Future',
-      shortcutLabel: <span><u>F</u>uture</span>,
       slug: FUTURE
     }
   },
   archive: {
     color: appTheme.palette.dark10d,
     icon: 'archive',
-    keystroke: 'c',
     label: 'Archive',
-    shortcutLabel: <span>Ar<u>c</u>hive</span>,
     slug: 'archive'
   },
   archived: {
     color: appTheme.palette.dark10d,
     icon: 'archive',
-    keystroke: 'c',
     label: 'Archived',
-    shortcutLabel: <span>Ar<u>c</u>hived</span>,
     slug: 'archived'
   },
   project: {
     color: appTheme.palette.dark,
     icon: 'calendar',
-    keystroke: 'p',
     label: 'Project',
-    shortcutLabel: <span><u>P</u>roject</span>,
     slug: 'project'
   }
 };

--- a/src/universal/styles/ui.js
+++ b/src/universal/styles/ui.js
@@ -210,7 +210,7 @@ const ui = {
   cardBorderColor: appTheme.palette.mid30l,
   cardBorderRadius: borderRadiusMedium,
   cardMaxWidth: '17.5rem',
-  cardMinHeight: '8.1875rem',
+  cardMinHeight: '6.875rem',
   cardPaddingBase: '.5rem',
   cardDragStyle: {
     boxShadow: shadow[3]

--- a/src/universal/utils/constants.js
+++ b/src/universal/utils/constants.js
@@ -24,6 +24,11 @@ export const APP_UPGRADE_PENDING_DONE = 'done';
 export const APP_VERSION_KEY = `${APP_NAME}:version`; // in localStorage
 export const APP_WEBPACK_PUBLIC_PATH_DEFAULT = '/static/';
 
+/* Meeting Misc. */
+export const MEETING_NAME = 'Action Meeting';
+export const MEETING_SUMMARY_LABEL = 'Summary';
+export const AGENDA_ITEM_LABEL = 'Agenda Item';
+
 /* Phases */
 export const LOBBY = 'lobby';
 // lowercase here to match url

--- a/src/universal/utils/makeCalendarInvites.js
+++ b/src/universal/utils/makeCalendarInvites.js
@@ -1,4 +1,5 @@
 import ms from 'ms';
+import {MEETING_NAME} from 'universal/utils/constants';
 
 // the ICS doesn't get the 'Add your conference' line because it doesn't accept line breaks. that's cool though because it isn't editable
 // eslint-disable-next-line max-len
@@ -33,9 +34,9 @@ const getStartTime = (createdAt) => {
 };
 
 export const createGoogleCalendarInviteURL = (createdAt, meetingUrl, teamName) => {
-  const text = `Action Meeting for ${teamName}`;
+  const text = `${MEETING_NAME} for ${teamName}`;
   // eslint-disable-next-line max-len
-  return encodeURI(`http://www.google.com/calendar/render?action=TEMPLATE&text=${text}&details=${description}&dates=${getStartTime(createdAt)}&trp=true&location=${meetingUrl}&sprop=${meetingUrl}&sprop=name:${teamName} Action Meeting`);
+  return encodeURI(`http://www.google.com/calendar/render?action=TEMPLATE&text=${text}&details=${description}&dates=${getStartTime(createdAt)}&trp=true&location=${meetingUrl}&sprop=${meetingUrl}&sprop=name:${teamName} ${MEETING_NAME}`);
 };
 
 export const createICS = (createdAt, meetingUrl, teamName) => {
@@ -56,7 +57,7 @@ LOCATION:${meetingUrl}
 SUMMARY:Star Wars Day Party
 DESCRIPTION:${description}
 CLASS:PUBLIC
-SUMMARY:Action Meeting for ${teamName}
+SUMMARY:${MEETING_NAME} for ${teamName}
 CLASS:PUBLIC
 DTSTAMP:${startTime}
 RRULE:FREQ=WEEKLY;COUNT=8


### PR DESCRIPTION
This PR addresses:

- [x] #1202 Meeting component names
- [x] #1282 Create project label (removes “Task”)
- [x] #1023 Create project icon confusion

Note, the code:

- Uses constants for UI labels in more places.
- Refactors UI labels in some places.
- Cleans up unused constants for UI labels.

_Oh yeah, and Rally added_: [JUST DO IT](https://youtu.be/ZXsQAXx_ao0)

## Test Plan

- [ ] Run a meeting locally with 2 team members (as Facilitator and as a non-Facilitator)
- [ ] Verify consistent labels (phase names, singular/plural) in navigation, avatar menus, facilitation hints, copy, buttons, etc. (as Facilitator and as a non-Facilitator)
- [ ] Verify consistent labels (phase names, singular/plural) within the Summary Email when 0, 1, and 2 Agenda Items are processed