### PR TITLE
Epic 6.5 Menu Sprint #1

### DIFF
--- a/src/universal/components/ProjectIntegrationLink.js
+++ b/src/universal/components/ProjectIntegrationLink.js
@@ -9,10 +9,12 @@ const ProjectIntegrationLink = (props) => {
   const {nameWithOwner, issueNumber} = integration || {};
   if (!issueNumber) return null;
   // TODO make this async and point to subcomponents when we have more than github
+  // NOTE: name="cardLink" used to detect activeElement (SEE: MeetingContainer.js)
   return (
     <a
       className={css(styles.demoLink)}
       href={`https://www.github.com/${nameWithOwner}/issues/${issueNumber}`}
+      name="cardLink"
       rel="noopener noreferrer"
       target="_blank"
       title={`GitHub Issue #${issueNumber} on ${nameWithOwner}`}

--- a/src/universal/components/ProjectIntegrationLink.js
+++ b/src/universal/components/ProjectIntegrationLink.js
@@ -9,12 +9,10 @@ const ProjectIntegrationLink = (props) => {
   const {nameWithOwner, issueNumber} = integration || {};
   if (!issueNumber) return null;
   // TODO make this async and point to subcomponents when we have more than github
-  // NOTE: name="cardLink" used to detect activeElement (SEE: MeetingContainer.js)
   return (
     <a
       className={css(styles.demoLink)}
       href={`https://www.github.com/${nameWithOwner}/issues/${issueNumber}`}
-      name="cardLink"
       rel="noopener noreferrer"
       target="_blank"
       title={`GitHub Issue #${issueNumber} on ${nameWithOwner}`}

--- a/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
@@ -93,6 +93,10 @@ const mutationHandlers = {
   updateAgendaItem: handleAgendaSort
 };
 
+const handleHotkey = (gotoFunc) => () => {
+  if (document.activeElement === document.body) gotoFunc();
+};
+
 const mapStateToProps = (state, props) => {
   const {match: {params: {localPhase, localPhaseItem, teamId}}} = props;
   const {sub: userId} = state.auth.obj;
@@ -160,8 +164,8 @@ export default class MeetingContainer extends Component {
   componentWillMount() {
     const {bindHotkey, teamId} = this.props;
     handleRedirects({}, this.props);
-    bindHotkey(['enter', 'right'], this.gotoNext);
-    bindHotkey('left', this.gotoPrev);
+    bindHotkey(['enter', 'right'], handleHotkey(this.gotoNext));
+    bindHotkey('left', handleHotkey(this.gotoPrev));
     bindHotkey('i c a n t h a c k i t', () => cashay.mutate('killMeeting', {variables: {teamId}}));
   }
 
@@ -277,10 +281,6 @@ export default class MeetingContainer extends Component {
   gotoNext = () => {
     const {localPhase, localPhaseItem} = this.props;
     const nextPhaseInfo = actionMeeting[localPhase];
-    const activeElement = document.activeElement;
-    if (activeElement.name === 'cardButton' || activeElement.name === 'cardLink') {
-      return;
-    }
     if (nextPhaseInfo.items) {
       this.gotoItem(localPhaseItem + 1);
     } else {

--- a/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
@@ -277,6 +277,10 @@ export default class MeetingContainer extends Component {
   gotoNext = () => {
     const {localPhase, localPhaseItem} = this.props;
     const nextPhaseInfo = actionMeeting[localPhase];
+    const activeElement = document.activeElement;
+    if (activeElement.name === 'cardButton' || activeElement.name === 'cardLink') {
+      return;
+    }
     if (nextPhaseInfo.items) {
       this.gotoItem(localPhaseItem + 1);
     } else {

--- a/src/universal/modules/menu/components/MenuItem/MenuItem.js
+++ b/src/universal/modules/menu/components/MenuItem/MenuItem.js
@@ -57,7 +57,7 @@ const MenuItem = (props) => {
   return (
     <div title={titleStr}>
       {hr === 'before' && <hr className={css(styles.hr)} />}
-      <div className={rootStyles} onClick={handleClick} >
+      <div className={rootStyles} onClick={handleClick}>
         {avatar && makeAvatar()}
         {!avatar && icon && makeIcon()}
         {labelEl}

--- a/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
@@ -93,16 +93,22 @@ class OutcomeCardFooter extends Component {
     );
 
     const {error} = this.state;
+    // NOTE: name="cardButton" used to detect activeElement (SEE: MeetingContainer.js)
     const ownerAvatarOrTeamName = (
       showTeam ?
         <div className={css(styles.teamName)}>{teamName}</div> :
-        (<div className={avatarStyles} tabIndex="0">
+        (<button
+          className={avatarStyles}
+          name="cardButton"
+          tabIndex={service && '-1'}
+          type="button"
+        >
           <img
             alt={owner.preferredName}
             className={css(styles.avatarImg)}
             src={owner.picture}
           />
-        </div>)
+        </button>)
     );
 
     return (
@@ -203,8 +209,10 @@ const styleThunk = () => ({
   },
 
   avatar: {
+    appearance: 'none',
     borderRadius: '100%',
     border: '.0625rem solid transparent',
+    boxShadow: 'none',
     cursor: 'pointer',
     height: '1.75rem',
     marginLeft: '-.125rem',

--- a/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
@@ -81,25 +81,20 @@ class OutcomeCardFooter extends Component {
     const {teamMember: owner, integration, team: {name: teamName}} = outcome;
     const {service} = integration || {};
     const isArchived = isProjectArchived(outcome.tags);
-
     const buttonBlockStyles = css(
       styles.buttonBlock,
       cardIsActive && styles.showBlock
     );
-
     const avatarStyles = css(
       styles.avatar,
       cardIsActive && styles.activeAvatar
     );
-
     const {error} = this.state;
-    // NOTE: name="cardButton" used to detect activeElement (SEE: MeetingContainer.js)
     const ownerAvatarOrTeamName = (
       showTeam ?
         <div className={css(styles.teamName)}>{teamName}</div> :
         (<button
           className={avatarStyles}
-          name="cardButton"
           tabIndex={service && '-1'}
           type="button"
         >

--- a/src/universal/modules/outcomeCard/components/OutcomeCardFooterButton/OutcomeCardFooterButton.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardFooterButton/OutcomeCardFooterButton.js
@@ -25,14 +25,11 @@ const OutcomeCardFooterButton = (props) => {
 
   const handleOnClick = (e) => {
     if (onClick) onClick(e);
-    // e.currentTarget.blur();
   };
 
-  // NOTE: name="cardButton" used to detect activeElement (SEE: MeetingContainer.js)
   return (
     <button
       className={buttonStyles}
-      name="cardButton"
       onClick={handleOnClick}
       onMouseEnter={onMouseEnter}
       type="button"

--- a/src/universal/modules/outcomeCard/components/OutcomeCardFooterButton/OutcomeCardFooterButton.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardFooterButton/OutcomeCardFooterButton.js
@@ -28,8 +28,15 @@ const OutcomeCardFooterButton = (props) => {
     // e.currentTarget.blur();
   };
 
+  // NOTE: name="cardButton" used to detect activeElement (SEE: MeetingContainer.js)
   return (
-    <button className={buttonStyles} onClick={handleOnClick} onMouseEnter={onMouseEnter}>
+    <button
+      className={buttonStyles}
+      name="cardButton"
+      onClick={handleOnClick}
+      onMouseEnter={onMouseEnter}
+      type="button"
+    >
       <FontAwesome name={icon} style={faStyle} />
     </button>
   );


### PR DESCRIPTION
This PR addresses: #1198 (tab + enter to open menu instead of advance meeting)

**NOTE**: This is just a patch to slightly improve the experience. There is still a number of menu behaviors that can be improved and this may need deeper refactoring and some more fluency on the menu HOC pattern. _I would save this work for perhaps a Sprint No. 2 or defer as the menu improvements are low priority overall_.

**Does Address**:
- If a user tabs to a card button and instinctively presses `enter` they get a menu instead of advancing the meeting. However, they have to use the mouse for further interaction (see note below).
- A user can tab into the GitHub link of an integrated card. Pressing `enter` will open the link in a new tab.
- A user will skip the avatar when tabbing through an integrated card (since one cannot reassign currently).

**Does Not Address**:
- Tabbing to another card button when a menu is open doesn’t close the currently open menu (but tapping `enter` will open the other menu and then close the current menu).
- Once a menu is open you can’t use arrow keys to select the options. This is described by #1199.

## Test Plan
- Start a meeting
- [ ] Tab to the card avatar and both card buttons in Updates and Agenda. Pressing enter will open the menu (Assign, GitHub, Status) instead of advancing the meeting. Note: The GitHub button logs an error during Updates as a separate issue #1336
- [ ] Tab through the content of an integrated card (with GitHub). You can tab to the issue link (pressing enter opens the link in a new tab) and to the assign menu, skipping the avatar menu (because currently you cannot reassign an integrated issue). During the meeting, pressing enter will not advance the meeting when opening the link or the assign menu.