### PR TITLE
Epic7 meeting link copier

### DIFF
--- a/src/universal/components/Button/Button.js
+++ b/src/universal/components/Button/Button.js
@@ -127,7 +127,6 @@ class Button extends Component {
       label,
       onClick,
       onMouseEnter,
-      size,
       styles,
       title,
       type,
@@ -151,18 +150,13 @@ class Button extends Component {
     const makeIconLabel = () => {
       const defaultIconPlacement = icon && label ? 'left' : '';
       const thisIconPlacement = iconPlacement || defaultIconPlacement;
-      const iconPlacementStyle = css(
+      const iconStyle = css(
+        styles.icon,
         thisIconPlacement === 'left' && styles.iconLeft,
         thisIconPlacement === 'right' && styles.iconRight,
       );
-      const iconMargin = iconOnly ? '' : iconPlacementStyle;
-      const iconStyle = {
-        fontSize: ui.buttonIconSize[size],
-        lineHeight: 'inherit',
-        verticalAlign: 'middle'
-      };
       const makeIcon = () =>
-        <FontAwesome className={iconMargin} name={icon} style={iconStyle} />;
+        <FontAwesome className={iconStyle} name={icon} />;
       return (
         <span className={css(styles.buttonInner)}>
           {iconOnly ?
@@ -200,10 +194,6 @@ class Button extends Component {
     );
   }
 }
-
-const icon = {
-  fontSize: ui.iconSize2x
-};
 
 const styleThunk = (theme, {buttonStyle, colorPalette, depth, size, textTransform}) => ({
   // Button base
@@ -245,13 +235,17 @@ const styleThunk = (theme, {buttonStyle, colorPalette, depth, size, textTransfor
     ...ui.buttonDisabledStyles
   },
 
+  icon: {
+    fontSize: ui.buttonIconSize[size] || ui.buttonIconSize.medium,
+    lineHeight: 'inherit',
+    verticalAlign: 'middle'
+  },
+
   iconLeft: {
-    ...icon,
     marginRight: '.375em'
   },
 
   iconRight: {
-    ...icon,
     marginLeft: '.375em'
   },
 

--- a/src/universal/components/Button/Button.js
+++ b/src/universal/components/Button/Button.js
@@ -51,6 +51,7 @@ const makePropColors = (buttonStyle, colorPalette) => {
 
 class Button extends Component {
   static propTypes = {
+    'aria-label': PropTypes.string,
     colorPalette: PropTypes.oneOf(ui.paletteOptions),
     compact: PropTypes.bool,
     // depth: up to 3 + 1 (for :hover, :focus) = up to ui.shadow[4]
@@ -116,6 +117,7 @@ class Button extends Component {
 
   render() {
     const {
+      'aria-label': ariaLabel,
       compact,
       depth,
       disabled,
@@ -186,6 +188,7 @@ class Button extends Component {
         onMouseLeave={this.onMouseLeave}
         title={title || label}
         type={type || 'button'}
+        aria-label={ariaLabel}
       >
         {icon ?
           makeIconLabel() :
@@ -197,6 +200,10 @@ class Button extends Component {
     );
   }
 }
+
+const icon = {
+  fontSize: ui.iconSize2x
+};
 
 const styleThunk = (theme, {buttonStyle, colorPalette, depth, size, textTransform}) => ({
   // Button base
@@ -239,10 +246,12 @@ const styleThunk = (theme, {buttonStyle, colorPalette, depth, size, textTransfor
   },
 
   iconLeft: {
+    ...icon,
     marginRight: '.375em'
   },
 
   iconRight: {
+    ...icon,
     marginLeft: '.375em'
   },
 

--- a/src/universal/components/Tooltip/ControlledTooltip.js
+++ b/src/universal/components/Tooltip/ControlledTooltip.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
 import TooltipModal from 'universal/components/Tooltip/TooltipModal';
-import withCoords from 'universal/decorators/withCoords';
 
 /**
  * A "controlled" tooltip is a tooltip which appears and disappears when you
@@ -38,4 +37,4 @@ class ControlledTooltip extends Component {
   }
 }
 
-export default withCoords(ControlledTooltip);
+export default ControlledTooltip;

--- a/src/universal/components/Tooltip/ControlledTooltip.js
+++ b/src/universal/components/Tooltip/ControlledTooltip.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+
+import TooltipModal from 'universal/components/Tooltip/TooltipModal';
+import withCoords from 'universal/decorators/withCoords';
+
+/**
+ * A "controlled" tooltip is a tooltip which appears and disappears when you
+ * ask it to.  It is controlled via the required `isOpen` boolean prop.  It's
+ * useful for providing feedback in response to particular events rather than
+ * hover/focus state.  If you want a tooltip that reacts to hover/focus state,
+ * use the `Tooltip` component.
+ */
+class ControlledTooltip extends Component {
+  static propTypes = {
+    tip: PropTypes.element.isRequired,
+    children: PropTypes.element.isRequired,
+    setOriginCoords: PropTypes.func.isRequired,
+    isOpen: PropTypes.bool.isRequired
+  };
+
+  setOriginCoords = (containerEl) => {
+    if (containerEl) {
+      this.props.setOriginCoords(containerEl.getBoundingClientRect());
+    }
+  };
+
+  render() {
+    const {isOpen, children} = this.props;
+    return isOpen ? (
+      <div>
+        <TooltipModal {...this.props} />
+        <div ref={this.setOriginCoords}>{children}</div>
+      </div>
+    ) : (
+      children
+    );
+  }
+}
+
+export default withCoords(ControlledTooltip);

--- a/src/universal/components/Tooltip/HoverTooltip.js
+++ b/src/universal/components/Tooltip/HoverTooltip.js
@@ -1,0 +1,81 @@
+import React, {Children, cloneElement, Component} from 'react';
+import TooltipModal from 'universal/components/Tooltip/TooltipModal';
+import withCoords from 'universal/decorators/withCoords';
+import PropTypes from 'prop-types';
+
+class HoverTooltip extends Component {
+  static propTypes = {
+    children: PropTypes.any.isRequired,
+    tip: PropTypes.any.isRequired,
+    setOriginCoords: PropTypes.func.isRequired
+  }
+  state = {
+    inTip: false,
+    inToggle: false
+  };
+
+  componentWillMount() {
+    this.makeSmartChildren(this.props.children);
+    this.makeSmartTip(this.props.tip);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.makeSmartChildren(nextProps.children);
+    this.makeSmartTip(nextProps.tip);
+  }
+
+  makeSmartChildren(children) {
+    const child = Children.only(children);
+    this.children = cloneElement(child, {
+      onMouseEnter: (e) => {
+        const {setOriginCoords} = this.props;
+        this.setState({
+          inToggle: true,
+          inTip: false
+        });
+        setOriginCoords(e.currentTarget.getBoundingClientRect());
+
+        // if the menu was gonna do something, do it
+        const {onMouseEnter} = child.props;
+        if (onMouseEnter) {
+          onMouseEnter(e);
+        }
+      },
+      onMouseLeave: () => {
+        this.setState({
+          inToggle: false
+        });
+      }
+    });
+  }
+
+  // this is useful if the tooltip is positioned over the toggle due to small screens, etc.
+  makeSmartTip(tip) {
+    this.tip = cloneElement(tip, {
+      onMouseEnter: () => {
+        this.setState({
+          inToggle: false,
+          inTip: true
+        });
+      },
+      onMouseLeave: () => {
+        this.setState({
+          inTip: false
+        });
+      }
+    });
+  }
+
+  render() {
+    const {inTip, inToggle} = this.state;
+    const isOpen = inTip || inToggle;
+    return (
+      <div>
+        <TooltipModal {...this.props} isOpen={isOpen} tip={this.tip} />
+        {this.children}
+      </div>
+    );
+  }
+}
+
+export default withCoords(HoverTooltip);

--- a/src/universal/components/Tooltip/HoverTooltip.js
+++ b/src/universal/components/Tooltip/HoverTooltip.js
@@ -1,6 +1,5 @@
 import React, {Children, cloneElement, Component} from 'react';
 import TooltipModal from 'universal/components/Tooltip/TooltipModal';
-import withCoords from 'universal/decorators/withCoords';
 import PropTypes from 'prop-types';
 
 class HoverTooltip extends Component {
@@ -78,4 +77,4 @@ class HoverTooltip extends Component {
   }
 }
 
-export default withCoords(HoverTooltip);
+export default HoverTooltip;

--- a/src/universal/components/Tooltip/Tooltip.js
+++ b/src/universal/components/Tooltip/Tooltip.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import ControlledTooltip from 'universal/components/Tooltip/ControlledTooltip';
 import HoverTooltip from 'universal/components/Tooltip/HoverTooltip';
+import withCoords from 'universal/decorators/withCoords';
 
 const Tooltip = (props) =>
   typeof props.isOpen === 'boolean' ? (
@@ -18,4 +19,4 @@ Tooltip.propTypes = {
   isOpen: PropTypes.bool
 };
 
-export default Tooltip;
+export default withCoords(Tooltip);

--- a/src/universal/components/Tooltip/Tooltip.js
+++ b/src/universal/components/Tooltip/Tooltip.js
@@ -1,81 +1,21 @@
-import React, {Children, cloneElement, Component} from 'react';
-import TooltipModal from 'universal/components/Tooltip/TooltipModal';
-import withCoords from 'universal/decorators/withCoords';
 import PropTypes from 'prop-types';
+import React from 'react';
 
-class Tooltip extends Component {
-  static propTypes = {
-    children: PropTypes.any.isRequired,
-    tip: PropTypes.any.isRequired,
-    setOriginCoords: PropTypes.func.isRequired
-  }
-  state = {
-    inTip: false,
-    inToggle: false
-  };
+import ControlledTooltip from 'universal/components/Tooltip/ControlledTooltip';
+import HoverTooltip from 'universal/components/Tooltip/HoverTooltip';
 
-  componentWillMount() {
-    this.makeSmartChildren(this.props.children);
-    this.makeSmartTip(this.props.tip);
-  }
+const Tooltip = (props) =>
+  typeof props.isOpen === 'boolean' ? (
+    <ControlledTooltip {...props} />
+  ) : (
+    <HoverTooltip {...props} />
+  );
 
-  componentWillReceiveProps(nextProps) {
-    this.makeSmartChildren(nextProps.children);
-    this.makeSmartTip(nextProps.tip);
-  }
+Tooltip.propTypes = {
+  tip: PropTypes.element.isRequired,
+  children: PropTypes.element.isRequired,
+  setOriginCoords: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool
+};
 
-  makeSmartChildren(children) {
-    const child = Children.only(children);
-    this.children = cloneElement(child, {
-      onMouseEnter: (e) => {
-        const {setOriginCoords} = this.props;
-        this.setState({
-          inToggle: true,
-          inTip: false
-        });
-        setOriginCoords(e.currentTarget.getBoundingClientRect());
-
-        // if the menu was gonna do something, do it
-        const {onMouseEnter} = child.props;
-        if (onMouseEnter) {
-          onMouseEnter(e);
-        }
-      },
-      onMouseLeave: () => {
-        this.setState({
-          inToggle: false
-        });
-      }
-    });
-  }
-
-  // this is useful if the tooltip is positioned over the toggle due to small screens, etc.
-  makeSmartTip(tip) {
-    this.tip = cloneElement(tip, {
-      onMouseEnter: () => {
-        this.setState({
-          inToggle: false,
-          inTip: true
-        });
-      },
-      onMouseLeave: () => {
-        this.setState({
-          inTip: false
-        });
-      }
-    });
-  }
-
-  render() {
-    const {inTip, inToggle} = this.state;
-    const isOpen = inTip || inToggle;
-    return (
-      <div>
-        <TooltipModal {...this.props} isOpen={isOpen} tip={this.tip} />
-        {this.children}
-      </div>
-    );
-  }
-}
-
-export default withCoords(Tooltip);
+export default Tooltip;

--- a/src/universal/modules/meeting/components/CopyShortLink/CopyShortLink.js
+++ b/src/universal/modules/meeting/components/CopyShortLink/CopyShortLink.js
@@ -44,6 +44,7 @@ class CopyShortLink extends Component {
       <CopyToClipboard text={url} onCopy={this.confirmCopied}>
         <Button
           aria-label={callToAction}
+          size="small"
           buttonStyle="inverted"
           colorPalette="cool"
           disabled={confirmingCopied}

--- a/src/universal/modules/meeting/components/CopyShortLink/CopyShortLink.js
+++ b/src/universal/modules/meeting/components/CopyShortLink/CopyShortLink.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import Button from 'universal/components/Button/Button';
 import CopyToClipboard from 'react-copy-to-clipboard';
+import Tooltip from 'universal/components/Tooltip/Tooltip';
 import voidClick from 'universal/utils/voidClick';
 
 class CopyShortLink extends Component {
@@ -31,30 +32,39 @@ class CopyShortLink extends Component {
   confirmCopied = () => {
     this.clearConfirmationTimeout();
     this.confirmationTimeout = setTimeout(() => {
-      this.setState({ confirmingCopied: false });
+      this.setState({confirmingCopied: false});
     }, 1500);
-    this.setState({ confirmingCopied: true });
+    this.setState({confirmingCopied: true});
   };
 
   render() {
     const {url} = this.props;
     const {confirmingCopied} = this.state;
-    const callToAction = 'Copy link to meeting';
+    const callToAction = 'Copy the meeting link';
     return (
-      <CopyToClipboard text={url} onCopy={this.confirmCopied}>
-        <Button
-          aria-label={callToAction}
-          size="small"
-          buttonStyle="inverted"
-          colorPalette="cool"
-          disabled={confirmingCopied}
-          title={callToAction}
-          icon={confirmingCopied ? 'check' : 'copy'}
-          iconPlacement="left"
-          label={confirmingCopied ? 'Copied!' : url}
-          onClick={voidClick}
-        />
-      </CopyToClipboard>
+      <Tooltip
+        isOpen={confirmingCopied}
+        tip={<div>Copied the meeting link!</div>}
+        maxHeight={40}
+        maxWidth={500}
+        originAnchor={{vertical: 'bottom', horizontal: 'center'}}
+        targetAnchor={{vertical: 'top', horizontal: 'center'}}
+      >
+        <CopyToClipboard text={url} onCopy={this.confirmCopied}>
+          <Button
+            aria-label={callToAction}
+            size="small"
+            buttonStyle="inverted"
+            colorPalette="cool"
+            disabled={confirmingCopied}
+            title={callToAction}
+            icon="copy"
+            iconPlacement="left"
+            label={url}
+            onClick={voidClick}
+          />
+        </CopyToClipboard>
+      </Tooltip>
     );
   }
 }

--- a/src/universal/modules/meeting/components/CopyShortLink/CopyShortLink.js
+++ b/src/universal/modules/meeting/components/CopyShortLink/CopyShortLink.js
@@ -1,82 +1,61 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import withStyles from 'universal/styles/withStyles';
-import {css} from 'aphrodite-local-styles/no-important';
-import FontAwesome from 'react-fontawesome';
+import React, {Component} from 'react';
+import Button from 'universal/components/Button/Button';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import appTheme from 'universal/styles/theme/appTheme';
-import ui from 'universal/styles/ui';
-import {textOverflow} from 'universal/styles/helpers';
 import voidClick from 'universal/utils/voidClick';
 
-const inlineBlock = {
-  display: 'inline-block',
-  height: '1.75rem',
-  lineHeight: '1.75rem',
-  verticalAlign: 'top'
-};
+class CopyShortLink extends Component {
+  static propTypes = {
+    url: PropTypes.string
+  };
 
-const CopyShortLink = (props) => {
-  const {styles, url} = props;
-  return (
-    <CopyToClipboard text={url}>
-      {/* TODO: prevent navigation and show a “Copied!” message inline or toast */}
-      <a
-        className={css(styles.link)}
-        href={url}
-        onClick={voidClick}
-        title={`Copy link to meeting: ${url}`}
-      >
-        <span className={css(styles.linkText)}>{url}</span>
-        <span className={css(styles.icon)}>
-          <FontAwesome
-            name="copy"
-            style={inlineBlock}
-          />
-        </span>
-      </a>
-    </CopyToClipboard>
-  );
-};
-
-CopyShortLink.propTypes = {
-  styles: PropTypes.object,
-  url: PropTypes.string
-};
-
-const styleThunk = () => ({
-  link: {
-    backgroundColor: appTheme.palette.cool10l,
-    borderRadius: '.375rem',
-    display: 'block',
-    fontSize: 0,
-    lineHeight: '1.75rem',
-    margin: '0 auto',
-    maxWidth: '24rem',
-    padding: '.625rem .5rem',
-    textAlign: 'center',
-    textDecoration: 'none !important',
-
-    ':hover': {
-      backgroundColor: appTheme.palette.cool20l
-    },
-    ':focus': {
-      backgroundColor: appTheme.palette.cool20l
-    }
-  },
-
-  linkText: {
-    ...inlineBlock,
-    ...textOverflow,
-    fontSize: appTheme.typography.s6,
-    maxWidth: '20rem'
-  },
-
-  icon: {
-    ...inlineBlock,
-    fontSize: ui.iconSize2x,
-    marginLeft: '.5rem'
+  constructor(props) {
+    super(props);
+    this.confirmationTimeout = null;
   }
-});
 
-export default withStyles(styleThunk)(CopyShortLink);
+  state = {
+    confirmingCopied: false
+  };
+
+  componentWillUnmount() {
+    this.clearConfirmationTimeout();
+  }
+
+  clearConfirmationTimeout = () => {
+    if (this.confirmationTimeout) {
+      clearTimeout(this.confirmationTimeout);
+    }
+  };
+
+  confirmCopied = () => {
+    this.clearConfirmationTimeout();
+    this.confirmationTimeout = setTimeout(() => {
+      this.setState({ confirmingCopied: false });
+    }, 1500);
+    this.setState({ confirmingCopied: true });
+  };
+
+  render() {
+    const {url} = this.props;
+    const {confirmingCopied} = this.state;
+    const callToAction = 'Copy link to meeting';
+    return (
+      <CopyToClipboard text={url} onCopy={this.confirmCopied}>
+        <Button
+          aria-label={callToAction}
+          buttonStyle="inverted"
+          colorPalette="cool"
+          disabled={confirmingCopied}
+          title={callToAction}
+          icon={confirmingCopied ? 'check' : 'copy'}
+          iconPlacement="left"
+          label={confirmingCopied ? 'Copied!' : url}
+          onClick={voidClick}
+        />
+      </CopyToClipboard>
+    );
+  }
+}
+
+export default CopyShortLink;

--- a/src/universal/modules/meeting/components/CopyShortLink/CopyShortLink.js
+++ b/src/universal/modules/meeting/components/CopyShortLink/CopyShortLink.js
@@ -56,7 +56,6 @@ class CopyShortLink extends Component {
             size="small"
             buttonStyle="inverted"
             colorPalette="cool"
-            disabled={confirmingCopied}
             title={callToAction}
             icon="copy"
             iconPlacement="left"

--- a/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
+++ b/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
@@ -25,7 +25,7 @@ const MeetingLobby = (props) => {
   const {members, team, styles} = props;
   const {id: teamId, name: teamName} = team;
   const onStartMeetingClick = createStartMeetingHandler(members);
-  const shortUrl = makeHref(`/meeting/${teamId}/lobby`);
+  const meetingUrl = makeHref(`/meeting/${teamId}`);
   return (
     <MeetingMain>
       {/* */}
@@ -54,7 +54,7 @@ const MeetingLobby = (props) => {
         </div>
         <p className={css(styles.label)}>{'Copy Meeting Link:'}</p>
         <div className={css(styles.urlBlock)}>
-          <CopyShortLink url={shortUrl} />
+          <CopyShortLink url={meetingUrl} />
         </div>
       </div>
       {/* */}

--- a/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
+++ b/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
@@ -25,7 +25,7 @@ const MeetingLobby = (props) => {
   const {members, team, styles} = props;
   const {id: teamId, name: teamName} = team;
   const onStartMeetingClick = createStartMeetingHandler(members);
-  const shortUrl = makeHref(`/team/${teamId}`);
+  const shortUrl = makeHref(`/meeting/${teamId}/lobby`);
   return (
     <MeetingMain>
       {/* */}
@@ -52,7 +52,7 @@ const MeetingLobby = (props) => {
             textTransform="uppercase"
           />
         </div>
-        <p className={css(styles.label)}>{'Meeting Link:'}</p>
+        <p className={css(styles.label)}>{'Copy Meeting Link:'}</p>
         <div className={css(styles.urlBlock)}>
           <CopyShortLink url={shortUrl} />
         </div>

--- a/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
+++ b/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
@@ -52,7 +52,7 @@ const MeetingLobby = (props) => {
             textTransform="uppercase"
           />
         </div>
-        <p className={css(styles.label)}>{'Copy Meeting Link:'}</p>
+        <p className={css(styles.label)}>{'Meeting Link:'}</p>
         <div className={css(styles.urlBlock)}>
           <CopyShortLink url={meetingUrl} />
         </div>


### PR DESCRIPTION
Alright, this should fix #1378. Following up here from the closed #1381.

I'm about to take a go at changing the feedback mechanism from changing the contents of the button to a tooltip modal. 

Test Plan
- [ ] `git checkout epic7-meeting-link-copier && git pull && npm run dev`
- [ ] Navigate to a team in the left-hand nav
- [ ] Click the "Meeting Lobby" button
- [ ] Click on the meeting link button near the bottom of the page
- [ ] *Verify* that "Copied the meeting link!" confirmation tooltip appears
- [ ] Open another window/tab
- [ ] Paste from the clipboard into the URL bar
- [ ] *Verify* that you're in the meeting lobby