### PR TITLE
support invoices that are not upcoming or paid

### DIFF
--- a/src/universal/modules/invoice/components/Invoice/Invoice.js
+++ b/src/universal/modules/invoice/components/Invoice/Invoice.js
@@ -168,10 +168,6 @@ Invoice.propTypes = {
   styles: PropTypes.object
 };
 
-Invoice.defaultProps = {
-  subject: 'February 2017'
-};
-
 const breakpoint = ui.invoiceBreakpoint;
 const invoiceGutterSmall = '1rem';
 const invoiceGutterLarge = '2rem';
@@ -352,6 +348,8 @@ export default createFragmentContainer(
             id
             amount
             email
+            endAt
+            startAt
           }
           quantity
           type

--- a/src/universal/modules/invoice/components/Invoice/Invoice.js
+++ b/src/universal/modules/invoice/components/Invoice/Invoice.js
@@ -138,22 +138,22 @@ const Invoice = (props) => {
           {startingBalance !== 0 &&
             <div>
               <div className={css(styles.amountLineSub)}>
-                <div>Total</div>
+                <div>{'Total'}</div>
                 <div>{invoiceLineFormat(total)}</div>
               </div>
               <div className={css(styles.amountLineSub)}>
-                <div>Previous Balance</div>
+                <div>{'Previous Balance'}</div>
                 <div>{invoiceLineFormat(startingBalance)}</div>
               </div>
             </div>
           }
           <div className={css(styles.amountLine)}>
-            <div>Amount due</div>
+            <div>{'Amount due'}</div>
             <div>{invoiceLineFormat(amountDue)}</div>
           </div>
           {brand &&
             <div className={css(styles.meta, status === FAILED && styles.metaError)}>
-              {chargeStatus[status]} to <b>{brand}</b> ending in <b>{last4}</b>
+              {chargeStatus[status]}{' to '}<b>{brand}</b> {'ending in '}<b>{last4}</b>
             </div>
           }
         </div>

--- a/src/universal/modules/invoice/components/Invoice/Invoice.js
+++ b/src/universal/modules/invoice/components/Invoice/Invoice.js
@@ -98,7 +98,7 @@ const Invoice = (props) => {
       <div className={css(styles.panel)}>
         {status === FAILED &&
           <div className={css(styles.failedStamp)}>
-            Payment Failed
+            {'Payment Failed'}
           </div>
         }
         {status === UPCOMING &&
@@ -209,10 +209,13 @@ const styleThunk = () => ({
     fontSize: '2.5rem',
     fontWeight: 700,
     left: '50%',
+    opacity: .5,
     position: 'absolute',
+    textAlign: 'center',
     textTransform: 'uppercase',
     top: '50%',
-    transform: 'translate(-50%, -50%, 0), rotate(-30deg)',
+    transform: 'translate3d(-50%, -50%, 0) rotate(-30deg)',
+    width: '100%',
 
     [breakpoint]: {
       fontSize: '3rem'

--- a/src/universal/modules/invoice/components/Invoice/Invoice.js
+++ b/src/universal/modules/invoice/components/Invoice/Invoice.js
@@ -209,7 +209,7 @@ const styleThunk = () => ({
     fontSize: '2.5rem',
     fontWeight: 700,
     left: '50%',
-    opacity: .5,
+    opacity: 0.5,
     position: 'absolute',
     textAlign: 'center',
     textTransform: 'uppercase',

--- a/src/universal/modules/userDashboard/components/InvoiceRow/InvoiceRow.js
+++ b/src/universal/modules/userDashboard/components/InvoiceRow/InvoiceRow.js
@@ -11,7 +11,7 @@ import makeDateString from 'universal/utils/makeDateString';
 import makeMonthString from 'universal/utils/makeMonthString';
 import {Link} from 'react-router-dom';
 import invoiceLineFormat from 'universal/modules/invoice/helpers/invoiceLineFormat';
-import {UPCOMING} from 'universal/utils/constants';
+import {PAID, UPCOMING} from 'universal/utils/constants';
 import fromGlobalId from 'universal/utils/relay/fromGlobalId';
 
 const InvoiceRow = (props) => {
@@ -62,14 +62,21 @@ const InvoiceRow = (props) => {
             </Link>
           </div>
           <div className={css(styles.infoRowRight)}>
-            {isEstimate ?
+            {status === UPCOMING &&
               <span className={css(styles.date, styles.toPay)}>
                 {hasCard ? `card will be charged on ${makeDateString(endAt)}` :
                   `Make sure to add billing info before ${makeDateString(endAt)}!`
                 }
-              </span> :
+              </span>
+            }
+            {status === PAID &&
               <span className={css(styles.date, styles.paid)}>
                 Paid on {makeDateString(paidAt)}
+              </span>
+            }
+            {status !== PAID && status !== UPCOMING &&
+              <span className={css(styles.unpaid)}>
+                Status: {status}
               </span>
             }
           </div>
@@ -143,6 +150,10 @@ const styleThunk = () => ({
     fontWeight: 700
   },
 
+  unpaid: {
+    color: appTheme.palette.warm,
+    fontWeight: 700
+  },
   invoiceTitle: {
     color: ui.rowHeadingColor,
     display: 'inline-block',

--- a/src/universal/modules/userDashboard/components/InvoiceRow/InvoiceRow.js
+++ b/src/universal/modules/userDashboard/components/InvoiceRow/InvoiceRow.js
@@ -11,7 +11,7 @@ import makeDateString from 'universal/utils/makeDateString';
 import makeMonthString from 'universal/utils/makeMonthString';
 import {Link} from 'react-router-dom';
 import invoiceLineFormat from 'universal/modules/invoice/helpers/invoiceLineFormat';
-import {PAID, UPCOMING} from 'universal/utils/constants';
+import {PAID, PENDING, UPCOMING} from 'universal/utils/constants';
 import fromGlobalId from 'universal/utils/relay/fromGlobalId';
 
 const InvoiceRow = (props) => {
@@ -32,6 +32,7 @@ const InvoiceRow = (props) => {
     styles.invoiceAvatar,
     isEstimate && styles.invoiceAvatarEstimate
   );
+  const statusStyle = status === PENDING ? styles.paid : styles.unpaid;
   return (
     <Row>
       <div className={invoiceAvatarStyles}>
@@ -58,7 +59,7 @@ const InvoiceRow = (props) => {
         <div className={css(styles.infoRow)}>
           <div className={css(styles.infoRowLeft)}>
             <Link className={css(styles.subHeader)} rel="noopener noreferrer" target="_blank" to={`/invoice/${invoiceId}`}>
-              See Details
+              {'See Details'}
             </Link>
           </div>
           <div className={css(styles.infoRowRight)}>
@@ -71,12 +72,12 @@ const InvoiceRow = (props) => {
             }
             {status === PAID &&
               <span className={css(styles.date, styles.paid)}>
-                Paid on {makeDateString(paidAt)}
+                {'Paid on '}{makeDateString(paidAt)}
               </span>
             }
             {status !== PAID && status !== UPCOMING &&
-              <span className={css(styles.unpaid)}>
-                Status: {status}
+              <span className={css(statusStyle)}>
+                {'Status: '}{status}
               </span>
             }
           </div>
@@ -93,7 +94,6 @@ InvoiceRow.propTypes = {
 };
 
 const lineHeightLarge = '1.625rem';
-// const lineHeightSmall = '1.125rem';
 
 const styleThunk = () => ({
   fileIcon: {


### PR DESCRIPTION
fixes #1389 

- [ ] `Paid At UNIX EPOCH` doesn't show up on a list of invoices anymore
- [ ] detailed line items show the correct pause/unpause date (this is harder than it should be to test, just trust me on this one :wink: we'll make proper tests when we can generate phony invoices)