### PR TITLE
Interrupting chicken

### DIFF
--- a/src/universal/modules/meeting/helpers/handleRedirects.js
+++ b/src/universal/modules/meeting/helpers/handleRedirects.js
@@ -92,7 +92,8 @@ export default function handleRedirects(oldProps, nextProps) {
     // were we n'sync?
     const inSync = localPhase === oldTeam.facilitatorPhase &&
       (localPhaseItem === undefined || localPhaseItem === oldTeam.facilitatorPhaseItem);
-    if (inSync && document.activeElement === document.body) {
+    // Ideally, we'd do this without the DOM & ensure it's an active project card, but this works for now
+    if (inSync && document.activeElement.contentEditable !== 'true') {
       const pushURL = makePushURL(teamId, facilitatorPhase, facilitatorPhaseItem);
       history.replace(pushURL);
       return false;

--- a/src/universal/modules/meeting/helpers/handleRedirects.js
+++ b/src/universal/modules/meeting/helpers/handleRedirects.js
@@ -92,7 +92,7 @@ export default function handleRedirects(oldProps, nextProps) {
     // were we n'sync?
     const inSync = localPhase === oldTeam.facilitatorPhase &&
       (localPhaseItem === undefined || localPhaseItem === oldTeam.facilitatorPhaseItem);
-    if (inSync) {
+    if (inSync && document.activeElement === document.body) {
       const pushURL = makePushURL(teamId, facilitatorPhase, facilitatorPhaseItem);
       history.replace(pushURL);
       return false;

--- a/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
+++ b/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
@@ -141,7 +141,7 @@ class OutcomeCardContainer extends Component {
   handleCardMouseLeave = () => this.setState({cardHasHover: false});
 
   handleCardBlur = (e) => {
-    const cb = !e.currentTarget.contains(e.relatedTarget) && this.handleCardUpdate;
+    const cb = !e.currentTarget.contains(e.relatedTarget) ? this.handleCardUpdate : undefined;
     this.setState({cardHasFocus: false}, cb);
   };
 


### PR DESCRIPTION
fix #490 

while in a meeting, if the facilitator advances with a participant is still typing, the participant advances with the facilitator, losing their work. This is frustrating for the participant.

It is not the job of the facilitator to wait for folks to finish typing.
It is not the job of the participant to alert the facilitator that the are still typing.

The solution is to not advanced with the facilitator if they're still typing.
To detect typing, we see if they have a contenteditable div active.
There are better forms of detection, but for now this works perfectly (ie if i'm adding an agenda item it still advances me).

also fixes an little break in react 16.