### PR TITLE
Epic 8 or 8.5: Editor Help Modal v1 (ready to test and ship!)

### DIFF
--- a/src/universal/components/Dashboard/DashModal.js
+++ b/src/universal/components/Dashboard/DashModal.js
@@ -58,7 +58,8 @@ DashModal.propTypes = {
     'fixed'
   ]),
   modalLayout: PropTypes.oneOf(ui.modalLayout),
-  styles: PropTypes.object
+  styles: PropTypes.object,
+  width: PropTypes.string
 };
 
 const animateIn = {
@@ -85,7 +86,7 @@ const animateOut = {
   }
 };
 
-const styleThunk = (theme, props) => ({
+const styleThunk = (theme, {closeAfter, width}) => ({
   backdrop: {
     alignItems: 'center',
     background: ui.modalBackdropBackgroundColor,
@@ -103,7 +104,7 @@ const styleThunk = (theme, props) => ({
   },
 
   closing: {
-    animationDuration: `${props.closeAfter}ms`,
+    animationDuration: `${closeAfter}ms`,
     animationName: animateOut
   },
 
@@ -152,7 +153,7 @@ const styleThunk = (theme, props) => ({
     boxShadow: ui.modalBoxShadow,
     overflow: 'hidden',
     padding: '1.25rem',
-    width: '30rem'
+    width: width || '30rem'
   }
 });
 

--- a/src/universal/components/EditorHelpModal/EditorHelpModal.js
+++ b/src/universal/components/EditorHelpModal/EditorHelpModal.js
@@ -118,7 +118,7 @@ const EditorHelpModal = (props) => {
           {makeIcon('keyboard-o', true)}
         </div>
         <div className={css(styles.modalHeaderTitle)}>
-          {'Formatting Help'}
+          {'Project Card Formatting'}
         </div>
         <button className={css(styles.closeButton)} onClick={handleCloseModal}>
           {makeIcon('times-circle', true)}

--- a/src/universal/components/EditorHelpModal/EditorHelpModal.js
+++ b/src/universal/components/EditorHelpModal/EditorHelpModal.js
@@ -1,0 +1,294 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import portal from 'react-portal-hoc';
+import FontAwesome from 'react-fontawesome';
+import {DashModal} from 'universal/components/Dashboard';
+import {css} from 'aphrodite-local-styles/no-important';
+import withStyles from 'universal/styles/withStyles';
+import ui from 'universal/styles/ui';
+import appTheme from 'universal/styles/theme/appTheme';
+
+const iconStyle = {
+  display: 'block',
+  lineHeight: ui.iconSize
+};
+const makeIcon = (name, large = false) => {
+  const style = {
+    ...iconStyle,
+    fontSize: large ? ui.iconSize2x : ui.iconSize
+  };
+  return <FontAwesome name={name} style={style} />;
+};
+
+const typeShortcuts = [
+  {
+    label: 'Bold',
+    icon: 'bold',
+    keyboard: 'command + b',
+    md: '**bold** or __bold__'
+  },
+  {
+    label: 'Italic',
+    icon: 'italic',
+    keyboard: 'command + i',
+    md: '*italic* or _italic_'
+  },
+  {
+    label: 'Underline',
+    icon: 'underline',
+    keyboard: 'command + u',
+    md: ''
+  },
+  {
+    label: 'Strikethrough',
+    icon: 'strikethrough',
+    keyboard: 'shift + command + x',
+    md: '~text~ or ~~text~~'
+  }
+];
+const mentionShortcuts = [
+  {
+    label: 'Links',
+    icon: 'link',
+    keyboard: 'command + k',
+    md: '[linked text](url)'
+  },
+  {
+    label: 'Tags',
+    icon: 'hashtag',
+    keyboard: 'press ‘#’',
+    md: ''
+  },
+  {
+    label: 'Emoji',
+    icon: 'smile-o',
+    keyboard: 'press ‘:’',
+    md: ''
+  },
+  {
+    label: 'Mentions',
+    icon: 'at',
+    keyboard: 'press ‘@’',
+    md: ''
+  }
+];
+const blockShortcuts = [
+  {
+    label: 'Inline code',
+    icon: 'code',
+    keyboard: '',
+    md: '`code`'
+  },
+  {
+    label: 'Code block',
+    icon: 'window-maximize',
+    keyboard: '',
+    md: <span>{'```'}<br />{'code'}<br />{'```'}</span>
+  },
+  {
+    label: 'Quotes',
+    icon: 'quote-left',
+    keyboard: '',
+    md: '>quote'
+  }
+];
+const shortcutLists = [
+  typeShortcuts,
+  mentionShortcuts,
+  blockShortcuts
+];
+const EditorHelpModal = (props) => {
+  const {
+    closeAfter,
+    handleCloseModal,
+    isClosing,
+    styles
+  } = props;
+  return (
+    <DashModal
+      closeAfter={closeAfter}
+      isClosing={isClosing}
+      modalLayout="viewport"
+      onBackdropClick={handleCloseModal}
+      position="absolute"
+      width="36.875rem"
+    >
+      <div className={css(styles.modalHeader)}>
+        <div className={css(styles.modalHeaderIcon)}>
+          {makeIcon('keyboard-o', true)}
+        </div>
+        <div className={css(styles.modalHeaderTitle)}>
+          {'Formatting Help'}
+        </div>
+        <button className={css(styles.closeButton)} onClick={handleCloseModal}>
+          {makeIcon('times-circle', true)}
+        </button>
+      </div>
+      <div className={css(styles.headerLabelBlock)}>
+        <div className={css(styles.headerLabel)}>
+          {'Keyboard'}
+        </div>
+        <div className={css(styles.headerLabel)}>
+          {'Markdown'}
+        </div>
+      </div>
+      {shortcutLists.map((shortcutList, listIndex) => {
+        const shortcutListStyles = css(
+          styles.helpList,
+          listIndex === 0 && styles.helpListFirst
+        );
+        return (
+          <div
+            className={shortcutListStyles}
+            key={`shortcutList${listIndex + 1}`}
+          >
+            {shortcutList.map((shortcut, shortcutIndex) => {
+              const rowStyles = css(
+                styles.helpRow,
+                (shortcutIndex % 2) && styles.helpRowAlt
+              );
+              return (
+                <div className={rowStyles} key={`${shortcutList}${shortcutIndex + 1}`}>
+                  <div className={css(styles.icon)}>
+                    {makeIcon(shortcut.icon)}
+                  </div>
+                  <div className={css(styles.label)}>
+                    <b>{shortcut.label}</b>
+                  </div>
+                  <div className={css(styles.keyboard)}>
+                    <code>{shortcut.keyboard}</code>
+                  </div>
+                  <div className={css(styles.md)}>
+                    <code>{shortcut.md}</code>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </DashModal>
+  );
+};
+
+const styleThunk = () => ({
+  modalHeader: {
+    alignItems: 'center',
+    color: ui.palette.mid,
+    display: 'flex',
+    justifyContent: 'center',
+    lineHeight: 1.5,
+    padding: '0 0 .25rem',
+    position: 'relative'
+  },
+
+  modalHeaderIcon: {
+    // Define
+  },
+
+  modalHeaderTitle: {
+    fontSize: appTheme.typography.s5,
+    marginLeft: '1rem'
+  },
+
+  closeButton: {
+    appearance: 'none',
+    backgroundColor: 'transparent',
+    boxShadow: 'none',
+    border: 0,
+    color: appTheme.palette.mid50l,
+    cursor: 'pointer',
+    display: 'block',
+    height: ui.iconSize2x,
+    lineHeight: ui.iconSize2x,
+    outline: 'none',
+    userSelect: 'none',
+    position: 'absolute',
+    right: '.125rem',
+    textAlign: 'center',
+    top: 0,
+    width: ui.iconSize2x,
+
+    ':hover': {
+      opacity: 0.5
+    },
+    ':focus': {
+      opacity: 0.5
+    }
+  },
+
+  helpList: {
+    border: `.0625rem solid ${appTheme.palette.mid30l}`,
+    color: appTheme.palette.dark50d,
+    fontSize: appTheme.typography.s2,
+    lineHeight: appTheme.typography.s4,
+    margin: '1rem auto 0',
+    minWidth: 0,
+    textAlign: 'left'
+  },
+
+  helpListFirst: {
+    margin: '0 auto'
+  },
+
+  helpRow: {
+    alignItems: 'center',
+    backgroundColor: appTheme.palette.mid10l,
+    display: 'flex',
+    padding: '.25rem 0'
+  },
+
+  helpRowAlt: {
+    backgroundColor: '#fff'
+  },
+
+  icon: {
+    padding: '0 .5rem 0 1rem',
+    textAlign: 'center',
+    width: '2.75rem'
+  },
+
+  label: {
+    padding: '0 .5rem',
+    width: '7.5rem'
+  },
+
+  keyboard: {
+    padding: '0 .5rem',
+    width: '12rem'
+  },
+
+  md: {
+    padding: '0 .5rem',
+    width: '12rem'
+  },
+
+  headerLabelBlock: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    padding: '.0625rem',
+    width: '100%'
+  },
+
+  headerLabel: {
+    color: ui.palette.dark,
+    fontSize: appTheme.typography.s2,
+    fontWeight: 700,
+    lineHeight: appTheme.typography.s4,
+    padding: '1rem .5rem .25rem',
+    textAlign: 'left',
+    textTransform: 'uppercase',
+    width: '12rem'
+  }
+});
+
+EditorHelpModal.propTypes = {
+  closeAfter: PropTypes.number,
+  handleCloseModal: PropTypes.func,
+  isClosing: PropTypes.bool,
+  isOpen: PropTypes.bool,
+  openPortal: PropTypes.func,
+  styles: PropTypes.object
+};
+
+export default portal({closeAfter: 100})(withStyles(styleThunk)(EditorHelpModal));

--- a/src/universal/components/ProjectColumns/ProjectColumns.js
+++ b/src/universal/components/ProjectColumns/ProjectColumns.js
@@ -5,6 +5,7 @@ import {css} from 'aphrodite-local-styles/no-important';
 import ui from 'universal/styles/ui';
 import {columnArray, meetingColumnArray, MEETING} from 'universal/utils/constants';
 import ProjectColumn from 'universal/modules/teamDashboard/components/ProjectColumn/ProjectColumn';
+import EditorHelpModalContainer from 'universal/containers/EditorHelpModalContainer/EditorHelpModalContainer';
 
 const ProjectColumns = (props) => {
   // myTeamMemberId is undefined if this is coming from USER_DASH
@@ -39,6 +40,7 @@ const ProjectColumns = (props) => {
           />)
         )}
       </div>
+      <EditorHelpModalContainer />
     </div>
   );
 };

--- a/src/universal/containers/EditorHelpModalContainer/EditorHelpModalContainer.js
+++ b/src/universal/containers/EditorHelpModalContainer/EditorHelpModalContainer.js
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import withHotkey from 'react-hotkey-hoc';
+import EditorHelpModal from 'universal/components/EditorHelpModal/EditorHelpModal';
+
+@withHotkey
+class EditorHelpModalContainer extends Component {
+  static propTypes = {
+    bindHotkey: PropTypes.func
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false
+    };
+  }
+
+  componentWillMount() {
+    const {bindHotkey} = this.props;
+    bindHotkey('?', this.toggleModal);
+    bindHotkey('escape', this.closeModal);
+  }
+
+  toggleModal = () => {
+    this.setState({isOpen: !this.state.isOpen});
+  }
+
+  closeModal = () => {
+    this.setState({isOpen: false});
+  }
+
+  render() {
+    return (
+      <EditorHelpModal
+        handleCloseModal={this.closeModal}
+        isOpen={this.state.isOpen}
+      />
+    );
+  }
+}
+
+export default EditorHelpModalContainer;

--- a/src/universal/modules/meeting/components/MeetingAgendaItems/MeetingAgendaItems.js
+++ b/src/universal/modules/meeting/components/MeetingAgendaItems/MeetingAgendaItems.js
@@ -13,6 +13,7 @@ import LoadingView from 'universal/components/LoadingView/LoadingView';
 import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
 import {AGENDA_ITEM_LABEL} from 'universal/utils/constants';
 import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
+import EditorHelpModalContainer from 'universal/containers/EditorHelpModalContainer/EditorHelpModalContainer';
 
 const MeetingAgendaItems = (props) => {
   const {
@@ -68,6 +69,7 @@ const MeetingAgendaItems = (props) => {
               agendaId={agendaItem.id}
               myTeamMemberId={self.id}
             />
+            <EditorHelpModalContainer />
           </div>
         </MeetingSection>
         {/* */}

--- a/src/universal/modules/userDashboard/components/UserDashMain/UserDashMain.js
+++ b/src/universal/modules/userDashboard/components/UserDashMain/UserDashMain.js
@@ -39,7 +39,6 @@ const UserDashMain = (props) => {
         </div>
       </DashContent>
     </DashMain>
-
   );
 };
 


### PR DESCRIPTION
This is a first pass at a help modal for the editor. See: #1343 

**Note**: Based off of `epic7` for latest…but this doesn’t have to ship with Epic 7.

## Test Plan
**Behaviors**:

- [ ] User can press `?` to open the modal.
- [ ] User can press `?` to close the modal.
- [ ] User can tap the backdrop to close the modal.
- [ ] User can tap the close button to close the modal.

**Contexts (wherever there are editable cards)**:

- [ ] The modal can be seen in the User Dashboard.
- [ ] The modal can be seen in the Team Dashboard.
- [ ] The modal can be seen during the Meeting Updates.
- [ ] The modal can be seen during the Agenda processing.