### PR TITLE
add projects during updates phase

### DIFF
--- a/src/universal/components/ProjectColumns/ProjectColumns.js
+++ b/src/universal/components/ProjectColumns/ProjectColumns.js
@@ -12,6 +12,7 @@ const ProjectColumns = (props) => {
   const {
     alignColumns,
     area,
+    isMyMeetingSection,
     myTeamMemberId,
     projects,
     queryKey,
@@ -28,6 +29,7 @@ const ProjectColumns = (props) => {
           (<ProjectColumn
             key={`projectCol${status}`}
             area={area}
+            isMyMeetingSection={isMyMeetingSection}
             firstColumn={idx === 0}
             lastColumn={idx === (lanes.length - 1)}
             myTeamMemberId={myTeamMemberId}
@@ -50,6 +52,7 @@ ProjectColumns.propTypes = {
     'right'
   ]),
   area: PropTypes.string,
+  isMyMeetingSection: PropTypes.bool,
   myTeamMemberId: PropTypes.string,
   projects: PropTypes.object.isRequired,
   queryKey: PropTypes.string,

--- a/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
+++ b/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
@@ -1,15 +1,15 @@
+import {css} from 'aphrodite-local-styles/no-important';
 import PropTypes from 'prop-types';
 import React from 'react';
-import withStyles from 'universal/styles/withStyles';
-import {css} from 'aphrodite-local-styles/no-important';
 import Button from 'universal/components/Button/Button';
+import ProjectColumns from 'universal/components/ProjectColumns/ProjectColumns';
+import MeetingFacilitationHint from 'universal/modules/meeting/components/MeetingFacilitationHint/MeetingFacilitationHint';
 import MeetingMain from 'universal/modules/meeting/components/MeetingMain/MeetingMain';
 import MeetingSection from 'universal/modules/meeting/components/MeetingSection/MeetingSection';
-import MeetingFacilitationHint from 'universal/modules/meeting/components/MeetingFacilitationHint/MeetingFacilitationHint';
-import {MEETING} from 'universal/utils/constants';
-import ProjectColumns from 'universal/components/ProjectColumns/ProjectColumns';
-import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
 import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
+import getFacilitatorName from 'universal/modules/meeting/helpers/getFacilitatorName';
+import withStyles from 'universal/styles/withStyles';
+import {MEETING} from 'universal/utils/constants';
 
 const MeetingUpdates = (props) => {
   const {
@@ -23,9 +23,12 @@ const MeetingUpdates = (props) => {
     team
   } = props;
   const self = members.find((m) => m.isSelf);
-  const currentTeamMember = members[localPhaseItem - 1];
+  const currentTeamMember = members[localPhaseItem - 1] || {};
   const isLastMember = localPhaseItem === members.length;
   const nextPhaseName = actionMeeting.agendaitems.name;
+  const myTeamMemberId = self && self.id;
+  const isMyMeetingSection = myTeamMemberId === currentTeamMember.id;
+
   return (
     <MeetingMain>
       <MeetingSection flexToFill>
@@ -50,7 +53,14 @@ const MeetingUpdates = (props) => {
           }
         </div>
         <div className={css(styles.body)}>
-          <ProjectColumns alignColumns="center" myTeamMemberId={self && self.id} projects={projects} queryKey={queryKey} area={MEETING} />
+          <ProjectColumns
+            alignColumns="center"
+            isMyMeetingSection={isMyMeetingSection}
+            myTeamMemberId={myTeamMemberId}
+            projects={projects}
+            queryKey={queryKey}
+            area={MEETING}
+          />
         </div>
       </MeetingSection>
     </MeetingMain>

--- a/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumn.js
+++ b/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumn.js
@@ -65,6 +65,7 @@ class ProjectColumn extends Component {
       atmosphere,
       dispatch,
       history,
+      isMyMeetingSection,
       status,
       projects,
       myTeamMemberId,
@@ -74,7 +75,7 @@ class ProjectColumn extends Component {
     } = this.props;
     const label = themeLabels.projectStatus[status].slug;
     const sortOrder = getNextSortOrder(projects, dndNoise());
-    if (area === TEAM_DASH) {
+    if (area === TEAM_DASH || isMyMeetingSection) {
       const teamMemberId = queryKey.indexOf('::') === -1 ? myTeamMemberId : queryKey;
       const handleAddProject = handleAddProjectFactory(atmosphere, dispatch, history, status, teamMemberId, sortOrder);
       return <AddProjectButton onClick={handleAddProject} label={label} />;
@@ -202,6 +203,7 @@ ProjectColumn.propTypes = {
   dragState: PropTypes.object,
   firstColumn: PropTypes.bool,
   history: PropTypes.object.isRequired,
+  isMyMeetingSection: PropTypes.bool,
   lastColumn: PropTypes.bool,
   myTeamMemberId: PropTypes.string,
   projects: PropTypes.array.isRequired,


### PR DESCRIPTION
fixes #1418
it
- [ ] shows a + sign in each project column to let you add cards during your update phase
- [ ] does not let you update cards in a team member's update phase (although you could reassign cards during your own update phase...)
 