### PR TITLE
Epic8.5 1504

### DIFF
--- a/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
@@ -117,7 +117,7 @@ class OutcomeCardFooter extends Component {
       <div className={css(styles.footerAndMessage)}>
         <div className={css(styles.footer)}>
           <div className={css(styles.avatarBlock)}>
-            {service || showTeam ?
+            {service || showTeam || isArchived ?
               ownerAvatarOrTeamName :
               <AsyncMenuContainer
                 fetchMenu={fetchAssignMenu}

--- a/src/universal/utils/__tests__/parseEmailAddressList.test.js
+++ b/src/universal/utils/__tests__/parseEmailAddressList.test.js
@@ -1,0 +1,31 @@
+import parseEmailAddressList from 'universal/utils/parseEmailAddressList';
+
+const getAddressStr = (res) => res && res.map((val) => val.address).join(', ');
+
+describe('parseEmailAddressList', () => {
+  it('validates a simple single email', () => {
+    const str = 'a@a.co';
+    const res = parseEmailAddressList(str);
+    expect(getAddressStr(res)).toEqual(str);
+  });
+  it('validates a trailing comma and trailing space', () => {
+    const str = 'a@a.co, ';
+    const res = parseEmailAddressList(str);
+    expect(getAddressStr(res)).toEqual('a@a.co');
+  });
+  it('validates 2 emails separated by a newline and comma', () => {
+    const str = 'a@a.co,\nb@b.co';
+    const res = parseEmailAddressList(str);
+    expect(getAddressStr(res)).toEqual('a@a.co, b@b.co');
+  });
+  it('validates 2 emails separated by a newline', () => {
+    const str = 'a@a.co\nb@b.co';
+    const res = parseEmailAddressList(str);
+    expect(getAddressStr(res)).toEqual('a@a.co, b@b.co');
+  });
+  it('validates 2 emails separated by a newline and semicolon', () => {
+    const str = 'a@a.co;\nb@b.co';
+    const res = parseEmailAddressList(str);
+    expect(getAddressStr(res)).toEqual('a@a.co, b@b.co');
+  });
+});

--- a/src/universal/utils/parseEmailAddressList.js
+++ b/src/universal/utils/parseEmailAddressList.js
@@ -2,7 +2,16 @@ import emailAddresses from 'email-addresses';
 
 const parseEmailAddressList = (rawStr = '') => {
   // this breaks RFC5322 standards, but people are not standard :-(
-  const commaDelimStr = rawStr.replace(';', ',');
+  window.raw = rawStr;
+  const commaDelimStr = rawStr
+    // replace line breaks & semi colons with commas
+    .replace(/(?:\r\n|\r|\n|;)/g, ',')
+    // if the above created 2 commas (like a , + linebreak), remove dupes
+    .replace(/,+/g, ',')
+    // remove leading/trailing whitespace
+    .trim()
+    // remove trailing commas
+    .replace(/,$/g, '');
   return emailAddresses.parseAddressList(commaDelimStr);
 };
 


### PR DESCRIPTION
2 small ones:

TEST
- [ ] on NewTeamForm, you can break up emails with a linebreak & still be OK (fix #1443)
- [ ] in the team archive, when you click the face to reassign the task, nothing happens (fix #1504)