### PR TITLE
fix drags without cache

### DIFF
--- a/src/universal/containers/ProjectCard/DraggableProject.js
+++ b/src/universal/containers/ProjectCard/DraggableProject.js
@@ -73,7 +73,7 @@ DraggableProject.propTypes = {
   connectDragSource: PropTypes.func,
   connectDragPreview: PropTypes.func,
   connectDropTarget: PropTypes.func.isRequired,
-  insert: PropTypes.func.isRequired,
+  insertProject: PropTypes.func.isRequired,
   isDragging: PropTypes.bool,
   isPreview: PropTypes.bool,
   myUserId: PropTypes.string,
@@ -100,11 +100,8 @@ const projectDragCollect = (connectSource, monitor) => ({
   isDragging: monitor.isDragging()
 });
 
-let lastDraggedProjectId;
-let lastDropTargetProjectId;
-let lastBefore;
 const handleProjectHover = (props, monitor, component) => {
-  const {insert, project} = props;
+  const {insertProject, project} = props;
   const dropTargetProjectId = project.id;
   const draggedProject = monitor.getItem();
   const draggedProjectId = draggedProject.id;
@@ -123,28 +120,7 @@ const handleProjectHover = (props, monitor, component) => {
   const dropTargetMidpoint = dropTargetTop + (dropTargetHeight / 2);
   const before = mouseY < dropTargetMidpoint;
 
-  // We're sort of memoizing here, since this hover function gets called
-  // constantly during a drag operation; if the last dragged project and drop
-  // target projects are the same with the same before/after relationship, then
-  // we don't need to re-insert them.
-  if (!monitor.isOver({shallow: true})) {
-    lastDraggedProjectId = null;
-    lastDropTargetProjectId = null;
-    lastBefore = null;
-    return;
-  }
-  if (
-    lastDraggedProjectId === draggedProjectId &&
-    dropTargetProjectId === lastDropTargetProjectId &&
-    before === lastBefore
-  ) {
-    return;
-  }
-  lastDraggedProjectId = draggedProjectId;
-  lastDropTargetProjectId = dropTargetProjectId;
-  lastBefore = before;
-
-  insert(draggedProjectId, before);
+  insertProject(draggedProjectId, dropTargetProjectId, before);
 };
 
 const projectDropCollect = (connect) => ({

--- a/src/universal/containers/ProjectCard/DraggableProject.js
+++ b/src/universal/containers/ProjectCard/DraggableProject.js
@@ -144,7 +144,7 @@ const handleProjectHover = (props, monitor, component) => {
   lastDropTargetProjectId = dropTargetProjectId;
   lastBefore = before;
 
-  insert(draggedProject, before);
+  insert(draggedProjectId, before);
 };
 
 const projectDropCollect = (connect) => ({

--- a/src/universal/dnd/sortOrderBetween.js
+++ b/src/universal/dnd/sortOrderBetween.js
@@ -1,34 +1,30 @@
 // @flow
 
+import type {Project} from 'universal/types/project';
 import {SORT_STEP} from 'universal/utils/constants';
 import dndNoise from 'universal/utils/dndNoise';
 
-type Sortable = {
-  id: string,
-  sortOrder: number
+type Options = {
+  isInsert: ?boolean,
+  boundedOffset: ?number
 };
 
 /**
- * Computes the sort order of a project to be sandwiched between
- * `target` and `boundng`.
+ * Computes the sort order of a dragged project
  */
-export default function sortOrderBetween(
-  target: ?Sortable,
-  boundng: ?Sortable,
-  dragged: Sortable,
-  before: boolean
-): number {
-  if (target == null && boundng == null) {
-    // if we have the chance to reset the decimals, do it!
-    return SORT_STEP;
-  } else if (target == null) {
-    throw new Error('`target` cannot be null if `boundng` is not null');
+export default function sortOrderBetween(projects: Array<Project>, desiredIdx: number, options: Options = {}): number {
+  if (projects.length === 0) {
+    return SORT_STEP + dndNoise();
   }
-  if (boundng == null) {
-    return target.sortOrder + ((SORT_STEP + dndNoise()) * (before ? 1 : -1));
+  if (desiredIdx === 0) {
+    return projects[0].sortOrder + SORT_STEP + dndNoise();
   }
-  // dragged is undefined if it has moved columns mid-drag
-  return boundng.id === (dragged && dragged.id)
-    ? boundng.sortOrder
-    : (boundng.sortOrder + target.sortOrder) / 2 + dndNoise();
+
+  const {isInsert} = options;
+  const boundedOffset = isInsert ? -1 : options.boundedOffset;
+  const maxLen = projects.length + (isInsert ? 0 : -1);
+  if (desiredIdx === maxLen) {
+    return projects[projects.length - 1].sortOrder - SORT_STEP + dndNoise();
+  }
+  return (projects[desiredIdx].sortOrder + projects[desiredIdx + boundedOffset].sortOrder) / 2 + dndNoise();
 }

--- a/src/universal/dnd/sortOrderBetween.js
+++ b/src/universal/dnd/sortOrderBetween.js
@@ -19,14 +19,16 @@ export default function sortOrderBetween(
   before: boolean
 ): number {
   if (target == null && boundng == null) {
-    return dragged.sortOrder;
+    // if we have the chance to reset the decimals, do it!
+    return SORT_STEP;
   } else if (target == null) {
     throw new Error('`target` cannot be null if `boundng` is not null');
   }
   if (boundng == null) {
     return target.sortOrder + ((SORT_STEP + dndNoise()) * (before ? 1 : -1));
   }
-  return boundng.id === dragged.id
+  // dragged is undefined if it has moved columns mid-drag
+  return boundng.id === (dragged && dragged.id)
     ? boundng.sortOrder
     : (boundng.sortOrder + target.sortOrder) / 2 + dndNoise();
 }

--- a/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumn.js
+++ b/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumn.js
@@ -132,19 +132,20 @@ class ProjectColumn extends Component {
    * `before` - whether the dragged project is being inserted before (true) or
    * after (false) the target project.
    */
-  insertProject = (draggedProject, targetProject, before) => {
+  insertProject = (draggedProjectId, targetProject, before) => {
     const {area, atmosphere, projects, status} = this.props;
     const targetIndex = projects.findIndex((p) => p.id === targetProject.id);
     // `boundingProject` is the project which sandwiches the dragged project on
     // the opposite side of the target project.  When the target project is in
     // the front or back of the list, this will be `undefined`.
     const boundingProject = projects[targetIndex + (before ? -1 : 1)];
+    const draggedProject = projects.find((p) => p.id === draggedProjectId);
     const sortOrder = sortOrderBetween(targetProject, boundingProject, draggedProject, before);
-    const noActionNeeded = sortOrder === draggedProject.sortOrder && draggedProject.status === status;
+    const noActionNeeded = draggedProject && sortOrder === draggedProject.sortOrder && draggedProject.status === status;
     if (noActionNeeded) {
       return;
     }
-    const updatedProject = {id: draggedProject.id, sortOrder, status};
+    const updatedProject = {id: draggedProjectId, sortOrder, status};
     UpdateProjectMutation(atmosphere, updatedProject, area);
   };
 
@@ -210,12 +211,12 @@ class ProjectColumn extends Component {
                 area={area}
                 project={project}
                 myUserId={atmosphere.userId}
-                insert={(draggedProject, before) => this.insertProject(draggedProject, project, before)}
+                insert={(draggedProjectId, before) => this.insertProject(draggedProjectId, project, before)}
               />
             ))}
             <ProjectColumnTrailingSpace
               area={area}
-              lastProject={projects[projects.length - 1]}
+              projects={projects}
               status={status}
             />
           </ScrollZone>

--- a/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumnTrailingSpace.js
+++ b/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumnTrailingSpace.js
@@ -1,58 +1,22 @@
 // @flow
 import type {Node} from 'react';
-import type {Project} from 'universal/types/project';
-
 import React from 'react';
 import {DropTarget} from 'react-dnd';
-
-import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
-import sortOrderBetween from 'universal/dnd/sortOrderBetween';
-import UpdateProjectMutation from 'universal/mutations/UpdateProjectMutation';
 import {PROJECT} from 'universal/utils/constants';
 
 type Props = {
   connectDropTarget: (node: Node) => Node,
   area: string,
   atmosphere: Object, // TODO: atmosphere needs a type definition
-  projects: Array<Project>,
+  insert: Function,
   status: string
 };
 
-let previousLastProjectId = null;
-let previousDraggedProjectId = null;
 const spec = {
   hover: (props: Props, monitor) => {
-    const {area, atmosphere, projects, status} = props;
-    const lastProject = projects[projects.length - 1];
+    const {insertProject} = props;
     const draggedProject = monitor.getItem();
-
-    if (!monitor.isOver({shallow: true})) {
-      previousLastProjectId = null;
-      previousDraggedProjectId = null;
-      return;
-    }
-    if (
-      draggedProject.id === previousDraggedProjectId &&
-      (lastProject && lastProject.id) === previousLastProjectId
-    ) {
-      return;
-    }
-    previousDraggedProjectId = draggedProject.id;
-    previousLastProjectId = lastProject && lastProject.id;
-
-    const sortOrder = sortOrderBetween(lastProject, null, draggedProject, false);
-    const isDraggedInColumn = Boolean(projects.find((p) => p.id === draggedProject.id));
-    const noActionNeeded = isDraggedInColumn && sortOrder === draggedProject.sortOrder && draggedProject.status === status;
-    if (noActionNeeded) {
-      return;
-    }
-
-    const updatedProject = {
-      id: draggedProject.id,
-      status,
-      sortOrder
-    };
-    UpdateProjectMutation(atmosphere, updatedProject, area);
+    insertProject(draggedProject.id);
   }
 };
 
@@ -64,8 +28,6 @@ const ProjectColumnTrailingSpace = ({connectDropTarget}: Props) => (
   connectDropTarget(<div style={{height: '100%'}} />)
 );
 
-export default withAtmosphere(
-  DropTarget(PROJECT, spec, collect)(
-    ProjectColumnTrailingSpace
-  )
+export default DropTarget(PROJECT, spec, collect)(
+  ProjectColumnTrailingSpace
 );

--- a/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumnTrailingSpace.js
+++ b/src/universal/modules/teamDashboard/components/ProjectColumn/ProjectColumnTrailingSpace.js
@@ -14,7 +14,7 @@ type Props = {
   connectDropTarget: (node: Node) => Node,
   area: string,
   atmosphere: Object, // TODO: atmosphere needs a type definition
-  lastProject: Project,
+  projects: Array<Project>,
   status: string
 };
 
@@ -22,7 +22,8 @@ let previousLastProjectId = null;
 let previousDraggedProjectId = null;
 const spec = {
   hover: (props: Props, monitor) => {
-    const {area, atmosphere, lastProject, status} = props;
+    const {area, atmosphere, projects, status} = props;
+    const lastProject = projects[projects.length - 1];
     const draggedProject = monitor.getItem();
 
     if (!monitor.isOver({shallow: true})) {
@@ -40,8 +41,8 @@ const spec = {
     previousLastProjectId = lastProject && lastProject.id;
 
     const sortOrder = sortOrderBetween(lastProject, null, draggedProject, false);
-
-    const noActionNeeded = sortOrder === draggedProject.sortOrder && draggedProject.status === status;
+    const isDraggedInColumn = Boolean(projects.find((p) => p.id === draggedProject.id));
+    const noActionNeeded = isDraggedInColumn && sortOrder === draggedProject.sortOrder && draggedProject.status === status;
     if (noActionNeeded) {
       return;
     }


### PR DESCRIPTION
@dan-f I think this does what you want without mucking up your beautiful code with a cache!
Here's how it works:
- When you call `UpdateProjectMutation`, Relay already optimistically updates the sortOrder & status. That update gets passed to the component, but `react-dnd`'s `monitor.getItem()` is still pointing to the old object.
- By grabbing the project ourselves from the column projects, instead of relying on `monitor.getItem()`, we can get the updated `sortOrder` _if it is an intra-column drag_
- if it is an inter-column drag, the drag item won't be found because it doesn't exist in the column-specific projects array. That's OK because it's not like it's old `sortOrder` gives us any useful info, we just need to handle the case where it might be undefined (see `sortOrderBetween`)
