### PR TITLE
add tier labels to orgs in new team form

### DIFF
--- a/src/universal/modules/dropdown/components/DropdownInput/DropdownInput.js
+++ b/src/universal/modules/dropdown/components/DropdownInput/DropdownInput.js
@@ -1,13 +1,16 @@
+import {css} from 'aphrodite-local-styles/no-important';
 import PropTypes from 'prop-types';
 import React from 'react';
-import withStyles from 'universal/styles/withStyles';
-import {css} from 'aphrodite-local-styles/no-important';
 import FontAwesome from 'react-fontawesome';
 import FieldBlock from 'universal/components/FieldBlock/FieldBlock';
 import FieldLabel from 'universal/components/FieldLabel/FieldLabel';
-import ui from 'universal/styles/ui';
-import makeFieldColorPalette from 'universal/styles/helpers/makeFieldColorPalette';
+import TagPro from 'universal/components/Tag/TagPro';
 import {Menu, MenuItem} from 'universal/modules/menu';
+import {textOverflow} from 'universal/styles/helpers';
+import makeFieldColorPalette from 'universal/styles/helpers/makeFieldColorPalette';
+import ui from 'universal/styles/ui';
+import withStyles from 'universal/styles/withStyles';
+import {PRO} from 'universal/utils/constants';
 
 const originAnchor = {
   vertical: 'bottom',
@@ -47,7 +50,12 @@ const DropdownInput = (props) => {
         <MenuItem
           isActive={value === anOrg.id}
           key={`orgDropdownMenuItem${anOrg.id}`}
-          label={anOrg.name}
+          label={
+            <span className={css(styles.orgNameMenuItem)}>
+              <span>{anOrg.name}</span>
+              {anOrg.tier === PRO && <TagPro />}
+            </span>
+          }
           onClick={() => {
             onChange(anOrg.id);
           }}
@@ -125,6 +133,13 @@ const styleThunk = (theme, {fieldSize}) => {
       borderTop: `.0625rem solid ${ui.menuBorderColor}`,
       padding: '.5rem .5rem 0',
       width: '100%'
+    },
+
+    orgNameMenuItem: {
+      ...textOverflow,
+      fontSize: ui.menuItemFontSize,
+      lineHeight: ui.menuItemHeight,
+      padding: `0 ${ui.menuGutterHorizontal}`
     }
   });
 };

--- a/src/universal/modules/dropdown/components/DropdownInput/DropdownInput.js
+++ b/src/universal/modules/dropdown/components/DropdownInput/DropdownInput.js
@@ -72,6 +72,7 @@ const DropdownInput = (props) => {
       {label && <FieldLabel fieldSize={fieldSize} label={label} htmlFor={name} indent />}
       <div className={fieldInputStyles} tabIndex="1">
         <span>{orgName}</span>
+        {org.tier === PRO && <TagPro />}
         {!disabled &&
           <Menu
             originAnchor={originAnchor}

--- a/src/universal/modules/newTeam/NewTeam.js
+++ b/src/universal/modules/newTeam/NewTeam.js
@@ -104,6 +104,7 @@ export default createFragmentContainer(
       organizations {
         id
         name
+        tier
       }
     }
   `


### PR DESCRIPTION
TEST
- [ ] create an org. go to /newteam. see it does not have a PRO badge next to the org name (or in the dropdown)
- [ ] upgrade to pro with a valid fake CC. go to /newteam to make a new team. see the PRO badge next to the PRO org.

fixes #1427