### PR TITLE
Solo Updates prompt conditions

### DIFF
--- a/src/universal/modules/meeting/components/HelpTextMyRound.js
+++ b/src/universal/modules/meeting/components/HelpTextMyRound.js
@@ -4,14 +4,16 @@ import React from 'react';
 import withStyles from 'universal/styles/withStyles';
 
 const HelpTextMyRound = (props) => {
-  const {styles} = props;
+  const {styles, updateUserHasProjects} = props;
+  const helpText = updateUserHasProjects ? 'Quick updates only, please.' : 'Add cards to track your current work.';
   return (
-    <span className={css(styles.helpText)}>{'(Your turn to share. Add cards to track your current work.)'}</span>
+    <span className={css(styles.helpText)}>{`(Your turn to share. ${helpText})`}</span>
   );
 };
 
 HelpTextMyRound.propTypes = {
-  styles: PropTypes.object
+  styles: PropTypes.object,
+  updateUserHasProjects: PropTypes.bool
 };
 
 const styleThunk = () => ({

--- a/src/universal/modules/meeting/components/MeetingUpdatesPrompt/MeetingUpdatesPrompt.js
+++ b/src/universal/modules/meeting/components/MeetingUpdatesPrompt/MeetingUpdatesPrompt.js
@@ -14,8 +14,8 @@ const MeetingUpdatesPrompt = (props) => {
   } = props;
   const {teamMembers} = team;
   const currentTeamMember = teamMembers[localPhaseItem - 1];
-  const {isSelf: isMyMeetingSection, isCheckedIn} = currentTeamMember;
-  const isCheckedInFalse = Boolean(isCheckedIn === false);
+  const {isSelf: isMyMeetingSection} = currentTeamMember;
+  const isCheckedInFalse = currentTeamMember.isCheckedIn === false;
   const question = updateUserHasProjects ? 'what’s changed with your tasks' : 'what are you working on';
   const headingHere = <span>{currentTeamMember.preferredName}, <i>{question}</i>{'?'}</span>;
   const questionNotHere = updateUserHasProjects
@@ -29,7 +29,9 @@ const MeetingUpdatesPrompt = (props) => {
       avatar={currentTeamMember.picture}
       heading={heading}
       helpText={isMyMeetingSection ?
-        <HelpTextMyRound /> :
+        <HelpTextMyRound
+          updateUserHasProjects={updateUserHasProjects}
+        /> :
         <HelpTextForTeam
           agendaInputRef={agendaInputRef}
           currentTeamMember={currentTeamMember}


### PR DESCRIPTION
Fixes #1595 for the following:

- [x] Only prompt users to “add cards for current work” during their Updates round when they do not have cards.
- [ ] Make the copy (based on having or not having cards) sticky once the facilitator makes it to a user’s round.