### PR TITLE
Move between completed agenda items without bouncing back

### DIFF
--- a/src/server/graphql/mutations/moveMeeting.js
+++ b/src/server/graphql/mutations/moveMeeting.js
@@ -124,7 +124,10 @@ export default {
         .update({isComplete: true}, {returnChanges: true})('changes')(0)('new_val').default(null)
     });
 
-    const data = {teamId, agendaItemId: completedAgendaItem.id};
+    const data = {
+      teamId,
+      agendaItemId: completedAgendaItem && completedAgendaItem.id
+    };
     publish(AGENDA_ITEM, teamId, MoveMeetingPayload, data, subOptions);
     publish(TEAM, teamId, MoveMeetingPayload, data, subOptions);
     return data;

--- a/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
@@ -247,29 +247,7 @@ class MeetingContainer extends Component {
   };
 
   gotoAgendaItem = (idx) => async () => {
-    const {atmosphere, viewer: {team: {activeFacilitator, agendaItems, facilitatorPhase}}, myTeamMemberId} = this.props;
-    const isFacilitating = activeFacilitator === myTeamMemberId;
-    const facilitatorPhaseInfo = actionMeeting[facilitatorPhase];
-    const agendaPhaseInfo = actionMeeting[AGENDA_ITEMS];
-    const firstIncompleteIdx = agendaItems.findIndex((a) => a.isComplete === false);
-    const nextItemIdx = firstIncompleteIdx + (facilitatorPhase === AGENDA_ITEMS ? 1 : 0);
-    const shouldResort = facilitatorPhaseInfo.index >= agendaPhaseInfo.index && idx > nextItemIdx && firstIncompleteIdx > -1;
-    if (isFacilitating && shouldResort) {
-      // resort
-      const desiredItem = agendaItems[idx];
-      const nextItem = agendaItems[nextItemIdx];
-      const prevItem = agendaItems[nextItemIdx - 1];
-      const updatedAgendaItem = {
-        id: desiredItem.id,
-        sortOrder: prevItem ? (prevItem.sortOrder + nextItem.sortOrder) / 2 : nextItem.sortOrder - SORT_STEP
-      };
-      const onCompleted = () => {
-        this.gotoItem(nextItemIdx + 1, AGENDA_ITEMS);
-      };
-      UpdateAgendaItemMutation(atmosphere, updatedAgendaItem, undefined, onCompleted);
-    } else {
-      this.gotoItem(idx + 1, AGENDA_ITEMS);
-    }
+    this.gotoItem(idx + 1, AGENDA_ITEMS);
   };
 
   rejoinFacilitator = () => {

--- a/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
+++ b/src/universal/modules/meeting/containers/MeetingContainer/MeetingContainer.js
@@ -32,10 +32,8 @@ import EndMeetingMutation from 'universal/mutations/EndMeetingMutation';
 import KillMeetingMutation from 'universal/mutations/KillMeetingMutation';
 import MoveMeetingMutation from 'universal/mutations/MoveMeetingMutation';
 import PromoteFacilitatorMutation from 'universal/mutations/PromoteFacilitatorMutation';
-import UpdateAgendaItemMutation from 'universal/mutations/UpdateAgendaItemMutation';
 import {
-  AGENDA_ITEMS, CHECKIN, FIRST_CALL, LAST_CALL, LOBBY, phaseArray, SORT_STEP,
-  UPDATES
+  AGENDA_ITEMS, CHECKIN, FIRST_CALL, LAST_CALL, LOBBY, phaseArray, UPDATES
 } from 'universal/utils/constants';
 import withMutationProps from 'universal/utils/relay/withMutationProps';
 

--- a/src/universal/mutations/EndMeetingMutation.js
+++ b/src/universal/mutations/EndMeetingMutation.js
@@ -40,7 +40,10 @@ const mutation = graphql`
   }
 `;
 
+const clearAgendaItems = (team) => team.setLinkedRecords([], 'agendaItems');
+
 export const endMeetingTeamUpdater = (payload, {history}) => {
+  clearAgendaItems(payload.getLinkedRecord('team'));
   const meetingId = getInProxy(payload, 'meeting', 'id');
   history.push(`/summary/${meetingId}`);
 };


### PR DESCRIPTION
Fixes #1660 and #1651 

To verify:

On `master` (failing) and `fix-agenda-nav-bounce` (passing) attempt the following:

- Run a meeting
- Move to the agenda
- Add several agenda items
- Navigate through all the items out-of-order that they're marked as completed
- Navigate back through the completed items
- Complete the meeting
- On `master`, expect to experience the bouncing. Also expect that once you complete the meeting, you see all the completed agenda items still on the team dashboard.
- On `fix-agenda-nav-bounce`, expect not to experience the bouncing; expect the intuitive behavior. Also expect that once you complete the meeting, the completed agenda items are gone from the team dashboard.