### PR TITLE
Scroll to active agenda item

### DIFF
--- a/src/universal/components/Dashboard/DashLayout.js
+++ b/src/universal/components/Dashboard/DashLayout.js
@@ -35,14 +35,15 @@ const styleThunk = () => ({
     backgroundColor: '#fff',
     display: 'flex !important',
     flexDirection: 'column',
-    minHeight: '100vh',
+    height: '100vh',
     minWidth: ui.dashMinWidth
   },
 
   main: {
     display: 'flex !important',
     flex: 1,
-    position: 'relative'
+    position: 'relative',
+    height: '100%'
   }
 });
 

--- a/src/universal/modules/meeting/components/MeetingLayout/MeetingLayout.js
+++ b/src/universal/modules/meeting/components/MeetingLayout/MeetingLayout.js
@@ -24,7 +24,7 @@ const styleThunk = () => ({
   root: {
     backgroundColor: '#fff',
     display: 'flex !important',
-    minHeight: '100vh'
+    height: '100vh'
   }
 });
 

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import withStyles from 'universal/styles/withStyles';
+import ui from 'universal/styles/ui';
 import {css} from 'aphrodite-local-styles/no-important';
 import {reduxForm, Field} from 'redux-form';
 import AgendaInputField from './AgendaInputField';

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
@@ -7,7 +7,7 @@ import {reduxForm, Field} from 'redux-form';
 import AgendaInputField from './AgendaInputField';
 
 const AgendaInput = (props) => {
-  const {agenda, disabled, handleSubmit, setAgendaInputRef, team, styles} = props;
+  const {afterSubmitAgendaItem, agenda, disabled, handleSubmit, setAgendaInputRef, team, styles} = props;
   return (
     <div className={css(styles.agendaInputBlock)}>
       <Field
@@ -16,6 +16,7 @@ const AgendaInput = (props) => {
         component={AgendaInputField}
         disabled={disabled}
         handleSubmit={handleSubmit}
+        afterSubmitAgendaItem={afterSubmitAgendaItem}
         setAgendaInputRef={setAgendaInputRef}
         team={team}
       />
@@ -27,6 +28,7 @@ AgendaInput.propTypes = {
   agenda: PropTypes.array,
   disabled: PropTypes.bool,
   handleSubmit: PropTypes.func,
+  afterSubmitAgendaItem: PropTypes.func.isRequired,
   setAgendaInputRef: PropTypes.func,
   styles: PropTypes.object,
   team: PropTypes.object.isRequired

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
@@ -34,7 +34,7 @@ AgendaInput.propTypes = {
 
 const styleThunk = () => ({
   agendaInputBlock: {
-    paddingBottom: ui.meetingSidebarGutter,
+    paddingTop: ui.meetingSidebarGutter,
     position: 'relative'
   }
 });

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
@@ -33,8 +33,7 @@ AgendaInput.propTypes = {
 
 const styleThunk = () => ({
   agendaInputBlock: {
-    paddingTop: '.25rem',
-    paddingBottom: '.25rem',
+    padding: `${ui.meetingSidebarGutter} 0`,
     position: 'relative'
   }
 });

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInput.js
@@ -4,7 +4,6 @@ import withStyles from 'universal/styles/withStyles';
 import {css} from 'aphrodite-local-styles/no-important';
 import {reduxForm, Field} from 'redux-form';
 import AgendaInputField from './AgendaInputField';
-import ui from 'universal/styles/ui';
 
 const AgendaInput = (props) => {
   const {agenda, disabled, handleSubmit, setAgendaInputRef, team, styles} = props;
@@ -34,7 +33,8 @@ AgendaInput.propTypes = {
 
 const styleThunk = () => ({
   agendaInputBlock: {
-    paddingTop: ui.meetingSidebarGutter,
+    paddingTop: '.25rem',
+    paddingBottom: '.25rem',
     position: 'relative'
   }
 });

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
@@ -93,7 +93,7 @@ const AgendaInputField = (props) => {
         disabled={disabled}
         maxLength="63"
         onKeyDown={maybeBlur}
-        placeholder="Next Agenda Item…"
+        placeholder="Add Agenda Topic…"
         ref={setRef}
         type="text"
       />

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
@@ -1,6 +1,6 @@
 import {css} from 'aphrodite-local-styles/no-important';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {Component} from 'react';
 import FontAwesome from 'react-fontawesome';
 import withHotkey from 'react-hotkey-hoc';
 import {createFragmentContainer} from 'react-relay';
@@ -29,25 +29,59 @@ const iconStyle = {
   width: ui.iconSize2x,
   zIndex: 200
 };
-const AgendaInputField = (props) => {
-  const {
-    afterSubmitAgendaItem,
-    atmosphere,
-    bindHotkey,
-    disabled,
-    handleSubmit,
-    setAgendaInputRef,
-    styles,
-    team: {teamId, agendaItems}
-  } = props;
-  let inputRef;
-  const setRef = (c) => {
-    inputRef = c;
+
+const hasFocus = (element) => (
+  element && document.activeElement === element
+);
+
+class AgendaInputField extends Component {
+  static propTypes = {
+    atmosphere: PropTypes.object.isRequired,
+    bindHotkey: PropTypes.func,
+    disabled: PropTypes.bool,
+    handleSubmit: PropTypes.func,
+    input: PropTypes.object,
+    afterSubmitAgendaItem: PropTypes.func.isRequired,
+    setAgendaInputRef: PropTypes.func,
+    styles: PropTypes.object,
+    team: PropTypes.object.isRequired
+  };
+
+  componentDidMount() {
+    const {disabled, bindHotkey} = this.props;
+    if (!disabled) {
+      bindHotkey('+', this.focusOnInput);
+    }
+  }
+
+  componentWillUpdate() {
+    this.maybeSaveFocus();
+  }
+
+  componentDidUpdate() {
+    this.maybeRefocus();
+  }
+
+  setRef = (c) => {
+    const {setAgendaInputRef} = this.props;
+    this.inputRef = c;
     if (setAgendaInputRef) {
       setAgendaInputRef(c);
     }
   };
-  const handleAgendaItemSubmit = (submittedData) => {
+
+  inputRef = null;
+  refocusAfterUpdate = false;
+
+  focusOnInput = (e) => {
+    e.preventDefault();
+    if (this.inputRef) {
+      this.inputRef.focus();
+    }
+  };
+
+  handleAgendaItemSubmit = (submittedData) => {
+    const {afterSubmitAgendaItem, atmosphere, team: {agendaItems, teamId}} = this.props;
     const content = submittedData.agendaItem;
     if (!content) return;
     const newAgendaItem = {
@@ -57,83 +91,92 @@ const AgendaInputField = (props) => {
       teamMemberId: toTeamMemberId(teamId, atmosphere.userId)
     };
     AddAgendaItemMutation(atmosphere, newAgendaItem);
-    inputRef.focus();
     afterSubmitAgendaItem();
   };
 
-  const focusOnInput = (e) => {
-    e.preventDefault();
-    if (inputRef) {
-      inputRef.focus();
-    }
+  makeForm = () => {
+    const {disabled, handleSubmit, styles} = this.props;
+    const rootStyles = css(
+      styles.root,
+      disabled && styles.rootDisabled
+    );
+    const inputStyles = css(
+      styles.input,
+      !disabled && styles.inputNotDisabled
+    );
+    return (
+      <form className={rootStyles} onSubmit={handleSubmit(this.handleAgendaItemSubmit)}>
+        <input
+          {...this.props.input}
+          autoCapitalize="off"
+          autoComplete="off"
+          className={inputStyles}
+          disabled={disabled}
+          maxLength="63"
+          onKeyDown={this.maybeBlur}
+          placeholder="Add Agenda Topic…"
+          ref={this.setRef}
+          type="text"
+        />
+        <FontAwesome name="plus-square-o" style={iconStyle} />
+      </form>
+    );
   };
-  const maybeBlur = (e) => {
-    if (e.key === 'Escape') {
-      inputRef.blur();
-    }
-  };
-  const rootStyles = css(
-    styles.root,
-    disabled && styles.rootDisabled
-  );
-  const inputStyles = css(
-    styles.input,
-    !disabled && styles.inputNotDisabled
-  );
-  if (!disabled) {
-    bindHotkey('+', focusOnInput);
-  }
-  const tip = (
-    <div style={{textAlign: 'center'}}>{'Add meeting topics to discuss,'}<br />{'like “upcoming vacation”'}</div>);
-  const input = (
-    <form className={rootStyles} onSubmit={handleSubmit(handleAgendaItemSubmit)}>
-      <input
-        {...props.input}
-        autoCapitalize="off"
-        autoComplete="off"
-        className={inputStyles}
-        disabled={disabled}
-        maxLength="63"
-        onKeyDown={maybeBlur}
-        placeholder="Add Agenda Topic…"
-        ref={setRef}
-        type="text"
-      />
-      <FontAwesome name="plus-square-o" style={iconStyle} />
-    </form>
-  );
-  const showTooltip = Boolean(agendaItems.length > 0 && !disabled);
-  return (
-    <div>
-      {showTooltip ?
-        <Tooltip
-          delay={1000}
-          hideOnFocus
-          tip={tip}
-          maxHeight={52}
-          maxWidth={224}
-          originAnchor={{vertical: 'top', horizontal: 'center'}}
-          targetAnchor={{vertical: 'bottom', horizontal: 'center'}}
-        >
-          {input}
-        </Tooltip> :
-        input
-      }
+
+  makeTooltip = () => (
+    <div style={{textAlign: 'center'}}>
+      {'Add meeting topics to discuss,'}<br />{'like “upcoming vacation”'}
     </div>
   );
-};
 
-AgendaInputField.propTypes = {
-  atmosphere: PropTypes.object.isRequired,
-  bindHotkey: PropTypes.func,
-  disabled: PropTypes.bool,
-  handleSubmit: PropTypes.func,
-  input: PropTypes.object,
-  afterSubmitAgendaItem: PropTypes.func.isRequired,
-  setAgendaInputRef: PropTypes.func,
-  styles: PropTypes.object,
-  team: PropTypes.object.isRequired
-};
+  maybeBlur = (e) => {
+    if (e.key === 'Escape') {
+      this.inputRef.blur();
+    }
+  };
+
+  maybeRefocus = () => {
+    if (this.inputRef && this.refocusAfterUpdate) {
+      this.inputRef.focus();
+      this.refocusAfterUpdate = false;
+    }
+  };
+
+  maybeSaveFocus = () => {
+    if (hasFocus(this.inputRef)) {
+      this.refocusAfterUpdate = true;
+    }
+  };
+
+  render() {
+    const {
+      disabled,
+      team: {agendaItems}
+    } = this.props;
+
+    const form = this.makeForm();
+    const showTooltip = Boolean(agendaItems.length > 0 && !disabled);
+    return (
+      <div>
+        {showTooltip ? (
+          <Tooltip
+            delay={1000}
+            hideOnFocus
+            tip={this.makeTooltip()}
+            maxHeight={52}
+            maxWidth={224}
+            originAnchor={{vertical: 'top', horizontal: 'center'}}
+            targetAnchor={{vertical: 'bottom', horizontal: 'center'}}
+          >
+            {form}
+          </Tooltip>
+        ) : (
+          form
+        )}
+      </div>
+    );
+  }
+}
 
 const inputPlaceholderStyles = makePlaceholderStyles(appTheme.palette.mid60l);
 

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
@@ -90,8 +90,7 @@ class AgendaInputField extends Component {
       teamId,
       teamMemberId: toTeamMemberId(teamId, atmosphere.userId)
     };
-    AddAgendaItemMutation(atmosphere, newAgendaItem);
-    afterSubmitAgendaItem();
+    AddAgendaItemMutation(atmosphere, newAgendaItem, null, afterSubmitAgendaItem);
   };
 
   makeForm = () => {

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
@@ -56,7 +56,7 @@ const AgendaInputField = (props) => {
       teamMemberId: toTeamMemberId(teamId, atmosphere.userId)
     };
     AddAgendaItemMutation(atmosphere, newAgendaItem);
-    inputRef.blur();
+    inputRef.focus();
   };
 
   const focusOnInput = (e) => {

--- a/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
+++ b/src/universal/modules/teamDashboard/components/AgendaInput/AgendaInputField.js
@@ -31,6 +31,7 @@ const iconStyle = {
 };
 const AgendaInputField = (props) => {
   const {
+    afterSubmitAgendaItem,
     atmosphere,
     bindHotkey,
     disabled,
@@ -57,6 +58,7 @@ const AgendaInputField = (props) => {
     };
     AddAgendaItemMutation(atmosphere, newAgendaItem);
     inputRef.focus();
+    afterSubmitAgendaItem();
   };
 
   const focusOnInput = (e) => {
@@ -127,6 +129,7 @@ AgendaInputField.propTypes = {
   disabled: PropTypes.bool,
   handleSubmit: PropTypes.func,
   input: PropTypes.object,
+  afterSubmitAgendaItem: PropTypes.func.isRequired,
   setAgendaInputRef: PropTypes.func,
   styles: PropTypes.object,
   team: PropTypes.object.isRequired

--- a/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
+++ b/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
@@ -33,8 +33,8 @@ class AgendaItem extends Component {
     idx: PropTypes.number,
     isCurrent: PropTypes.bool,
     isComplete: PropTypes.bool,
+    isFacilitator: PropTypes.bool,
     facilitatorPhase: PropTypes.oneOf(phaseArray),
-    facilitatorPhaseItem: PropTypes.number,
     gotoAgendaItem: PropTypes.func,
     localPhase: PropTypes.oneOf(phaseArray),
     localPhaseItem: PropTypes.number,
@@ -46,12 +46,14 @@ class AgendaItem extends Component {
     this.scrollToWhenCurrent();
   }
 
-  componentDidUpdate() {
-    this.scrollToWhenCurrent();
+  componentDidUpdate(prevProps) {
+    if (!prevProps.isFacilitator && this.props.isFacilitator) {
+      this.scrollToWhenCurrent();
+    }
   }
 
   scrollToWhenCurrent = () => {
-    if (this.props.isCurrent && this.el) {
+    if (this.props.isFacilitator && this.el) {
       this.el.scrollIntoViewIfNeeded();
     }
   };
@@ -67,17 +69,16 @@ class AgendaItem extends Component {
       disabled,
       idx,
       isCurrent,
+      isFacilitator,
       handleRemove,
       localPhase,
       facilitatorPhase,
-      facilitatorPhaseItem,
       gotoAgendaItem,
       localPhaseItem,
       styles
     } = this.props;
     const {content, isComplete, teamMember = {}} = agendaItem;
     const isLocal = idx + 1 === localPhaseItem;
-    const isFacilitator = idx + 1 === facilitatorPhaseItem;
     const canDelete = !isComplete && !isCurrent && !disabled;
     const inAgendaGroupLocal = inAgendaGroup(localPhase);
     const inAgendaGroupFacilitator = inAgendaGroup(facilitatorPhase);

--- a/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
+++ b/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
@@ -55,7 +55,7 @@ class AgendaItem extends Component {
 
   scrollToIfNeeded = () => {
     if (this.props.ensureVisible && this.el) {
-      this.el.scrollIntoView();
+      this.el.scrollIntoView({behavior: 'smooth'});
     }
   };
 

--- a/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
+++ b/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
@@ -55,7 +55,7 @@ class AgendaItem extends Component {
 
   scrollToIfNeeded = () => {
     if (this.props.ensureVisible && this.el) {
-      this.el.scrollIntoViewIfNeeded();
+      this.el.scrollIntoView();
     }
   };
 

--- a/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
+++ b/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
@@ -121,26 +121,6 @@ class AgendaItem extends Component {
   }
 }
 
-AgendaItem.propTypes = {
-  agendaItem: PropTypes.object.isRequired,
-  agendaLength: PropTypes.number.isRequired,
-  canNavigate: PropTypes.bool,
-  connectDragSource: PropTypes.func.isRequired,
-  content: PropTypes.string,
-  disabled: PropTypes.bool,
-  handleRemove: PropTypes.func,
-  idx: PropTypes.number,
-  isCurrent: PropTypes.bool,
-  isComplete: PropTypes.bool,
-  facilitatorPhase: PropTypes.oneOf(phaseArray),
-  facilitatorPhaseItem: PropTypes.number,
-  gotoAgendaItem: PropTypes.func,
-  localPhase: PropTypes.oneOf(phaseArray),
-  localPhaseItem: PropTypes.number,
-  styles: PropTypes.object,
-  teamMember: PropTypes.object
-};
-
 const warmLinkHover = tinycolor(appTheme.palette.warm).darken(15).toHexString();
 const lineHeight = '1.5rem';
 

--- a/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
+++ b/src/universal/modules/teamDashboard/components/AgendaItem/AgendaItem.js
@@ -29,6 +29,7 @@ class AgendaItem extends Component {
     connectDragSource: PropTypes.func.isRequired,
     content: PropTypes.string,
     disabled: PropTypes.bool,
+    ensureVisible: PropTypes.bool,
     handleRemove: PropTypes.func,
     idx: PropTypes.number,
     isCurrent: PropTypes.bool,
@@ -43,17 +44,17 @@ class AgendaItem extends Component {
   };
 
   componentDidMount() {
-    this.scrollToWhenCurrent();
+    this.scrollToIfNeeded();
   }
 
   componentDidUpdate(prevProps) {
-    if (!prevProps.isFacilitator && this.props.isFacilitator) {
-      this.scrollToWhenCurrent();
+    if (!prevProps.ensureVisible && this.props.ensureVisible) {
+      this.scrollToIfNeeded();
     }
   }
 
-  scrollToWhenCurrent = () => {
-    if (this.props.isFacilitator && this.el) {
+  scrollToIfNeeded = () => {
+    if (this.props.ensureVisible && this.el) {
       this.el.scrollIntoViewIfNeeded();
     }
   };

--- a/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
+++ b/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
@@ -21,6 +21,25 @@ const columnTarget = {
 };
 
 class AgendaList extends Component {
+  static propTypes = {
+    atmosphere: PropTypes.object.isRequired,
+    agendaPhaseItem: PropTypes.number,
+    canNavigate: PropTypes.bool,
+    connectDropTarget: PropTypes.func.isRequired,
+    context: PropTypes.string,
+    disabled: PropTypes.bool,
+    dragState: PropTypes.object.isRequired,
+    facilitatorPhase: PropTypes.oneOf(phaseArray),
+    facilitatorPhaseItem: PropTypes.number,
+    gotoAgendaItem: PropTypes.func,
+    localPhase: PropTypes.oneOf(phaseArray),
+    localPhaseItem: PropTypes.number,
+    styles: PropTypes.object,
+    visibleAgendaItemId: PropTypes.string,
+    submittedCount: PropTypes.number,
+    team: PropTypes.object.isRequired
+  };
+
   state = {
     overflownAbove: false,
     overflownBelow: false
@@ -132,6 +151,7 @@ class AgendaList extends Component {
       gotoAgendaItem,
       localPhase,
       localPhaseItem,
+      visibleAgendaItemId,
       styles,
       team
     } = this.props;
@@ -154,6 +174,7 @@ class AgendaList extends Component {
                 agendaPhaseItem={agendaPhaseItem}
                 canNavigate={canNavigateItems}
                 disabled={disabled}
+                ensureVisible={visibleAgendaItemId === item.id}
                 facilitatorPhase={facilitatorPhase}
                 gotoAgendaItem={gotoAgendaItem && gotoAgendaItem(idx)}
                 handleRemove={this.removeItemFactory(item.id)}
@@ -179,23 +200,6 @@ class AgendaList extends Component {
     );
   }
 }
-
-AgendaList.propTypes = {
-  atmosphere: PropTypes.object.isRequired,
-  agendaPhaseItem: PropTypes.number,
-  canNavigate: PropTypes.bool,
-  connectDropTarget: PropTypes.func.isRequired,
-  context: PropTypes.string,
-  disabled: PropTypes.bool,
-  dragState: PropTypes.object.isRequired,
-  facilitatorPhase: PropTypes.oneOf(phaseArray),
-  facilitatorPhaseItem: PropTypes.number,
-  gotoAgendaItem: PropTypes.func,
-  localPhase: PropTypes.oneOf(phaseArray),
-  localPhaseItem: PropTypes.number,
-  styles: PropTypes.object,
-  team: PropTypes.object.isRequired
-};
 
 const styleThunk = () => ({
   root: {

--- a/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
+++ b/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
@@ -129,16 +129,13 @@ const styleThunk = () => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
-    flex: 1,
-    position: 'relative',
+    minHeight: '5rem',
+    maxHeight: '15rem',
     width: '100%'
   },
 
   inner: {
     ...overflowTouch,
-    bottom: 0,
-    position: 'absolute',
-    top: 0,
     width: '100%'
   },
 

--- a/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
+++ b/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
@@ -155,11 +155,11 @@ class AgendaList extends Component {
                 canNavigate={canNavigateItems}
                 disabled={disabled}
                 facilitatorPhase={facilitatorPhase}
-                facilitatorPhaseItem={facilitatorPhaseItem}
                 gotoAgendaItem={gotoAgendaItem && gotoAgendaItem(idx)}
                 handleRemove={this.removeItemFactory(item.id)}
                 idx={idx}
                 isCurrent={idx + 1 === agendaPhaseItem}
+                isFacilitator={idx + 1 === facilitatorPhaseItem}
                 localPhase={localPhase}
                 localPhaseItem={localPhaseItem}
                 ref={(c) => {

--- a/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
+++ b/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
@@ -202,7 +202,6 @@ const styleThunk = () => ({
     display: 'flex',
     flexDirection: 'column',
     minHeight: '5rem',
-    maxHeight: '15rem',
     width: '100%'
   },
 

--- a/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
+++ b/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
@@ -89,6 +89,7 @@ class AgendaList extends Component {
                 gotoAgendaItem={gotoAgendaItem && gotoAgendaItem(idx)}
                 handleRemove={this.removeItemFactory(item.id)}
                 idx={idx}
+                isCurrent={idx + 1 === agendaPhaseItem}
                 localPhase={localPhase}
                 localPhaseItem={localPhaseItem}
                 ref={(c) => {

--- a/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
+++ b/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
@@ -79,6 +79,8 @@ class AgendaList extends Component {
     return (
       <div
         style={{
+          position: 'relative',
+          top: '-1px',
           boxShadow: '0 1px 1px rgba(0, 0, 0, 0.25)',
           height: '1px'
         }}
@@ -90,6 +92,8 @@ class AgendaList extends Component {
     return (
       <div
         style={{
+          position: 'relative',
+          top: '-1px',
           boxShadow: '0 -1px 1px rgba(0, 0, 0, 0.25)',
           height: '1px'
         }}

--- a/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
+++ b/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
@@ -201,7 +201,7 @@ const styleThunk = () => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
-    minHeight: '5rem',
+    maxHeight: 'calc(100% - 3.625rem)',
     width: '100%'
   },
 

--- a/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
+++ b/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
@@ -93,7 +93,7 @@ class AgendaList extends Component {
       <div
         style={{
           position: 'relative',
-          top: '-1px',
+          top: '1px',
           boxShadow: '0 -1px 1px rgba(0, 0, 0, 0.25)',
           height: '1px'
         }}

--- a/src/universal/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.js
+++ b/src/universal/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.js
@@ -29,12 +29,6 @@ const AgendaListAndInput = (props) => {
   );
   return (
     <div className={rootStyles}>
-      <AgendaInput
-        context={context}
-        disabled={disabled}
-        setAgendaInputRef={setAgendaInputRef}
-        team={team}
-      />
       <AgendaList
         agendaPhaseItem={agendaPhaseItem}
         canNavigate={canNavigate}
@@ -45,6 +39,12 @@ const AgendaListAndInput = (props) => {
         gotoAgendaItem={gotoAgendaItem}
         localPhase={localPhase}
         localPhaseItem={localPhaseItem}
+        team={team}
+      />
+      <AgendaInput
+        context={context}
+        disabled={disabled}
+        setAgendaInputRef={setAgendaInputRef}
         team={team}
       />
     </div>

--- a/src/universal/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.js
+++ b/src/universal/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.js
@@ -29,24 +29,26 @@ const AgendaListAndInput = (props) => {
   );
   return (
     <div className={rootStyles}>
-      <AgendaList
-        agendaPhaseItem={agendaPhaseItem}
-        canNavigate={canNavigate}
-        context={context}
-        disabled={disabled}
-        facilitatorPhase={facilitatorPhase}
-        facilitatorPhaseItem={facilitatorPhaseItem}
-        gotoAgendaItem={gotoAgendaItem}
-        localPhase={localPhase}
-        localPhaseItem={localPhaseItem}
-        team={team}
-      />
-      <AgendaInput
-        context={context}
-        disabled={disabled}
-        setAgendaInputRef={setAgendaInputRef}
-        team={team}
-      />
+      <div className={css(styles.inner)}>
+        <AgendaList
+          agendaPhaseItem={agendaPhaseItem}
+          canNavigate={canNavigate}
+          context={context}
+          disabled={disabled}
+          facilitatorPhase={facilitatorPhase}
+          facilitatorPhaseItem={facilitatorPhaseItem}
+          gotoAgendaItem={gotoAgendaItem}
+          localPhase={localPhase}
+          localPhaseItem={localPhaseItem}
+          team={team}
+        />
+        <AgendaInput
+          context={context}
+          disabled={disabled}
+          setAgendaInputRef={setAgendaInputRef}
+          team={team}
+        />
+      </div>
     </div>
   );
 };
@@ -76,7 +78,16 @@ const styleThunk = (theme, {context}) => ({
     flexDirection: 'column',
     flex: 1,
     paddingTop: context === 'dashboard' ? 0 : ui.meetingSidebarGutter,
+    position: 'relative',
     width: '100%'
+  },
+
+  inner: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0
   },
 
   disabled: {

--- a/src/universal/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.js
+++ b/src/universal/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.js
@@ -1,76 +1,123 @@
 import {css} from 'aphrodite-local-styles/no-important';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {Component} from 'react';
 import {createFragmentContainer} from 'react-relay';
 import AgendaInput from 'universal/modules/teamDashboard/components/AgendaInput/AgendaInput';
 import AgendaList from 'universal/modules/teamDashboard/components/AgendaList/AgendaList';
 import ui from 'universal/styles/ui';
 import withStyles from 'universal/styles/withStyles';
-import {phaseArray} from 'universal/utils/constants';
+import {phaseArray, AGENDA_ITEMS} from 'universal/utils/constants';
 
-const AgendaListAndInput = (props) => {
-  const {
-    agendaPhaseItem,
-    canNavigate,
-    context,
-    disabled,
-    facilitatorPhase,
-    facilitatorPhaseItem,
-    gotoAgendaItem,
-    localPhase,
-    localPhaseItem,
-    setAgendaInputRef,
-    styles,
-    team
-  } = props;
-  const rootStyles = css(
-    styles.root,
-    disabled && styles.disabled
-  );
-  return (
-    <div className={rootStyles}>
-      <div className={css(styles.inner)}>
-        <AgendaList
-          agendaPhaseItem={agendaPhaseItem}
-          canNavigate={canNavigate}
-          context={context}
-          disabled={disabled}
-          facilitatorPhase={facilitatorPhase}
-          facilitatorPhaseItem={facilitatorPhaseItem}
-          gotoAgendaItem={gotoAgendaItem}
-          localPhase={localPhase}
-          localPhaseItem={localPhaseItem}
-          team={team}
-        />
-        <AgendaInput
-          context={context}
-          disabled={disabled}
-          setAgendaInputRef={setAgendaInputRef}
-          team={team}
-        />
+const meetingOnAgendaItem = (props) => (
+  props.facilitatorPhase === AGENDA_ITEMS && props.facilitatorPhaseItem != null
+);
+
+const meetingChangingAgendaItem = (curProps, nextProps) => (
+  nextProps.facilitatorPhase === AGENDA_ITEMS &&
+  nextProps.facilitatorPhaseItem !== curProps.facilitatorPhaseItem
+);
+
+class AgendaListAndInput extends Component {
+  static propTypes = {
+    agenda: PropTypes.array,
+    agendaPhaseItem: PropTypes.number,
+    canNavigate: PropTypes.bool,
+    context: PropTypes.oneOf([
+      'dashboard',
+      'meeting'
+    ]),
+    disabled: PropTypes.bool,
+    facilitatorPhase: PropTypes.oneOf(phaseArray),
+    facilitatorPhaseItem: PropTypes.number,
+    gotoAgendaItem: PropTypes.func,
+    localPhase: PropTypes.oneOf(phaseArray),
+    localPhaseItem: PropTypes.number,
+    setAgendaInputRef: PropTypes.func,
+    styles: PropTypes.object,
+    team: PropTypes.object.isRequired
+  };
+
+  state = {
+    visibleAgendaItemId: null
+  };
+
+  componentDidMount() {
+    if (meetingOnAgendaItem(this.props)) {
+      this.scrollToFacilitatedAgendaItem(this.props);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {team: {agendaItems}} = this.props;
+    if (!agendaItems.length) { return; }
+    if (meetingChangingAgendaItem(this.props, nextProps)) {
+      this.scrollToFacilitatedAgendaItem(nextProps);
+    }
+  }
+
+  scrollToFacilitatedAgendaItem = (props) => {
+    const {facilitatorPhaseItem, team: {agendaItems}} = props;
+    if (!meetingOnAgendaItem(props)) {
+      return;
+    }
+    this.setState({visibleAgendaItemId: agendaItems[facilitatorPhaseItem - 1].id});
+  };
+
+  scrollToLatestAgendaItem = () => {
+    const {team: {agendaItems}} = this.props;
+    if (!agendaItems.length) { return; }
+    const visibleAgendaItemId = agendaItems[agendaItems.length - 1].id;
+    this.setState({visibleAgendaItemId});
+  };
+
+  render() {
+    const {
+      agendaPhaseItem,
+      canNavigate,
+      context,
+      disabled,
+      facilitatorPhase,
+      facilitatorPhaseItem,
+      gotoAgendaItem,
+      localPhase,
+      localPhaseItem,
+      setAgendaInputRef,
+      styles,
+      team
+    } = this.props;
+    const {visibleAgendaItemId} = this.state;
+    const rootStyles = css(
+      styles.root,
+      disabled && styles.disabled
+    );
+    return (
+      <div className={rootStyles}>
+        <div className={css(styles.inner)}>
+          <AgendaList
+            agendaPhaseItem={agendaPhaseItem}
+            canNavigate={canNavigate}
+            context={context}
+            disabled={disabled}
+            facilitatorPhase={facilitatorPhase}
+            facilitatorPhaseItem={facilitatorPhaseItem}
+            gotoAgendaItem={gotoAgendaItem}
+            localPhase={localPhase}
+            localPhaseItem={localPhaseItem}
+            visibleAgendaItemId={visibleAgendaItemId}
+            team={team}
+          />
+          <AgendaInput
+            context={context}
+            disabled={disabled}
+            afterSubmitAgendaItem={this.scrollToLatestAgendaItem}
+            setAgendaInputRef={setAgendaInputRef}
+            team={team}
+          />
+        </div>
       </div>
-    </div>
-  );
-};
-
-AgendaListAndInput.propTypes = {
-  agenda: PropTypes.array,
-  agendaPhaseItem: PropTypes.number,
-  canNavigate: PropTypes.bool,
-  context: PropTypes.oneOf([
-    'dashboard',
-    'meeting'
-  ]),
-  disabled: PropTypes.bool,
-  facilitatorPhase: PropTypes.oneOf(phaseArray),
-  facilitatorPhaseItem: PropTypes.number,
-  gotoAgendaItem: PropTypes.func,
-  localPhase: PropTypes.oneOf(phaseArray),
-  localPhaseItem: PropTypes.number,
-  setAgendaInputRef: PropTypes.func,
-  styles: PropTypes.object,
-  team: PropTypes.object.isRequired
-};
+    );
+  }
+}
 
 const styleThunk = (theme, {context}) => ({
   root: {


### PR DESCRIPTION
Fixes #1365 

## Test:
- [ ] Agenda Item Input placeholder/label now says "Add Agenda Topic..."
- [ ] Agenda Item Input sits below Agenda List
- [ ] As agenda items are added, Agenda List grows to a point and then overflows
- [ ] When overflow happens, the Agenda Item Input stays in-view no matter the scroll position
- [ ] When the list is overflown to the top, there's a drop shadow at the top of the list indicating additional content
- [ ] When the list is overflown to the bottom, there's a drop shadow at the bottom of the list indicating additional content
- [ ] extra credit: input gains focus when users submit an item so that they can write out many without having to manually focus again
- [ ] extra credit: when the list is overflown and you continue to add agenda items, the list scrolls to show the items you've just added.
