### PR TITLE
fix leaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "shortid": "^2.2.8",
     "string-score": "^1.0.1",
     "stripe": "^4.24.0",
-    "subscriptions-transport-ws": "https://github.com/mattkrick/subscriptions-transport-ws/tarball/7937e7300dd306de0f91b89390100377baa4d9c1",
+    "subscriptions-transport-ws": "https://github.com/mattkrick/subscriptions-transport-ws/tarball/725ccffb40834075ba765852e03c70fe59fa90fa",
     "tinycolor2": "^1.4.1",
     "tlds": "^1.192.0",
     "unicode-substring": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "start": "NODE_ENV=production node --trace-warnings ./src/server/server.babel.js",
     "start:tunnel": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d '\"') && ultrahook -k $ULTRAHOOK_API_KEY dev 3000",
+    "start:memwatch": "NODE_ENV=production MEMWATCH=true node --expose-gc --inspect --trace-warnings ./src/server/server.babel.js",
     "quickstart": "npm run db:migrate && npm run build && npm run start",
     "dev": "if [ ! -f \"dll/vendors.json\" ] ; then npm run build:dll ; fi ; NODE_ENV=development node --trace-warnings ./src/server/server.babel.js",
     "bs": "npm run build && npm start",
@@ -96,6 +97,7 @@
     "jest-junit-reporter": "^1.0.1",
     "jsdom": "^11.1.0",
     "json-loader": "^0.5.7",
+    "memwatch-next": "^0.3.0",
     "mocha": "^4.0.1",
     "mockdate": "^2.0.1",
     "piping": "^1.0.0-rc.4",

--- a/src/client/__mocks__/SubscriptionClient.js
+++ b/src/client/__mocks__/SubscriptionClient.js
@@ -12,7 +12,6 @@ class SubscriptionClient {
       subscribe: jest.fn()
     }));
   }
-
 }
 
 export default SubscriptionClient;

--- a/src/server/server.babel.js
+++ b/src/server/server.babel.js
@@ -13,10 +13,11 @@ const ignorePatterns = [
 
 const ignoreRegexp = new RegExp(ignorePatterns.join('|'), 'i');
 if (process.env.NODE_ENV !== 'production') {
-  if (!require('piping')({ // eslint-disable-line
-      hook: false,
-      ignore: ignoreRegexp
-    })) {
+  const hasChanged = require('piping')({ // eslint-disable-line
+    hook: false,
+    ignore: ignoreRegexp
+  });
+  if (!hasChanged) {
     return;
   }
 }

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -21,6 +21,7 @@ import handleGitHubWebhooks from 'server/integrations/handleGitHubWebhooks';
 import SharedDataLoader from 'shared-dataloader';
 import {Server} from 'uws';
 import http from 'http';
+import startMemwatch from 'server/utils/startMemwatch';
 
 // Import .env and expand variables:
 getDotenv();
@@ -111,3 +112,7 @@ app.get('*', createSSR);
 
 // handle sockets
 wss.on('connection', connectionHandler(sharedDataLoader));
+
+if (process.env.MEMWATCH) {
+  startMemwatch();
+}

--- a/src/server/socketHandlers/handleDisconnect.js
+++ b/src/server/socketHandlers/handleDisconnect.js
@@ -1,7 +1,8 @@
 import unsubscribeRelaySub from 'server/utils/unsubscribeRelaySub';
 import wsGraphQLHandler from 'server/socketHandlers/wsGraphQLHandler';
 
-const handleDisconnect = (connectionContext) => () => {
+const handleDisconnect = (connectionContext, options = {}) => () => {
+  const {exitCode = 1000} = options;
   const payload = {
     query: `
     mutation DisconnectSocket {
@@ -12,6 +13,8 @@ const handleDisconnect = (connectionContext) => () => {
   `
   };
   unsubscribeRelaySub(connectionContext);
+  connectionContext.socket.close(exitCode);
+  clearInterval(connectionContext.cancelKeepAlive);
   wsGraphQLHandler(connectionContext, {payload});
 };
 

--- a/src/server/socketHandlers/handleMessage.js
+++ b/src/server/socketHandlers/handleMessage.js
@@ -29,7 +29,7 @@ const handleMessage = (connectionContext) => async (message) => {
      * The endpoint is terminating the connection because a message was received that contained inconsistent data
      * (e.g., non-UTF-8 data within a text message).
      */
-    socket.close(1007);
+    handleDisconnect(connectionContext, {exitCode: 1007})();
     return;
   }
 
@@ -42,7 +42,6 @@ const handleMessage = (connectionContext) => async (message) => {
   }
 
   if (type === GQL_CONNECTION_TERMINATE) {
-    socket.terminate();
     handleDisconnect(connectionContext)();
   } else if (type === GQL_START && isQueryProvided(payload) && isSubscriptionPayload(payload)) {
     wsRelaySubscribeHandler(connectionContext, parsedMessage);

--- a/src/server/socketHandlers/wsRelaySubscribeHandler.js
+++ b/src/server/socketHandlers/wsRelaySubscribeHandler.js
@@ -34,8 +34,8 @@ const handleSubscribe = async (connectionContext, parsedMessage, options = {}) =
     relayUnsubscribe(connectionContext.subs, opId);
   }
 
-    const asyncIterator = await trySubscribe(authToken, parsedMessage, socketId, sharedDataLoader, isResub);
-    if (!asyncIterator) return;
+  const asyncIterator = await trySubscribe(authToken, parsedMessage, socketId, sharedDataLoader, isResub);
+  if (!asyncIterator) return;
 
   connectionContext.subs[opId] = {
     asyncIterator

--- a/src/server/socketHandlers/wsRelaySubscribeHandler.js
+++ b/src/server/socketHandlers/wsRelaySubscribeHandler.js
@@ -25,49 +25,51 @@ const trySubscribe = async (authToken, parsedMessage, socketId, sharedDataLoader
   return undefined;
 };
 
-export default function wsRelaySubscribeHandler(connectionContext, parsedMessage) {
-  const {id: opId} = parsedMessage;
+const handleSubscribe = async (connectionContext, parsedMessage, options = {}) => {
   const {id: socketId, authToken, socket, sharedDataLoader} = connectionContext;
-  connectionContext.subs[opId] = {status: 'pending'};
-  const handleSubscribe = async (options = {}) => {
-    const isResub = options;
-    if (connectionContext.subs[opId]) {
-      // subscription already exists, restart it
-      relayUnsubscribe(connectionContext.subs, opId);
-    }
+  const {id: opId} = parsedMessage;
+  const isResub = options;
+  if (connectionContext.subs[opId]) {
+    // subscription already exists, restart it
+    relayUnsubscribe(connectionContext.subs, opId);
+  }
 
     const asyncIterator = await trySubscribe(authToken, parsedMessage, socketId, sharedDataLoader, isResub);
     if (!asyncIterator) return;
 
-    connectionContext.subs[opId] = {
-      asyncIterator
-    };
-    const iterableCb = (payload) => {
-      const changedAuth = handleGraphQLResult(connectionContext, payload);
-      if (changedAuth) {
-        // if auth changed, then we can't trust any of the subscriptions, so dump em all and resub for the client
-        // delay it to guarantee that no matter when this is published, it is the last message on the mutation
-        setTimeout(() => unsubscribeRelaySub(connectionContext), 1000);
-        return;
-      }
-      const resultType = payload.errors ? GQL_ERROR : GQL_DATA;
-      sendMessage(socket, resultType, payload, opId);
-    };
-
-    // Use this to kick clients out of the sub
-    // setTimeout(() => {
-    //  asyncIterator.return();
-    //  console.log('sub ended', opId)
-    // }, 5000)
-    await forAwaitEach(asyncIterator, iterableCb);
-    const resubIdx = connectionContext.availableResubs.indexOf(opId);
-    if (resubIdx !== -1) {
-      // reinitialize the subscription
-      handleSubscribe({isResub: true});
-      connectionContext.availableResubs.splice(resubIdx, 1);
-    } else {
-      sendMessage(socket, GQL_COMPLETE, undefined, opId);
-    }
+  connectionContext.subs[opId] = {
+    asyncIterator
   };
-  handleSubscribe();
+  const iterableCb = (payload) => {
+    const changedAuth = handleGraphQLResult(connectionContext, payload);
+    if (changedAuth) {
+      // if auth changed, then we can't trust any of the subscriptions, so dump em all and resub for the client
+      // delay it to guarantee that no matter when this is published, it is the last message on the mutation
+      setTimeout(() => unsubscribeRelaySub(connectionContext, {isResub: true}), 1000);
+      return;
+    }
+    const resultType = payload.errors ? GQL_ERROR : GQL_DATA;
+    sendMessage(socket, resultType, payload, opId);
+  };
+
+  // Use this to kick clients out of the sub
+  // setTimeout(() => {
+  //  asyncIterator.return();
+  //  console.log('sub ended', opId)
+  // }, 5000)
+  await forAwaitEach(asyncIterator, iterableCb);
+  const resubIdx = connectionContext.availableResubs.indexOf(opId);
+  if (resubIdx !== -1) {
+    // reinitialize the subscription
+    handleSubscribe(connectionContext, parsedMessage, {isResub: true});
+    connectionContext.availableResubs.splice(resubIdx, 1);
+  } else {
+    sendMessage(socket, GQL_COMPLETE, undefined, opId);
+  }
+};
+
+export default function wsRelaySubscribeHandler(connectionContext, parsedMessage) {
+  const {id: opId} = parsedMessage;
+  connectionContext.subs[opId] = {status: 'pending'};
+  handleSubscribe(connectionContext, parsedMessage);
 }

--- a/src/server/socketHandlers/wssConnectionHandler.js
+++ b/src/server/socketHandlers/wssConnectionHandler.js
@@ -3,19 +3,22 @@ import keepAlive from 'server/socketHelpers/keepAlive';
 import handleDisconnect from 'server/socketHandlers/handleDisconnect';
 import handleMessage from 'server/socketHandlers/handleMessage';
 
-const makeConnectionContext = (socket, sharedDataLoader) => ({
-  authToken: null,
-  subs: {},
-  availableResubs: [],
-  id: shortid.generate(),
-  isAlive: true,
-  socket,
-  sharedDataLoader
-});
+class ConnectionContext {
+  constructor(socket, sharedDataLoader) {
+    this.authToken = null;
+    this.availableResubs = [];
+    this.cancelKeepAlive = null;
+    this.id = shortid.generate();
+    this.isAlive = true;
+    this.socket = socket;
+    this.sharedDataLoader = sharedDataLoader;
+    this.subs = {};
+  }
+}
 
 export default function connectionHandler(sharedDataLoader) {
   return async function socketConnectionHandler(socket) {
-    const connectionContext = makeConnectionContext(socket, sharedDataLoader);
+    const connectionContext = new ConnectionContext(socket, sharedDataLoader);
     keepAlive(connectionContext, 10000);
     socket.on('pong', () => {
       connectionContext.isAlive = true;

--- a/src/server/socketHelpers/closeUnauthedSocket.js
+++ b/src/server/socketHelpers/closeUnauthedSocket.js
@@ -1,5 +1,6 @@
 import {GQL_CONNECTION_ERROR} from 'universal/utils/constants';
 import sendMessage from 'server/socketHelpers/sendMessage';
+import handleDisconnect from 'server/socketHandlers/handleDisconnect';
 
 const closeUnauthedSocket = (connectionContext) => {
   const {authToken, socket} = connectionContext;
@@ -10,7 +11,7 @@ const closeUnauthedSocket = (connectionContext) => {
      *  authorization credentials.
      */
     sendMessage(socket, GQL_CONNECTION_ERROR);
-    socket.close(4401);
+    handleDisconnect(connectionContext, {exitCode: 4401})();
     return true;
   }
   return false;

--- a/src/server/socketHelpers/keepAlive.js
+++ b/src/server/socketHelpers/keepAlive.js
@@ -1,19 +1,15 @@
 import handleDisconnect from 'server/socketHandlers/handleDisconnect';
 
 const keepAlive = (connectionContext, timeout) => {
-  const cancel = setInterval(() => {
+  connectionContext.cancelKeepAlive = setInterval(() => {
     const {socket} = connectionContext;
     if (connectionContext.isAlive === false) {
-      clearInterval(cancel);
       handleDisconnect(connectionContext)();
-      // no need to gracefully close if it's dead
-      socket.terminate();
     } else {
       connectionContext.isAlive = false;
       socket.ping(socket.onping);
     }
   }, timeout);
-  return cancel;
 };
 
 export default keepAlive;

--- a/src/server/utils/startMemwatch.js
+++ b/src/server/utils/startMemwatch.js
@@ -5,7 +5,7 @@ const path = require('path');
 const startMemwatch = () => {
   console.log('starting memwatch');
   memwatch.on('leak', (info) => {
-    console.error('Mem leak detected', info)
+    console.error('Mem leak detected', info);
   });
   let snapStart;
   let snapStop;
@@ -24,7 +24,7 @@ const startMemwatch = () => {
       const jsonPath = path.join(process.cwd(), 'leak.json');
       fs.writeFileSync(jsonPath, JSON.stringify(end, null, 2));
     }
-  })
+  });
 };
 
 export default startMemwatch;

--- a/src/server/utils/startMemwatch.js
+++ b/src/server/utils/startMemwatch.js
@@ -1,0 +1,30 @@
+const memwatch = require('memwatch-next');
+const fs = require('fs');
+const path = require('path');
+
+const startMemwatch = () => {
+  console.log('starting memwatch');
+  memwatch.on('leak', (info) => {
+    console.error('Mem leak detected', info)
+  });
+  let snapStart;
+  let snapStop;
+  let heapDiff;
+  memwatch.on('stats', (stats) => {
+    console.log(stats.current_base);
+    if (stats.current_base > 137062320 && stats.current_base < 139000000 && !snapStart) {
+      snapStart = true;
+      console.log('startMemwatch heapDiff');
+      heapDiff = new memwatch.HeapDiff();
+    }
+    if (stats.current_base > 145000000 && snapStart && !snapStop) {
+      snapStop = true;
+      const end = heapDiff.end();
+      console.log('heapDiff end', end);
+      const jsonPath = path.join(process.cwd(), 'leak.json');
+      fs.writeFileSync(jsonPath, JSON.stringify(end, null, 2));
+    }
+  })
+};
+
+export default startMemwatch;

--- a/src/server/utils/unsubscribeRelaySub.js
+++ b/src/server/utils/unsubscribeRelaySub.js
@@ -1,4 +1,4 @@
-const unsubscribeRelaySub = (connectionContext) => {
+const unsubscribeRelaySub = (connectionContext, options = {}) => {
   if (connectionContext.subs) {
     const opIds = Object.keys(connectionContext.subs);
     for (let ii = 0; ii < opIds.length; ii++) {
@@ -10,7 +10,9 @@ const unsubscribeRelaySub = (connectionContext) => {
     }
     connectionContext.subs = {};
     // flag all of these as eligible for resubscribing
-    connectionContext.availableResubs = opIds;
+    if (options.isResub) {
+      connectionContext.availableResubs = opIds;
+    }
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,6 +1398,10 @@ binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
 
+bindings@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -4064,6 +4068,10 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+heapdump@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/heapdump/-/heapdump-0.3.9.tgz#03c74eb0df5d67be0982e83429ba9c9d2b3b7f78"
+
 history@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
@@ -4751,9 +4759,13 @@ istanbul-reports@^1.1.3:
   dependencies:
     handlebars "^4.0.3"
 
-iterall@1.1.3, iterall@^1.1.0, iterall@^1.1.1:
+iterall@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
+
+iterall@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.4.tgz#0db40d38fdcf53ae14dc8ec674e62ab190d52cfc"
 
 jest-changed-files@^22.0.6:
   version "22.0.6"
@@ -5827,6 +5839,13 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+memwatch-next@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/memwatch-next/-/memwatch-next-0.3.0.tgz#2111050f9a906e0aa2d72a4ec0f0089c78726f8f"
+  dependencies:
+    bindings "^1.2.1"
+    nan "^2.3.2"
+
 meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -6034,6 +6053,10 @@ nan@2.6.2:
 nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+
+nan@^2.3.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 nanomatch@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
TESTS

- [ ] run `yarn build && yarn start:memwatch`, log in, go all around the site, hit refresh a BUNCH. like, 50+ times. mutate stuff, query stuff, open a few extra tabs & close them. Close all the tabs. See the last number printed to the server console is about the same as the first number. 

data leak postmortem:
there wasn't a satisfying AHA moment, I'm not even 100% sure what the leak was. This is because in order to replace socket cluster, i had to rewrite a fair amount of logic across the board, and some of that  new logic had leaks in it :see_no_evil:, so i couldn't strictly compare with/without.
 
possible sources of the leak:
- the iterall package had a leak up until v1.1.3. All packages used a minimum of `^1.1.0`, so i don't think this was it
- the `connectionContext.subs` object now gets a temporary value synchronously. if the server received 2 requests for the same subscription opId, it would create 2 subscriptions but the 2nd asyncIterator would overwrite the 1st, so there would be no way to close the first. It seems highly unlikely that this was the culprit, especially with a single server, but maybe?
- we now end the keepAlive interval immediately upon a disconnect. i doubt this was a leak, but now we can GC up to 30 seconds earlier.
- use a single function to close sockets. highly unlikely that this stopped any leaks, but it's a lot cleaner.