### PR TITLE
Add label, better a11y to assignment menu

### DIFF
--- a/src/universal/components/LoadableMenu.js
+++ b/src/universal/components/LoadableMenu.js
@@ -88,6 +88,7 @@ class LoadableMenu extends Component {
 
   makeSmartToggle(toggle) {
     return React.cloneElement(toggle, {
+      'aria-haspopup': 'true',
       onClick: (e) => {
         const {setOriginCoords, LoadableComponent} = this.props;
         LoadableComponent.preload();
@@ -111,7 +112,7 @@ class LoadableMenu extends Component {
     const {coords, setModalRef, LoadableComponent, queryVars, maxWidth, maxHeight} = this.props;
     return (
       <React.Fragment>
-        {this.smartToggle}
+        {React.cloneElement(this.smartToggle, {'aria-expanded': this.state.isOpen})}
         <TransitionGroup appear component={null}>
           {isOpen &&
           <AnimatedFade>

--- a/src/universal/modules/menu/components/MenuItem/MenuItem.js
+++ b/src/universal/modules/menu/components/MenuItem/MenuItem.js
@@ -63,7 +63,7 @@ class MenuItem extends Component {
         src={avatar}
       />);
     return (
-      <div title={titleStr} ref={(c) => { this.itemRef = c; }}>
+      <div role="menuitem" title={titleStr} ref={(c) => { this.itemRef = c; }}>
         {hr === 'before' && <hr className={css(styles.hr)} />}
         <div className={rootStyles} onClick={handleClick}>
           {avatar && makeAvatar()}

--- a/src/universal/modules/outcomeCard/components/AddSoftTeamMember.js
+++ b/src/universal/modules/outcomeCard/components/AddSoftTeamMember.js
@@ -146,12 +146,14 @@ class AddSoftTeamMember extends Component {
     } = this.props;
     const rootStyles = css(styles.root, isActive && styles.active);
     const inputStyles = css(styles.input, isActive && styles.inputActive);
+    const labelText = 'Invite a new teammate by their email address';
     return (
-      <div title="Invite a new teammate by email">
+      <div title={labelText}>
         <div className={rootStyles} onClick={this.onClick}>
-          <img alt="Invite a new teammate by email" className={css(styles.avatar)} src={avatarUser} />
+          <img alt="" className={css(styles.avatar)} src={avatarUser} />
           <form onSubmit={this.onSubmit}>
             <input
+              aria-label={labelText}
               className={inputStyles}
               onChange={this.onChange}
               onFocus={setAddSoftAsActive}

--- a/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
@@ -106,6 +106,7 @@ class OutcomeCardFooter extends Component {
       showTeam ?
         <div className={css(styles.teamNameLabel)}>{teamName}</div> :
         (<button
+          aria-label="Assign this task to a teammate"
           className={css(styles.avatarButton)}
           tabIndex={service && '-1'}
           title={`Assigned to ${assignee.preferredName}`}


### PR DESCRIPTION
Fixes #1470.

Testing:
- [ ] Create a task on the team dashboard
- [ ] Open the task assignment menu
- [ ] See "Assign To:" as the menu label
- [ ] Open the inspector
- [ ] Observe that the toggle button has an appropriate `aria-label`
- [ ] Observe that the toggle button has `aria-haspopup="true"` at all times
- [ ] Observe that the toggle button has `aria-expanded="false"` when the menu is closed and `aria-expanded="true"` when the menu is open
- [ ] Observe that the menu container has `role="menu"`
- [ ] Observe that the menu container has an appropriate `aria-label`
- [ ] Observe that all menu items have `role="menuitem"`
- [ ] Observe that the `img` element in the soft invite form has an empty `alt` property, since it is decorative, and decorative images require null `alt` properties
- [ ] Observe that the `input` element in the soft invite form has an appropriate `aria-label`