### PR TITLE
Change team menu

### DIFF
--- a/src/server/graphql/mutations/changeTaskTeam.js
+++ b/src/server/graphql/mutations/changeTaskTeam.js
@@ -1,0 +1,93 @@
+import {GraphQLID, GraphQLNonNull} from 'graphql';
+import getRethink from 'server/database/rethinkDriver';
+import AreaEnum from 'server/graphql/types/AreaEnum';
+import ChangeTaskTeamPayload from 'server/graphql/types/ChangeTaskTeamPayload';
+import {getUserId, requireTeamMember} from 'server/utils/authorization';
+import shortid from 'shortid';
+import removeEntityKeepText from 'universal/utils/draftjs/removeEntityKeepText';
+import {TASK, TASK_INVOLVES} from 'universal/utils/constants';
+import publish from 'server/utils/publish';
+
+export default {
+  type: ChangeTaskTeamPayload,
+  description: 'Update a task with a change in content, ownership, or status',
+  args: {
+    area: {
+      type: AreaEnum,
+      description: 'The part of the site where the creation occurred'
+    },
+    taskId: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'The task to change'
+    },
+    teamId: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'The new team to assign the task to'
+    }
+  },
+  async resolve(source, {area, taskId, teamId}, {authToken, dataLoader, socketId: mutatorId}) {
+    const r = getRethink();
+    const now = new Date();
+    const operationId = dataLoader.share();
+    const subOptions = {mutatorId, operationId};
+
+    // AUTH
+    const viewerId = getUserId(authToken);
+    requireTeamMember(authToken, teamId);
+
+    // VALIDATION
+    const task = await r.table('Task').get(taskId);
+    if (!task) {
+      throw new Error('Task not found');
+    }
+    const {content, tags, teamId: oldTeamId} = task;
+    requireTeamMember(authToken, oldTeamId);
+    if (task.userId !== viewerId) {
+      throw new Error('Cannot change team for a task assigned to someone else');
+    }
+
+    // RESOLUTION
+    const [oldTeamMembers, newTeamMembers] = await dataLoader.get('teamMembersByTeamId').loadMany([oldTeamId, teamId]);
+    const exclusivelyOldTeamMembers = oldTeamMembers.filter((teamMember) => !newTeamMembers.find(({id}) => id === teamMember.id));
+    const rawContent = JSON.parse(content);
+    const eqFn = (entity) => entity.type === 'MENTION' && Boolean(exclusivelyOldTeamMembers.find((teamMember) => teamMember.userId === entity.data.userId));
+    const {rawContent: nextRawContent, removedEntities} = removeEntityKeepText(rawContent, eqFn);
+
+    const updates = {
+      content: rawContent === nextRawContent ? undefined : JSON.stringify(nextRawContent),
+      updatedAt: now,
+      teamId
+    };
+    const {newTask} = await r({
+      newTask: r.table('Task').get(taskId).update(updates),
+      taskHistory: r.table('TaskHistory')
+        .between([taskId, r.minval], [taskId, r.maxval], {index: 'taskIdUpdatedAt'})
+        .orderBy({index: 'taskIdUpdatedAt'})
+        .nth(-1)
+        .do((taskHistoryRecord) => {
+          return r.table('TaskHistory').insert(taskHistoryRecord.merge(updates, {id: shortid.generate()}))
+        })
+    });
+
+    const mentioneeUserIdsToRemove = Array.from(new Set(removedEntities.map(({data}) => data.userId)));
+    const notificationsToRemove = mentioneeUserIdsToRemove.length === 0 ? [] : await r.table('Notification')
+      .getAll(r.args(mentioneeUserIdsToRemove), {index: 'userIds'})
+      .filter({
+        taskId,
+        type: TASK_INVOLVES
+      })
+      .delete({returnChanges: true})('changes')('old_val')
+      .pluck('id', 'userIds')
+      .default([]);
+
+    const isPrivate = tags.includes('private');
+    const data = {taskId, notificationsToRemove};
+    const teamMembers = oldTeamMembers.concat(newTeamMembers);
+    teamMembers.forEach(({userId}) => {
+      if (!isPrivate || userId === newTask.userId) {
+        publish(TASK, userId, ChangeTaskTeamPayload, data, subOptions);
+      }
+    });
+    return data;
+  }
+};

--- a/src/server/graphql/mutations/createGitHubIssue.js
+++ b/src/server/graphql/mutations/createGitHubIssue.js
@@ -69,15 +69,15 @@ export default {
     const subOptions = {mutatorId, operationId};
 
     // AUTH
-    const [teamId] = taskId.split('::');
-    requireTeamMember(authToken, teamId);
-
-    // VALIDATION
-    const viewerId = getUserId(authToken);
     const task = await r.table('Task').get(taskId);
     if (!task) {
       throw new Error('That task no longer exists');
     }
+    const {teamId} = task;
+    requireTeamMember(authToken, teamId);
+
+    // VALIDATION
+    const viewerId = getUserId(authToken);
     if (task.integration && task.integration.service) {
       throw new Error(`That task is already linked to ${task.integration.service}`);
     }

--- a/src/server/graphql/mutations/createTask.js
+++ b/src/server/graphql/mutations/createTask.js
@@ -43,7 +43,7 @@ export default {
 
     // RESOLUTION
     const teamMemberId = toTeamMemberId(teamId, userId);
-    const taskId = `${teamId}::${shortid.generate()}`;
+    const taskId = shortid.generate();
     const {entityMap} = JSON.parse(content);
     const tags = getTagsFromEntityMap(entityMap);
     const task = {

--- a/src/server/graphql/mutations/editTask.js
+++ b/src/server/graphql/mutations/editTask.js
@@ -3,7 +3,6 @@ import EditTaskPayload from 'server/graphql/types/EditTaskPayload';
 import {getUserId, requireTeamMember} from 'server/utils/authorization';
 import publish from 'server/utils/publish';
 import {TASK} from 'universal/utils/constants';
-import promiseAllObj from 'universal/utils/promiseAllObj';
 
 export default {
   type: EditTaskPayload,
@@ -30,7 +29,7 @@ export default {
 
     // RESOLUTION
     // grab the task to see if it's private, don't share with other if it is
-    const {teamMembers} = await dataLoader.get('teamMembersByTeamId').load(teamId);
+    const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId);
     const isPrivate = tags.includes('private');
     const data = {taskId, editorId: viewerId, isEditing};
     teamMembers.forEach((teamMember) => {

--- a/src/server/graphql/mutations/editTask.js
+++ b/src/server/graphql/mutations/editTask.js
@@ -21,18 +21,16 @@ export default {
   async resolve(source, {taskId, isEditing}, {authToken, dataLoader, socketId: mutatorId}) {
     const operationId = dataLoader.share();
     const subOptions = {mutatorId, operationId};
+
     // AUTH
+    const task = await dataLoader.get('tasks').load(taskId);
     const viewerId = getUserId(authToken);
-    const [teamId] = taskId.split('::');
+    const {tags, teamId, userId: taskUserId} = task;
     requireTeamMember(authToken, teamId);
 
     // RESOLUTION
     // grab the task to see if it's private, don't share with other if it is
-    const {task, teamMembers} = await promiseAllObj({
-      task: dataLoader.get('tasks').load(taskId),
-      teamMembers: dataLoader.get('teamMembersByTeamId').load(teamId)
-    });
-    const {tags, userId: taskUserId} = task;
+    const {teamMembers} = await dataLoader.get('teamMembersByTeamId').load(teamId);
     const isPrivate = tags.includes('private');
     const data = {taskId, editorId: viewerId, isEditing};
     teamMembers.forEach((teamMember) => {

--- a/src/server/graphql/mutations/updateTask.js
+++ b/src/server/graphql/mutations/updateTask.js
@@ -81,7 +81,7 @@ export default {
     }
 
     let taskHistory;
-    if (Object.keys(taskUpdates).length > 2 || taskUpdates.sortOrder === undefined) {
+    if (Object.keys(updatedTask).length > 2 || taskUpdates.sortOrder === undefined) {
       // if this is anything but a sort update, log it to history
       taskUpdates.updatedAt = now;
       const mergeDoc = {

--- a/src/server/graphql/resolvers.js
+++ b/src/server/graphql/resolvers.js
@@ -64,9 +64,10 @@ export const resolveOrgApproval = ({orgApprovalId, orgApproval}, args, {dataLoad
 
 export const resolveTask = async ({task, taskId}, args, {authToken, dataLoader}) => {
   const taskDoc = taskId ? await dataLoader.get('tasks').load(taskId) : task;
-  const {userId, tags} = taskDoc;
+  const {userId, tags, teamId} = taskDoc;
   const isViewer = userId === getUserId(authToken);
-  return (isViewer || !tags.includes('private')) ? taskDoc : null;
+  const isViewerOnTeam = authToken.tms.includes(teamId);
+  return (isViewer || (!tags.includes('private') && isViewerOnTeam)) ? taskDoc : null;
 };
 
 export const resolveTasks = async ({taskIds}, args, {authToken, dataLoader}) => {

--- a/src/server/graphql/rootMutation.js
+++ b/src/server/graphql/rootMutation.js
@@ -11,6 +11,7 @@ import archiveTeam from 'server/graphql/mutations/archiveTeam';
 import cancelApproval from 'server/graphql/mutations/cancelApproval';
 import cancelTeamInvite from 'server/graphql/mutations/cancelTeamInvite';
 import clearNotification from 'server/graphql/mutations/clearNotification';
+import changeTaskTeam from 'server/graphql/mutations/changeTaskTeam';
 import connectSocket from 'server/graphql/mutations/connectSocket';
 import createGitHubIssue from 'server/graphql/mutations/createGitHubIssue';
 import createTask from 'server/graphql/mutations/createTask';
@@ -81,6 +82,7 @@ export default new GraphQLObjectType({
     archiveTeam,
     cancelApproval,
     cancelTeamInvite,
+    changeTaskTeam,
     clearNotification,
     connectSocket,
     createImposterToken,

--- a/src/server/graphql/types/ChangeTaskTeamPayload.js
+++ b/src/server/graphql/types/ChangeTaskTeamPayload.js
@@ -1,0 +1,27 @@
+import {GraphQLID, GraphQLObjectType} from 'graphql';
+import {makeResolveNotificationForViewer, resolveTask} from 'server/graphql/resolvers';
+import NotifyTaskInvolves from 'server/graphql/types/NotifyTaskInvolves';
+import Task from 'server/graphql/types/Task';
+
+const ChangeTaskTeamPayload = new GraphQLObjectType({
+  name: 'ChangeTaskTeamPayload',
+  fields: () => ({
+    task: {
+      type: Task,
+      resolve: resolveTask
+    },
+    removedNotification: {
+      type: NotifyTaskInvolves,
+      resolve: makeResolveNotificationForViewer('notificationIdsToRemove', 'notificationsToRemove')
+    },
+    removedTaskId: {
+      type: GraphQLID,
+      description: 'the taskId sent to a user who is not on the new team so they can remove it from their client',
+      resolve: async ({taskId}) => {
+        return taskId;
+      }
+    }
+  })
+});
+
+export default ChangeTaskTeamPayload;

--- a/src/server/graphql/types/Task.js
+++ b/src/server/graphql/types/Task.js
@@ -22,7 +22,7 @@ const Task = new GraphQLObjectType({
   fields: () => ({
     id: {
       type: GraphQLID,
-      description: 'A shortid for the task teamId::shortid'
+      description: 'shortid'
     },
     agendaId: {
       type: GraphQLID,

--- a/src/server/graphql/types/TaskSubscriptionPayload.js
+++ b/src/server/graphql/types/TaskSubscriptionPayload.js
@@ -1,4 +1,5 @@
 import graphQLSubscriptionType from 'server/graphql/graphQLSubscriptionType';
+import ChangeTaskTeamPayload from 'server/graphql/types/ChangeTaskTeamPayload';
 import CreateGitHubIssuePayload from 'server/graphql/types/CreateGitHubIssuePayload';
 import CreateTaskPayload from 'server/graphql/types/CreateTaskPayload';
 import DeleteTaskPayload from 'server/graphql/types/DeleteTaskPayload';
@@ -19,6 +20,7 @@ const types = [
   AcceptTeamInviteNotificationPayload,
   CancelApprovalPayload,
   CancelTeamInvitePayload,
+  ChangeTaskTeamPayload,
   CreateGitHubIssuePayload,
   CreateTaskPayload,
   DeleteTaskPayload,

--- a/src/universal/components/PlainButton/PlainButton.js
+++ b/src/universal/components/PlainButton/PlainButton.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'react-emotion';
 
 const PlainButton = styled('button')({

--- a/src/universal/components/PlainButton/PlainButton.js
+++ b/src/universal/components/PlainButton/PlainButton.js
@@ -1,29 +1,14 @@
-import {css} from 'aphrodite-local-styles/no-important';
-import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
-import withStyles from 'universal/styles/withStyles';
-
-const PlainButton = ({styles, ...props}) => (
-  <button className={css(styles.root)} {...props}>
-    {props.children}
-  </button>
-);
-
-PlainButton.propTypes = {
-  children: PropTypes.node,
-  styles: PropTypes.object.isRequired
-};
-
-const styleThunk = () => ({
-  root: {
-    appearance: 'none',
-    background: 'inherit',
-    border: 0,
-    borderRadius: 0,
-    margin: 0,
-    padding: 0
-  }
+const PlainButton = styled('button')({
+  appearance: 'none',
+  background: 'inherit',
+  border: 0,
+  borderRadius: 0,
+  cursor: 'pointer',
+  margin: 0,
+  padding: 0
 });
 
-export default withStyles(styleThunk)(PlainButton);
+export default PlainButton;

--- a/src/universal/containers/GitHubReposMenuRoot/GitHubReposMenuRoot.js
+++ b/src/universal/containers/GitHubReposMenuRoot/GitHubReposMenuRoot.js
@@ -55,11 +55,11 @@ const GitHubReposMenuRoot = (rootProps) => {
     atmosphere,
     handleAddTask,
     taskId,
+    teamId,
     setError,
     clearError,
     closePortal
   } = rootProps;
-  const [teamId] = taskId.split('::');
   return (
     <QueryRenderer
       cacheConfig={cacheConfig}
@@ -84,6 +84,7 @@ GitHubReposMenuRoot.propTypes = {
   atmosphere: PropTypes.object.isRequired,
   handleAddTask: PropTypes.func,
   taskId: PropTypes.string.isRequired,
+  teamId: PropTypes.string.isRequired,
   viewer: PropTypes.object,
   setError: PropTypes.func.isRequired,
   clearError: PropTypes.func.isRequired,

--- a/src/universal/modules/menu/components/MenuItem/MenuItemWithShortcuts.js
+++ b/src/universal/modules/menu/components/MenuItem/MenuItemWithShortcuts.js
@@ -22,7 +22,6 @@ const rootStyle = css({
 const activeStyle = css({
   backgroundColor: ui.menuItemBackgroundColorActive,
   color: ui.menuItemColorHoverActive,
-  cursor: 'default',
   '&:hover,:focus': {
     backgroundColor: ui.menuItemBackgroundColorActive
   }

--- a/src/universal/modules/menu/components/MenuItem/MenuItemWithShortcuts.js
+++ b/src/universal/modules/menu/components/MenuItem/MenuItemWithShortcuts.js
@@ -63,31 +63,34 @@ class MenuItemWithShortcuts extends Component {
     }
   }
 
-  render() {
+  handleClick = () => {
     const {
       activate,
-      avatar,
       noCloseOnClick,
-      children,
       closePortal,
+      onClick
+    } = this.props;
+    if (noCloseOnClick) {
+      activate();
+    } else if (closePortal) {
+      closePortal();
+    }
+    if (onClick) {
+      onClick();
+    }
+  };
+
+  render() {
+    const {
+      avatar,
+      children,
       icon,
       iconColor,
       isActive,
       label,
-      onClick,
       menuRef,
       title
     } = this.props;
-    const handleClick = () => {
-      if (noCloseOnClick) {
-        activate();
-      } else if (closePortal) {
-        closePortal();
-      }
-      if (onClick) {
-        onClick();
-      }
-    };
     const labelEl = typeof label === 'string' ?
       <div className={cx(labelStyle, (avatar || icon) && iconLabelStyle)}>{label}</div> : label;
     const titleFallbackStr = typeof label === 'string' ? label : 'Menu Item';
@@ -124,7 +127,7 @@ class MenuItemWithShortcuts extends Component {
         title={titleStr}
         ref={(c) => { this.itemRef = c; }}
         className={cx(rootStyle, isActive && activeStyle)}
-        onClick={handleClick}
+        onClick={this.handleClick}
       >
         {avatar && makeAvatar()}
         {!avatar && icon && makeIcon()}

--- a/src/universal/modules/outcomeCard/components/AddSoftTeamMember.js
+++ b/src/universal/modules/outcomeCard/components/AddSoftTeamMember.js
@@ -138,7 +138,7 @@ class AddSoftTeamMember extends Component {
     const {
       isActive,
       error,
-      styles,
+      styles
     } = this.props;
     const rootStyles = css(styles.root, isActive && styles.active);
     const inputStyles = css(styles.input, isActive && styles.inputActive);

--- a/src/universal/modules/outcomeCard/components/AddSoftTeamMember.js
+++ b/src/universal/modules/outcomeCard/components/AddSoftTeamMember.js
@@ -55,7 +55,6 @@ class AddSoftTeamMember extends Component {
     submitMutation: PropTypes.func.isRequired,
     onCompleted: PropTypes.func.isRequired,
     onError: PropTypes.func.isRequired,
-    setAddSoftAsActive: PropTypes.func.isRequired,
     styles: PropTypes.object.isRequired,
     team: PropTypes.object.isRequired
   };
@@ -140,7 +139,6 @@ class AddSoftTeamMember extends Component {
       isActive,
       error,
       styles,
-      setAddSoftAsActive
     } = this.props;
     const rootStyles = css(styles.root, isActive && styles.active);
     const inputStyles = css(styles.input, isActive && styles.inputActive);
@@ -154,7 +152,6 @@ class AddSoftTeamMember extends Component {
               aria-label={labelText}
               className={inputStyles}
               onChange={this.onChange}
-              onFocus={setAddSoftAsActive}
               placeholder="name@company.co"
               ref={(c) => { this.inputRef = c; }}
               value={inviteeEmail}

--- a/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignMenu.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignMenu.js
@@ -92,7 +92,6 @@ class OutcomeCardAssignMenu extends Component {
             closePortal={closePortal}
             taskId={taskId}
             team={team}
-            setAddSoftAsActive={this.setAddSoftAsActive}
           />
         </MenuItemWithShortcuts>
       </MenuWithShortcuts>

--- a/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignMenu.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignMenu.js
@@ -31,12 +31,6 @@ class OutcomeCardAssignMenu extends Component {
     }
   }
 
-  setAddSoftAsActive = () => {
-    this.setState({
-      active: this.state.assignees.length
-    });
-  };
-
   setAssignees(props) {
     const {viewer: {team: {teamMembers, softTeamMembers}}, task: {assignee: {assigneeId}}} = props;
     this.setState({
@@ -67,7 +61,6 @@ class OutcomeCardAssignMenu extends Component {
   };
 
   render() {
-    const {active} = this.state;
     const {
       area,
       closePortal,
@@ -83,12 +76,11 @@ class OutcomeCardAssignMenu extends Component {
         closePortal={closePortal}
       >
         <div className={css(styles.label)}>Assign to:</div>
-        {assignees.map((teamMember, idx) => {
+        {assignees.map((teamMember) => {
           return (
             <MenuItemWithShortcuts
               key={teamMember.id}
               avatar={teamMember.picture || avatarUser}
-              isActive={active === idx}
               label={teamMember.preferredName}
               onClick={this.handleMenuItemClick(teamMember)}
             />

--- a/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
@@ -11,6 +11,10 @@ import MenuItemWithShortcuts from 'universal/modules/menu/components/MenuItem/Me
 import MenuWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuWithShortcuts';
 import ChangeTaskTeamMutation from 'universal/mutations/ChangeTaskTeamMutation';
 
+const makeAssignableTeams = (props) => {
+  const {viewer: {teams}, task: {team: {teamId}}} = props;
+  return teams.filter((team) => team.teamId !== teamId);
+};
 
 class OutcomeCardAssignTeamMenu extends Component {
   state = {
@@ -18,7 +22,7 @@ class OutcomeCardAssignTeamMenu extends Component {
   };
 
   componentWillMount() {
-    this.state.assignableTeams = this.makeAssignableTeams(this.props);
+    this.state.assignableTeams = makeAssignableTeams(this.props);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -26,27 +30,21 @@ class OutcomeCardAssignTeamMenu extends Component {
     const {viewer: {teams: oldTeams}} = this.props;
     if (teams !== oldTeams) {
       this.setState({
-        assignableTeams: this.makeAssignableTeams(nextProps)
+        assignableTeams: makeAssignableTeams(nextProps)
       });
     }
   }
 
-  makeAssignableTeams(props) {
-    const {viewer: {teams}, task: {team: {teamId}}} = props;
-    return teams.filter((team) => team.teamId !== teamId);
-  }
-
-  handleTaskUpdate = (newTeam) => () =>  {
+  handleTaskUpdate = (newTeam) => () => {
     const {
       atmosphere,
-      area,
       task: {taskId, team: {teamId: oldTeamId}}
     } = this.props;
     const {teamId} = newTeam;
     if (oldTeamId === teamId) {
       return;
     }
-    ChangeTaskTeamMutation(atmosphere, {area, taskId, teamId});
+    ChangeTaskTeamMutation(atmosphere, {taskId, teamId});
   };
 
   render() {
@@ -56,7 +54,7 @@ class OutcomeCardAssignTeamMenu extends Component {
     } = this.props;
     const {assignableTeams} = this.state;
 
-    if (assignableTeams.length === 0) return <div></div>;
+    if (assignableTeams.length === 0) return <div />;
     return (
       <MenuWithShortcuts
         ariaLabel={'Assign this task to another team'}

--- a/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
@@ -40,9 +40,10 @@ class OutcomeCardAssignTeamMenu extends Component {
     const {
       atmosphere,
       area,
-      task: {taskId, team: {teamId}}
+      task: {taskId, team: {teamId: oldTeamId}}
     } = this.props;
-    if (newTeam.teamId === teamId) {
+    const {teamId} = newTeam;
+    if (oldTeamId === teamId) {
       return;
     }
     ChangeTaskTeamMutation(atmosphere, {area, taskId, teamId});

--- a/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
@@ -9,6 +9,7 @@ import ui from 'universal/styles/ui';
 import withStyles from 'universal/styles/withStyles';
 import MenuItemWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuItemWithShortcuts';
 import MenuWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuWithShortcuts';
+import ChangeTaskTeamMutation from 'universal/mutations/ChangeTaskTeamMutation';
 
 
 class OutcomeCardAssignTeamMenu extends Component {
@@ -45,7 +46,7 @@ class OutcomeCardAssignTeamMenu extends Component {
     if (newTeam.teamId === teamId) {
       return;
     }
-    ChangeTaskTeamMutation(atmosphere, {area, taskId, teamId})
+    ChangeTaskTeamMutation(atmosphere, {area, taskId, teamId});
   };
 
   render() {

--- a/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
@@ -1,0 +1,117 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import {createFragmentContainer} from 'react-relay';
+import {css} from 'aphrodite-local-styles/no-important';
+import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
+import {textOverflow} from 'universal/styles/helpers';
+import appTheme from 'universal/styles/theme/appTheme';
+import ui from 'universal/styles/ui';
+import withStyles from 'universal/styles/withStyles';
+import MenuItemWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuItemWithShortcuts';
+import MenuWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuWithShortcuts';
+
+
+class OutcomeCardAssignTeamMenu extends Component {
+  state = {
+    assignableTeams: []
+  };
+
+  componentDidMount() {
+    this.setAssignableTeams(this.props);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {viewer: {teams}} = nextProps;
+    const {viewer: {teams: oldTeams}} = this.props;
+    if (teams !== oldTeams) {
+      this.setAssignableTeams(nextProps);
+    }
+  }
+
+  setAssignableTeams(props) {
+    const {viewer: {teams}, task: {team: {teamId}}} = props;
+    this.setState({
+      assignableTeams: teams
+        .filter((team) => team.teamId !== teamId)
+    });
+  }
+
+  handleTaskUpdate = (newTeam) => {
+    const {
+      atmosphere,
+      area,
+      task: {taskId, team: {teamId}}
+    } = this.props;
+    if (newTeam.teamId === teamId) {
+      return;
+    }
+    ChangeTaskTeamMutation(atmosphere, {area, taskId, teamId})
+  };
+
+  render() {
+    const {
+      closePortal,
+      styles
+    } = this.props;
+    const {assignableTeams} = this.state;
+
+    if (assignableTeams.length === 0) return <div></div>;
+    return (
+      <MenuWithShortcuts
+        ariaLabel={'Assign this task to another team'}
+        closePortal={closePortal}
+      >
+        <div className={css(styles.label)}>Move to:</div>
+        {assignableTeams.map((team) => {
+          return (
+            <MenuItemWithShortcuts
+              key={team.teamId}
+              label={team.teamName}
+              onClick={this.handleTaskUpdate(team)}
+            />
+          );
+        })}
+      </MenuWithShortcuts>
+    );
+  }
+}
+
+OutcomeCardAssignTeamMenu.propTypes = {
+  area: PropTypes.string.isRequired,
+  atmosphere: PropTypes.object.isRequired,
+  closePortal: PropTypes.func.isRequired,
+  styles: PropTypes.object.isRequired,
+  task: PropTypes.object.isRequired,
+  viewer: PropTypes.object.isRequired
+};
+
+const styleThunk = () => ({
+  label: {
+    ...textOverflow,
+    borderBottom: `1px solid ${appTheme.palette.mid30l}`,
+    color: ui.palette.dark,
+    fontSize: ui.menuItemFontSize,
+    fontWeight: 700,
+    lineHeight: ui.menuItemHeight,
+    marginBottom: ui.menuGutterVertical,
+    padding: `0 ${ui.menuGutterHorizontal}`
+  }
+});
+
+export default createFragmentContainer(
+  withAtmosphere(withStyles(styleThunk)(OutcomeCardAssignTeamMenu)),
+  graphql`
+    fragment OutcomeCardAssignTeamMenu_viewer on User {
+      teams {
+        teamId: id
+        teamName: name
+      }
+    }
+    fragment OutcomeCardAssignTeamMenu_task on Task {
+      taskId: id
+      team {
+        teamId: id
+      }
+    }
+  `
+);

--- a/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
@@ -1,20 +1,30 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {createFragmentContainer} from 'react-relay';
-import {css} from 'aphrodite-local-styles/no-important';
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
 import {textOverflow} from 'universal/styles/helpers';
 import appTheme from 'universal/styles/theme/appTheme';
 import ui from 'universal/styles/ui';
-import withStyles from 'universal/styles/withStyles';
 import MenuItemWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuItemWithShortcuts';
 import MenuWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuWithShortcuts';
 import ChangeTaskTeamMutation from 'universal/mutations/ChangeTaskTeamMutation';
+import styled from 'react-emotion';
 
 const makeAssignableTeams = (props) => {
   const {viewer: {teams}, task: {team: {teamId}}} = props;
   return teams.filter((team) => team.teamId !== teamId);
 };
+
+const MenuLabel = styled('div')({
+  ...textOverflow,
+  borderBottom: `1px solid ${appTheme.palette.mid30l}`,
+  color: ui.palette.dark,
+  fontSize: ui.menuItemFontSize,
+  fontWeight: 700,
+  lineHeight: ui.menuItemHeight,
+  marginBottom: ui.menuGutterVertical,
+  padding: `0 ${ui.menuGutterHorizontal}`
+});
 
 class OutcomeCardAssignTeamMenu extends Component {
   state = {
@@ -49,8 +59,7 @@ class OutcomeCardAssignTeamMenu extends Component {
 
   render() {
     const {
-      closePortal,
-      styles
+      closePortal
     } = this.props;
     const {assignableTeams} = this.state;
 
@@ -60,7 +69,7 @@ class OutcomeCardAssignTeamMenu extends Component {
         ariaLabel={'Assign this task to another team'}
         closePortal={closePortal}
       >
-        <div className={css(styles.label)}>Move to:</div>
+        <MenuLabel>Move to:</MenuLabel>
         {assignableTeams.map((team) => {
           return (
             <MenuItemWithShortcuts
@@ -79,26 +88,12 @@ OutcomeCardAssignTeamMenu.propTypes = {
   area: PropTypes.string.isRequired,
   atmosphere: PropTypes.object.isRequired,
   closePortal: PropTypes.func.isRequired,
-  styles: PropTypes.object.isRequired,
   task: PropTypes.object.isRequired,
   viewer: PropTypes.object.isRequired
 };
 
-const styleThunk = () => ({
-  label: {
-    ...textOverflow,
-    borderBottom: `1px solid ${appTheme.palette.mid30l}`,
-    color: ui.palette.dark,
-    fontSize: ui.menuItemFontSize,
-    fontWeight: 700,
-    lineHeight: ui.menuItemHeight,
-    marginBottom: ui.menuGutterVertical,
-    padding: `0 ${ui.menuGutterHorizontal}`
-  }
-});
-
 export default createFragmentContainer(
-  withAtmosphere(withStyles(styleThunk)(OutcomeCardAssignTeamMenu)),
+  withAtmosphere(OutcomeCardAssignTeamMenu),
   graphql`
     fragment OutcomeCardAssignTeamMenu_viewer on User {
       teams {

--- a/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu.js
@@ -17,27 +17,26 @@ class OutcomeCardAssignTeamMenu extends Component {
     assignableTeams: []
   };
 
-  componentDidMount() {
-    this.setAssignableTeams(this.props);
+  componentWillMount() {
+    this.state.assignableTeams = this.makeAssignableTeams(this.props);
   }
 
   componentWillReceiveProps(nextProps) {
     const {viewer: {teams}} = nextProps;
     const {viewer: {teams: oldTeams}} = this.props;
     if (teams !== oldTeams) {
-      this.setAssignableTeams(nextProps);
+      this.setState({
+        assignableTeams: this.makeAssignableTeams(nextProps)
+      });
     }
   }
 
-  setAssignableTeams(props) {
+  makeAssignableTeams(props) {
     const {viewer: {teams}, task: {team: {teamId}}} = props;
-    this.setState({
-      assignableTeams: teams
-        .filter((team) => team.teamId !== teamId)
-    });
+    return teams.filter((team) => team.teamId !== teamId);
   }
 
-  handleTaskUpdate = (newTeam) => {
+  handleTaskUpdate = (newTeam) => () =>  {
     const {
       atmosphere,
       area,

--- a/src/universal/modules/outcomeCard/components/OutcomeCardAssignTeamMenuRoot.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardAssignTeamMenuRoot.js
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {graphql} from 'react-relay';
+import QueryRenderer from 'universal/components/QueryRenderer/QueryRenderer';
+import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
+import {cacheConfig} from 'universal/utils/constants';
+import {DEFAULT_MENU_HEIGHT, DEFAULT_MENU_WIDTH, HUMAN_ADDICTION_THRESH, MAX_WAIT_TIME} from 'universal/styles/ui';
+import Loadable from 'react-loadable';
+import LoadableLoading from 'universal/components/LoadableLoading';
+import RelayLoadableTransitionGroup from 'universal/components/RelayLoadableTransitionGroup';
+
+const query = graphql`
+  query OutcomeCardAssignTeamMenuRootQuery {
+    viewer {
+      ...OutcomeCardAssignTeamMenu_viewer
+    }
+  }
+`;
+
+const loading = (props) => <LoadableLoading {...props} height={DEFAULT_MENU_HEIGHT} width={DEFAULT_MENU_WIDTH} />;
+
+const LoadableOutcomeCardAssignTeamMenu = Loadable({
+  loader: () => System.import(
+    /* webpackChunkName: 'OutcomeCardAssignTeamMenu' */
+    'universal/modules/outcomeCard/components/OutcomeCardAssignMenu/OutcomeCardAssignTeamMenu'
+  ),
+  loading,
+  delay: HUMAN_ADDICTION_THRESH,
+  timeout: MAX_WAIT_TIME
+});
+
+const OutcomeCardAssignTeamMenuRoot = (props) => {
+  const {area, atmosphere, closePortal, task} = props;
+  return (
+    <QueryRenderer
+      cacheConfig={cacheConfig}
+      environment={atmosphere}
+      query={query}
+      render={(readyState) => (
+        <RelayLoadableTransitionGroup
+          LoadableComponent={LoadableOutcomeCardAssignTeamMenu}
+          loading={loading}
+          readyState={readyState}
+          extraProps={{area, closePortal, task}}
+        />
+      )}
+    />
+  );
+};
+
+OutcomeCardAssignTeamMenuRoot.propTypes = {
+  area: PropTypes.string.isRequired,
+  atmosphere: PropTypes.object.isRequired,
+  closePortal: PropTypes.func.isRequired,
+  task: PropTypes.object.isRequired
+};
+
+export default withAtmosphere(OutcomeCardAssignTeamMenuRoot);

--- a/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
@@ -18,11 +18,22 @@ import avatarUser from 'universal/styles/theme/images/avatar-user.svg';
 import Loadable from 'react-loadable';
 import LoadableMenu from 'universal/components/LoadableMenu';
 import LoadableLoading from 'universal/components/LoadableLoading';
+import PlainButton from 'universal/components/PlainButton/PlainButton';
 
 const LoadableAssignMenu = Loadable({
   loader: () => System.import(
     /* webpackChunkName: 'OutcomeCardAssignMenuRoot' */
     'universal/modules/outcomeCard/components/OutcomeCardAssignMenuRoot'
+  ),
+  loading: (props) => <LoadableLoading {...props} height={DEFAULT_MENU_HEIGHT} width={DEFAULT_MENU_WIDTH} />,
+  delay: HUMAN_ADDICTION_THRESH,
+  timeout: MAX_WAIT_TIME
+});
+
+const LoadableAssignTeamMenu = Loadable({
+  loader: () => System.import(
+    /* webpackChunkName: 'OutcomeCardAssignMenuRoot' */
+    'universal/modules/outcomeCard/components/OutcomeCardAssignTeamMenuRoot'
   ),
   loading: (props) => <LoadableLoading {...props} height={DEFAULT_MENU_HEIGHT} width={DEFAULT_MENU_WIDTH} />,
   delay: HUMAN_ADDICTION_THRESH,
@@ -120,7 +131,12 @@ class OutcomeCardFooter extends Component {
     const {error} = this.state;
     const ownerAvatarOrTeamName = (
       showTeam ?
-        <div className={css(styles.teamNameLabel)}>{teamName}</div> :
+        (<PlainButton
+          aria-label="Assign this task to another team"
+          onClick={this.selectAllQuestion}
+        >
+          {teamName}
+        </PlainButton>) :
         (<button
           aria-label="Assign this task to a teammate"
           className={css(styles.avatarButton)}
@@ -142,27 +158,44 @@ class OutcomeCardFooter extends Component {
         </button>)
     );
 
+    const canAssign = !service && !isArchived;
     return (
       <div className={css(styles.footerAndMessage)}>
         <div className={css(styles.footer)}>
           <div className={css(styles.avatarBlock)}>
-            {service || showTeam || isArchived ?
-              ownerAvatarOrTeamName :
-              <LoadableMenu
-                LoadableComponent={LoadableAssignMenu}
-                maxWidth={350}
-                maxHeight={225}
-                originAnchor={assignOriginAnchor}
-                queryVars={{
-                  area,
-                  task,
-                  teamId
-                }}
-                targetAnchor={assignTargetAnchor}
-                toggle={ownerAvatarOrTeamName}
-                onOpen={toggleMenuState}
-                onClose={toggleMenuState}
-              />
+            {!canAssign && ownerAvatarOrTeamName}
+            {canAssign && showTeam &&
+            <LoadableMenu
+              LoadableComponent={LoadableAssignTeamMenu}
+              maxWidth={350}
+              maxHeight={225}
+              originAnchor={assignOriginAnchor}
+              queryVars={{
+                area,
+                task
+              }}
+              targetAnchor={assignTargetAnchor}
+              toggle={ownerAvatarOrTeamName}
+              onOpen={toggleMenuState}
+              onClose={toggleMenuState}
+            />
+            }
+            {canAssign && !showTeam &&
+            <LoadableMenu
+              LoadableComponent={LoadableAssignMenu}
+              maxWidth={350}
+              maxHeight={225}
+              originAnchor={assignOriginAnchor}
+              queryVars={{
+                area,
+                task,
+                teamId
+              }}
+              targetAnchor={assignTargetAnchor}
+              toggle={ownerAvatarOrTeamName}
+              onOpen={toggleMenuState}
+              onClose={toggleMenuState}
+            />
             }
           </div>
           <div className={buttonBlockStyles}>
@@ -365,6 +398,7 @@ export default createFragmentContainer(
         teamId: id
         teamName: name
       }
+      ...OutcomeCardAssignTeamMenu_task
       ...OutcomeCardAssignMenu_task
       ...OutcomeCardStatusMenu_task
     }`

--- a/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
+++ b/src/universal/modules/outcomeCard/components/OutcomeCardFooter/OutcomeCardFooter.js
@@ -213,6 +213,7 @@ class OutcomeCardFooter extends Component {
                       area,
                       handleAddTask,
                       taskId,
+                      teamId,
                       setError: this.setError,
                       clearError: this.clearError
                     }}

--- a/src/universal/mutations/ChangeTaskTeamMutation.js
+++ b/src/universal/mutations/ChangeTaskTeamMutation.js
@@ -5,7 +5,7 @@ import handleRemoveNotifications from 'universal/mutations/handlers/handleRemove
 import getInProxy from 'universal/utils/relay/getInProxy';
 
 graphql`
-  fragment ChangeTaskTeamMutation_task on ChangeTaskTeamMutationPayload {
+  fragment ChangeTaskTeamMutation_task on ChangeTaskTeamPayload {
     task {
       ...CompleteTaskFrag @relay(mask: false)
     }

--- a/src/universal/mutations/ChangeTaskTeamMutation.js
+++ b/src/universal/mutations/ChangeTaskTeamMutation.js
@@ -1,0 +1,84 @@
+import jwtDecode from 'jwt-decode';
+import {commitMutation} from 'react-relay';
+import {setWelcomeActivity} from 'universal/modules/userDashboard/ducks/settingsDuck';
+import {acceptTeamInviteTeamUpdater} from 'universal/mutations/AcceptTeamInviteMutation';
+import handleToastError from 'universal/mutations/handlers/handleToastError';
+import {setAuthToken} from 'universal/redux/authDuck';
+import handleUpsertTasks from 'universal/mutations/handlers/handleUpsertTasks';
+import getTagsFromEntityMap from 'universal/utils/draftjs/getTagsFromEntityMap';
+import updateProxyRecord from 'universal/utils/relay/updateProxyRecord';
+import fromTeamMemberId from 'universal/utils/relay/fromTeamMemberId';
+import handleRemoveTasks from 'universal/mutations/handlers/handleRemoveTasks';
+import handleRemoveNotifications from 'universal/mutations/handlers/handleRemoveNotifications';
+import getInProxy from 'universal/utils/relay/getInProxy';
+import popInvolvementToast from 'universal/mutations/toasts/popInvolvementToast';
+import handleAddNotifications from 'universal/mutations/handlers/handleAddNotifications';
+
+graphql`
+  fragment ChangeTaskTeamMutation_task on ChangeTaskTeamMutationPayload {
+    task {
+      ...CompleteTaskFrag @relay(mask: false)
+    }
+  }
+`;
+
+const mutation = graphql`
+  mutation ChangeTaskTeamMutation($taskId: ID!, $teamId: ID!, $area: AreaEnum) {
+    changeTaskTeam(taskId: $taskId, teamId: $teamId, area: $area) {
+      ...ChangeTaskTeamMutation_task @relay(mask: false)
+    }
+  }
+`;
+
+export const changeTaskTeamTaskUpdater = (payload, store, viewerId, options) => {
+  const task = payload.getLinkedRecord('task');
+  handleUpsertTasks(task, store, viewerId);
+
+  const addedNotification = payload.getLinkedRecord('addedNotification');
+  handleAddNotifications(addedNotification, store, viewerId);
+  if (options) {
+    popInvolvementToast(addedNotification, options);
+  }
+
+  const removedNotificationId = getInProxy(payload, 'removedNotification', 'id');
+  handleRemoveNotifications(removedNotificationId);
+
+  const privatizedTaskId = payload.getValue('privatizedTaskId');
+  const taskUserId = getInProxy(task, 'userId');
+  if (taskUserId !== viewerId && privatizedTaskId) {
+    handleRemoveTasks(privatizedTaskId, store, viewerId);
+  }
+};
+
+const ChangeTaskTeamMutation = (environment, variables, onError, onCompleted) => {
+  const {viewerId} = environment;
+  return commitMutation(environment, {
+    mutation,
+    variables,
+    updater: (store) => {
+      const payload = store.getRootField('acceptTeamInviteEmail');
+      acceptTeamInviteEmailTeamUpdater(payload, store, viewerId, dispatch);
+    },
+    optimisticUpdater: (store) => {
+      const {taskId, teamId} = variables;
+      const task = store.get(taskId);
+      if (!taskId) return;
+      const now = new Date();
+      const optimisticTask = {
+        updatedAt: now.toJSON()
+      };
+      updateProxyRecord(task, optimisticTask);
+      task.setValue(teamId, 'teamId');
+      const team = store.get(teamId);
+      if (team) {
+        task.setLinkedRecord(team, 'team');
+      }
+      handleUpsertTasks(task, store, viewerId);
+    },
+    onError,
+    onCompleted
+    }
+  });
+};
+
+export default ChangeTaskTeamMutation;

--- a/src/universal/mutations/ChangeTaskTeamMutation.js
+++ b/src/universal/mutations/ChangeTaskTeamMutation.js
@@ -9,6 +9,10 @@ graphql`
   fragment ChangeTaskTeamMutation_task on ChangeTaskTeamPayload {
     task {
       ...CompleteTaskFrag @relay(mask: false)
+      editors {
+        userId
+        preferredName
+      }
     }
     removedNotification {
       id
@@ -18,8 +22,8 @@ graphql`
 `;
 
 const mutation = graphql`
-  mutation ChangeTaskTeamMutation($taskId: ID!, $teamId: ID!, $area: AreaEnum) {
-    changeTaskTeam(taskId: $taskId, teamId: $teamId, area: $area) {
+  mutation ChangeTaskTeamMutation($taskId: ID!, $teamId: ID!) {
+    changeTaskTeam(taskId: $taskId, teamId: $teamId) {
       ...ChangeTaskTeamMutation_task @relay(mask: false)
     }
   }
@@ -32,7 +36,7 @@ export const changeTaskTeamTaskUpdater = (payload, store, viewerId) => {
   handleUpsertTasks(task, store, viewerId);
 
   const removedNotificationId = getInProxy(payload, 'removedNotification', 'id');
-  handleRemoveNotifications(removedNotificationId);
+  handleRemoveNotifications(removedNotificationId, store, viewerId);
 };
 
 const ChangeTaskTeamMutation = (environment, variables, onError, onCompleted) => {

--- a/src/universal/mutations/ChangeTaskTeamMutation.js
+++ b/src/universal/mutations/ChangeTaskTeamMutation.js
@@ -3,6 +3,7 @@ import handleUpsertTasks from 'universal/mutations/handlers/handleUpsertTasks';
 import updateProxyRecord from 'universal/utils/relay/updateProxyRecord';
 import handleRemoveNotifications from 'universal/mutations/handlers/handleRemoveNotifications';
 import getInProxy from 'universal/utils/relay/getInProxy';
+import safeRemoveNodeFromUnknownConn from 'universal/utils/relay/safeRemoveNodeFromUnknownConn';
 
 graphql`
   fragment ChangeTaskTeamMutation_task on ChangeTaskTeamPayload {
@@ -12,6 +13,7 @@ graphql`
     removedNotification {
       id
     }
+    removedTaskId
   }
 `;
 
@@ -25,6 +27,8 @@ const mutation = graphql`
 
 export const changeTaskTeamTaskUpdater = (payload, store, viewerId) => {
   const task = payload.getLinkedRecord('task');
+  const taskId = getInProxy(task, 'id') || payload.getValue('removedTaskId');
+  safeRemoveNodeFromUnknownConn(store, viewerId, 'TeamColumnsContainer_tasks', taskId);
   handleUpsertTasks(task, store, viewerId);
 
   const removedNotificationId = getInProxy(payload, 'removedNotification', 'id');

--- a/src/universal/mutations/UpdateTaskMutation.js
+++ b/src/universal/mutations/UpdateTaskMutation.js
@@ -49,7 +49,7 @@ export const updateTaskTaskUpdater = (payload, store, viewerId, options) => {
   }
 
   const removedNotificationId = getInProxy(payload, 'removedNotification', 'id');
-  handleRemoveNotifications(removedNotificationId);
+  handleRemoveNotifications(removedNotificationId, store, viewerId);
 
   const privatizedTaskId = payload.getValue('privatizedTaskId');
   const taskUserId = getInProxy(task, 'userId');

--- a/src/universal/subscriptions/TaskSubscription.js
+++ b/src/universal/subscriptions/TaskSubscription.js
@@ -57,7 +57,7 @@ const TaskSubscription = (environment, queryVariables, {dispatch, history, locat
         case 'CancelTeamInvitePayload':
           cancelTeamInviteTaskUpdater(payload, store, viewerId);
           break;
-        case 'ChangeTaskTeamMutationPayload':
+        case 'ChangeTaskTeamPayload':
           changeTaskTeamTaskUpdater(payload, store, viewerId);
           break;
         case 'CreateTaskPayload':

--- a/src/universal/subscriptions/TaskSubscription.js
+++ b/src/universal/subscriptions/TaskSubscription.js
@@ -10,6 +10,7 @@ import {rejectOrgApprovalTaskUpdater} from 'universal/mutations/RejectOrgApprova
 import {cancelTeamInviteTaskUpdater} from 'universal/mutations/CancelTeamInviteMutation';
 import {inviteTeamMembersTaskUpdater} from 'universal/mutations/InviteTeamMembersMutation';
 import {acceptTeamInviteTaskUpdater} from 'universal/mutations/AcceptTeamInviteMutation';
+import {changeTaskTeamTaskUpdater} from 'universal/mutations/ChangeTaskTeamMutation';
 
 const subscription = graphql`
   subscription TaskSubscription {
@@ -20,9 +21,10 @@ const subscription = graphql`
       ...RemoveTeamMemberMutation_task
       ...CancelApprovalMutation_task
       ...CancelTeamInviteMutation_task
-      ...CreateGitHubIssueMutation_task,
-      ...CreateTaskMutation_task,
-      ...DeleteTaskMutation_task,
+      ...ChangeTaskTeamMutation_task
+      ...CreateGitHubIssueMutation_task
+      ...CreateTaskMutation_task
+      ...DeleteTaskMutation_task
       ...EditTaskMutation_task
       ...EndMeetingMutation_task
       ...InviteTeamMembersMutation_task
@@ -54,6 +56,9 @@ const TaskSubscription = (environment, queryVariables, {dispatch, history, locat
           break;
         case 'CancelTeamInvitePayload':
           cancelTeamInviteTaskUpdater(payload, store, viewerId);
+          break;
+        case 'ChangeTaskTeamMutationPayload':
+          changeTaskTeamTaskUpdater(payload, store, viewerId);
           break;
         case 'CreateTaskPayload':
           createTaskTaskUpdater(payload, store, viewerId, false);

--- a/src/universal/utils/draftjs/removeEntityKeepText.js
+++ b/src/universal/utils/draftjs/removeEntityKeepText.js
@@ -22,18 +22,24 @@ const updateBlockEntityRanges = (blocks, updatedKeyMap) => {
  */
 const removeEntityKeepText = (rawContent, eqFn) => {
   const {blocks, entityMap} = rawContent;
-  const nextEntityMap = [];
+  const nextEntityMap = {};
   // oldKey: newKey. null is a remove sentinel
   const updatedKeyMap = {};
   const removedEntities = [];
-  for (let ii = 0; ii < entityMap.length; ii++) {
-    const entity = entityMap[ii];
+  // I'm not really sure how draft-js assigns keys, so I just reuse what they give me FIFO
+  const releasedKeys = [];
+  const entityMapKeys = Object.keys(entityMap);
+  for (let ii = 0; ii < entityMapKeys.length; ii++) {
+    const key = entityMapKeys[ii];
+    const entity = entityMap[key];
     if (eqFn(entity)) {
       removedEntities.push(entity);
-      updatedKeyMap[ii] = null;
+      updatedKeyMap[key] = null;
+      releasedKeys.push(key);
     } else {
-      nextEntityMap.push(entity);
-      updatedKeyMap[ii] = nextEntityMap.length;
+      const nextKey = releasedKeys.length ? releasedKeys.shift() : key;
+      nextEntityMap[nextKey] = entity;
+      updatedKeyMap[key] = nextKey;
     }
   }
 

--- a/src/universal/utils/draftjs/removeEntityKeepText.js
+++ b/src/universal/utils/draftjs/removeEntityKeepText.js
@@ -1,0 +1,50 @@
+const updateBlockEntityRanges = (blocks, updatedKeyMap) => {
+  const nextBlocks = [];
+  for (let ii = 0; ii < blocks.length; ii++) {
+    const block = blocks[ii];
+    const {entityRanges} = block;
+    const nextEntityRanges = [];
+    for (let jj = 0; jj < entityRanges.length; jj++) {
+      const entityRange = entityRanges[jj];
+      const nextKey = updatedKeyMap[entityRange.key];
+      if (nextKey !== null) {
+        nextEntityRanges.push({...entityRange, key: nextKey});
+      }
+    }
+    nextBlocks.push({...block, entityRanges: nextEntityRanges});
+  }
+  return nextBlocks;
+};
+
+/*
+ * Removes the underlying entity but keeps the text in place
+ * Useful for e.g. removing a mention but keeping the name
+ */
+const removeEntityKeepText = (rawContent, eqFn) => {
+  const {blocks, entityMap} = rawContent;
+  const nextEntityMap = [];
+  // oldKey: newKey. null is a remove sentinel
+  const updatedKeyMap = {};
+  const removedEntities = [];
+  for (let ii = 0; ii < entityMap.length; ii++) {
+    const entity = entityMap[ii];
+    if (eqFn(entity)) {
+      removedEntities.push(entity);
+      updatedKeyMap[ii] = null;
+    } else {
+      nextEntityMap.push(entity);
+      updatedKeyMap[ii] = nextEntityMap.length;
+    }
+  }
+
+  return {
+    rawContent: removedEntities.length === 0 ? rawContent :
+      {
+        blocks: updateBlockEntityRanges(blocks, updatedKeyMap),
+        entityMap: nextEntityMap
+      },
+    removedEntities
+  };
+};
+
+export default removeEntityKeepText;

--- a/src/universal/utils/relay/findConnectionWithNodeId.js
+++ b/src/universal/utils/relay/findConnectionWithNodeId.js
@@ -1,0 +1,16 @@
+import findNodeInConn from 'universal/utils/relay/findNodeInConn';
+
+/*
+ * Given that a nodeId only exists in 1 of many connections
+ * Find which connection it resides in
+ */
+const findConnectionWithNodeId = (connections, nodeId) => {
+  for (let ii = 0; ii < connections.length; ii++) {
+    const connection = connections[ii];
+    const node = findNodeInConn(connection, nodeId);
+    if (node) return connection;
+  }
+  return undefined;
+};
+
+export default findConnectionWithNodeId;

--- a/src/universal/utils/relay/findNodeInConn.js
+++ b/src/universal/utils/relay/findNodeInConn.js
@@ -1,0 +1,17 @@
+const findNodeInConn = (connection, nodeId) => {
+  if (!connection) return null;
+  const edges = connection.getLinkedRecords('edges');
+  if (!edges) return null;
+  for (let ii = 0; ii < edges.length; ii++) {
+    const edge = edges[ii];
+    if (!edge) continue;
+    const node = edge.getLinkedRecord('node');
+    if (!node) continue;
+    if (node.getDataID() === nodeId) {
+      return node;
+    }
+  }
+  return null;
+};
+
+export default findNodeInConn;

--- a/src/universal/utils/relay/getAllConnections.js
+++ b/src/universal/utils/relay/getAllConnections.js
@@ -1,0 +1,18 @@
+import getRelayHandleKey from 'relay-runtime/lib/getRelayHandleKey';
+
+/*
+ * Sometimes you want all the connections that currently exist.
+ * This uses a bunch of relay interval data structures. Use with caution.
+ */
+const getAllConnections = (store, viewerId, connection) => {
+  const connectionRecordPrefix = getRelayHandleKey('connection', connection, null);
+  const mutator = store.__recordSource.__mutator;
+  const viewerRecord = mutator._base.get(viewerId);
+  if (!viewerRecord) return [];
+  const viewerIds = Object.keys(viewerRecord);
+  return viewerIds
+    .filter((id) => id.startsWith(connectionRecordPrefix))
+    .map((viewerRecordId) => store.get(mutator.getLinkedRecordID(viewerId, viewerRecordId)))
+};
+
+export default getAllConnections;

--- a/src/universal/utils/relay/getAllConnections.js
+++ b/src/universal/utils/relay/getAllConnections.js
@@ -12,7 +12,7 @@ const getAllConnections = (store, viewerId, connection) => {
   const viewerIds = Object.keys(viewerRecord);
   return viewerIds
     .filter((id) => id.startsWith(connectionRecordPrefix))
-    .map((viewerRecordId) => store.get(mutator.getLinkedRecordID(viewerId, viewerRecordId)))
+    .map((viewerRecordId) => store.get(mutator.getLinkedRecordID(viewerId, viewerRecordId)));
 };
 
 export default getAllConnections;

--- a/src/universal/utils/relay/safeRemoveNodeFromUnknownConn.js
+++ b/src/universal/utils/relay/safeRemoveNodeFromUnknownConn.js
@@ -1,0 +1,16 @@
+/*
+ * Sometimes a node may exist in 1 of many different connections.
+ * This removes it from the first one it is found in
+ */
+import getAllConnections from 'universal/utils/relay/getAllConnections';
+import findConnectionWithNodeId from 'universal/utils/relay/findConnectionWithNodeId';
+import safeRemoveNodeFromConn from 'universal/utils/relay/safeRemoveNodeFromConn';
+
+const safeRemoveNodeFromUnknownConn = (store, viewerId, connectionName, nodeId) => {
+  if (!nodeId) return;
+  const teamConnections = getAllConnections(store, viewerId, connectionName);
+  const conn = findConnectionWithNodeId(teamConnections, nodeId);
+  safeRemoveNodeFromConn(nodeId, conn);
+};
+
+export default safeRemoveNodeFromUnknownConn;


### PR DESCRIPTION
fixes #1474 

BACKGROUND
Sometimes a user creates a card and later realizes it was better suited for another team. For example, taya creates a card during a product meeting, but the task belong in exco. this allows users to do that from the my dashboard view.

TEST
- [ ] Create a new user "Jordan" in browser 1. Create Team 1 and invite User "Terry"
- [ ] As Jordan, create Team 2
- [ ] In browser 2, goto invitation url from server console and create new user "Terry"
- [ ] in browser 1, go to my Dashboard & create a new task on Team 1. See the New task card pop open in Terry's browser
- [ ] in browser 1, mention yourself and terry like `@terry` and `@jordan` 
- [ ] in browser 2, receive the mentionee notification and click "check it out"
- [ ] in browser 1, append "this is great" to the end of the card. in browser 2, see the notification update
- [ ] in browser 2, navigate to the Team 1 dash
- [ ] in browser 1, click Team 1 in the card footer and change to Team 2. See the mention turn to plaintext for terry but remain for jordan. Plaintext = no teal background & no bold letters on the name.
- [ ] in browser 2, see the notification bubble go away. see the card disappear from the Team 2 Dash
- [ ] in browser 1, change the card team back to Team 1.
- [ ] in browser 2, see the card reappear

