### PR TITLE
Password recovery

### DIFF
--- a/src/universal/components/Action/Action.js
+++ b/src/universal/components/Action/Action.js
@@ -19,6 +19,7 @@ const signout = () => System.import('universal/containers/Signout/SignoutContain
 const notFound = () => System.import('universal/components/NotFound/NotFound');
 const dashWrapper = () => System.import('universal/components/DashboardWrapper/DashboardWrapper');
 const meetingRoot = () => System.import('universal/modules/meeting/components/MeetingRoot');
+const resetPasswordPage = () => System.import('universal/components/ResetPasswordPage/ResetPasswordPage');
 const retroRoot = () => System.import('universal/components/RetroRoot/RetroRoot');
 const signInPage = () => System.import('universal/components/SignInPage/SignInPage');
 const signUpPage = () => System.import('universal/components/SignUpPage/SignUpPage');
@@ -39,6 +40,9 @@ const Action = (props) => {
         }
         {__RELEASE_FLAGS__.newSignIn &&
           <AsyncRoute exact path="/signup" mod={signUpPage} />
+        }
+        {__RELEASE_FLAGS__.newSignIn &&
+          <AsyncRoute exact path="/reset-password" mod={resetPasswordPage} />
         }
         <AsyncRoute isAbstract isPrivate path="(/me|/newteam|/team)" mod={dashWrapper} />
         <AsyncRoute isPrivate path="/meeting/:teamId/:localPhase?/:localPhaseItem?" mod={meetingRoot} />

--- a/src/universal/components/AuthPage/AuthPage.js
+++ b/src/universal/components/AuthPage/AuthPage.js
@@ -21,14 +21,16 @@ type Props = {
 const PageContainer = styled('div')({
   color: appTheme.palette.dark,
   display: 'flex',
-  flexDirection: 'column'
+  flexDirection: 'column',
+  alignItems: 'center'
 });
 
 const CenteredBlock = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  height: '100%'
+  height: '100%',
+  width: '30rem'
 });
 
 export default ({children, title}: Props) => (

--- a/src/universal/components/ErrorAlert/ErrorAlert.js
+++ b/src/universal/components/ErrorAlert/ErrorAlert.js
@@ -12,6 +12,10 @@ import FontAwesome from 'react-fontawesome';
 
 import appTheme from 'universal/styles/theme/appTheme';
 
+type Props = {
+  message: string
+};
+
 const ErrorAlertWrapper = styled('div')({
   padding: '0.5rem 1rem',
   backgroundColor: appTheme.palette.warm20a,
@@ -22,7 +26,7 @@ const SpacedIcon = styled(FontAwesome)({
   marginRight: '1rem'
 });
 
-const ErrorAlert = ({message}: {message: string}) => {
+const ErrorAlert = ({message}: Props) => {
   return (
     <ErrorAlertWrapper role="alert">
       <SpacedIcon name="exclamation-circle" />

--- a/src/universal/components/HorizontalSeparator/HorizontalSeparator.js
+++ b/src/universal/components/HorizontalSeparator/HorizontalSeparator.js
@@ -5,7 +5,7 @@
  * @flow
  */
 
-import React from 'react';
+import React, {Fragment} from 'react';
 import styled from 'react-emotion';
 
 import appTheme from 'universal/styles/theme/appTheme';
@@ -31,14 +31,25 @@ const RightSeparator = styled('div')({
   marginLeft: '0.5rem'
 });
 
+const FullSeparator = styled('div')({
+  ...separatorLineStyles,
+  width: '20rem'
+});
+
 type Props = {
-  text: string
+  text?: string
 };
 
 export default ({text}: Props) => (
   <SeparatorContainer>
-    <LeftSeparator />
-    {text}
-    <RightSeparator />
+    {text ? (
+      <Fragment>
+        <LeftSeparator />
+        {text}
+        <RightSeparator />
+      </Fragment>
+    ) : (
+      <FullSeparator />
+    )}
   </SeparatorContainer>
 );

--- a/src/universal/components/InputField/InputField.js
+++ b/src/universal/components/InputField/InputField.js
@@ -21,7 +21,7 @@ const InputField = (props) => {
     isLarger,
     isWider,
     label,
-    meta: {touched, error},
+    meta: {autofilled, dirty, error, invalid, touched},
     onButtonClick,
     placeholder,
     readyOnly,
@@ -75,7 +75,7 @@ const InputField = (props) => {
           ref={(c) => { ref = c; }}
         />
       </div>
-      {touched && error && <FieldHelpText fieldSize={fieldSize} hasErrorText helpText={error} indent />}
+      {touched && !autofilled && dirty && invalid && <FieldHelpText fieldSize={fieldSize} hasErrorText helpText={error} indent />}
       {shortcutHint && <FieldShortcutHint disabled={shortcutDisabled} hint={shortcutHint} />}
     </FieldBlock>
   );

--- a/src/universal/components/PlainButton/PlainButton.js
+++ b/src/universal/components/PlainButton/PlainButton.js
@@ -5,7 +5,9 @@ const PlainButton = styled('button')({
   background: 'inherit',
   border: 0,
   borderRadius: 0,
+  color: 'inherit',
   cursor: 'pointer',
+  fontSize: 'inherit',
   margin: 0,
   padding: 0
 });

--- a/src/universal/components/ResetPasswordPage/ResetPassword.js
+++ b/src/universal/components/ResetPasswordPage/ResetPassword.js
@@ -1,0 +1,50 @@
+/**
+ * Renders the password reset UI.
+ *
+ * @flow
+ */
+
+import React, {Fragment} from 'react';
+import styled from 'react-emotion';
+
+import PlainButton from 'universal/components/PlainButton/PlainButton';
+import ErrorAlert from 'universal/components/ErrorAlert/ErrorAlert';
+import PasswordResetForm from './ResetPasswordForm';
+
+type Props = {
+  error: ?string,
+  emailSent: boolean,
+  handleSubmitResetPassword: ({ email: string }) => Promise<any>,
+  tryAgain: () => void
+};
+
+const P = styled('p')({
+  textAlign: 'center',
+  margin: '1rem 0'
+});
+
+const LinkButton = styled(PlainButton)({
+  textDecoration: 'underline'
+});
+
+const PasswordReset = (props: Props) => (
+  <Fragment>
+    {props.error && <ErrorAlert message={props.error} />}
+    {props.emailSent ? (
+      <Fragment>
+        <P>You’re all set!</P>
+        <P>We’ve sent you an email with password recovery instructions.</P>
+        <P>
+          Didn’t get it? Check your spam folder, or <LinkButton onClick={props.tryAgain}>click here</LinkButton> to try again.
+        </P>
+      </Fragment>
+    ) : (
+      <Fragment>
+        <P>Confirm your email address, and we’ll send you an email with password recovery instructions.</P>
+        <PasswordResetForm onSubmit={props.handleSubmitResetPassword} />
+      </Fragment>
+    )}
+  </Fragment>
+);
+
+export default PasswordReset;

--- a/src/universal/components/ResetPasswordPage/ResetPasswordForm.js
+++ b/src/universal/components/ResetPasswordPage/ResetPasswordForm.js
@@ -1,0 +1,64 @@
+/**
+ * The form used to reset a password.
+ *
+ * @flow
+ */
+
+import React from 'react';
+import styled from 'react-emotion';
+import {Field, reduxForm} from 'redux-form';
+
+import Button from 'universal/components/Button/Button';
+import InputField from 'universal/components/InputField/InputField';
+import parseEmailAddressList from 'universal/utils/parseEmailAddressList';
+import shouldValidate from 'universal/validation/shouldValidate';
+
+type Props = {
+  handleSubmit: () => void, // from redux-form
+  onSubmit: ({email: string}) => Promise<any>, // from parents of this component
+  submitting: boolean,
+  valid: boolean
+};
+
+const Form = styled('form')({
+  display: 'flex',
+  flexDirection: 'column'
+});
+
+const FieldsContainer = styled('div')({
+  marginBottom: '2rem'
+});
+
+const PasswordResetForm = (props: Props) => {
+  return (
+    <Form onSubmit={props.handleSubmit}>
+      <FieldsContainer>
+        <Field
+          type="email"
+          autoFocus
+          component={InputField}
+          placeholder="you@company.co"
+          label="Email:"
+          name="email"
+          underline
+          disabled={props.submitting}
+        />
+      </FieldsContainer>
+      <Button
+        waiting={!props.valid || props.submitting}
+        type="submit"
+        label="Submit"
+        title="Submit"
+        colorPalette="warm"
+      />
+    </Form>
+  );
+};
+
+const validate = ({email}) => ({
+  email: parseEmailAddressList(email)
+    ? null
+    : 'Enter a valid email address'
+});
+
+export default reduxForm({form: 'passwordReset', shouldValidate, validate})(PasswordResetForm);

--- a/src/universal/components/ResetPasswordPage/ResetPasswordForm.js
+++ b/src/universal/components/ResetPasswordPage/ResetPasswordForm.js
@@ -45,7 +45,8 @@ const PasswordResetForm = (props: Props) => {
         />
       </FieldsContainer>
       <Button
-        waiting={!props.valid || props.submitting}
+        disabled={!props.valid}
+        waiting={props.submitting}
         type="submit"
         label="Submit"
         title="Submit"

--- a/src/universal/components/ResetPasswordPage/ResetPasswordPage.js
+++ b/src/universal/components/ResetPasswordPage/ResetPasswordPage.js
@@ -1,0 +1,79 @@
+/**
+ * The password reset page. Allows the user to reset their password via email.
+ *
+ * @flow
+ */
+
+import React, {Component} from 'react';
+import {Link} from 'react-router-dom';
+
+import AuthPage from 'universal/components/AuthPage/AuthPage';
+import HorizontalSeparator from 'universal/components/HorizontalSeparator/HorizontalSeparator';
+import {AUTH0_DB_CONNECTION} from 'universal/utils/constants';
+import getWebAuth from 'universal/utils/getWebAuth';
+import PasswordReset from './ResetPassword';
+
+type Props = {};
+
+type State = {
+  error: ?string,
+  emailSent: boolean
+};
+
+export default class PasswordResetPage extends Component<Props, State> {
+  state = {
+    error: null,
+    emailSent: false
+  };
+
+  webAuth = getWebAuth();
+
+  auth0ChangePassword = ({email}: {email: string}): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      this.webAuth.changePassword({
+        connection: AUTH0_DB_CONNECTION,
+        email
+      }, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  };
+
+  handleSubmitResetPassword = async ({email}: {email: string}): Promise<void> => {
+    try {
+      await this.auth0ChangePassword({email});
+      this.setState({emailSent: true, error: null});
+    } catch (error) {
+      this.setState({error: error.message});
+    }
+  };
+
+  resetState = () => {
+    this.setState({error: null, emailSent: false});
+  };
+
+  render() {
+    const {error, emailSent} = this.state;
+    return (
+      <AuthPage title="Reset Password | Parabol">
+        <h1>
+          Forgot your password?
+        </h1>
+        <h2>
+          <Link to="/signin">Back to Sign in</Link>
+        </h2>
+        <HorizontalSeparator />
+        <PasswordReset
+          error={error}
+          emailSent={emailSent}
+          handleSubmitResetPassword={this.handleSubmitResetPassword}
+          tryAgain={this.resetState}
+        />
+      </AuthPage>
+    );
+  }
+}

--- a/src/universal/components/SignUpPage/SignUpPage.js
+++ b/src/universal/components/SignUpPage/SignUpPage.js
@@ -14,7 +14,7 @@ import AuthPage from 'universal/components/AuthPage/AuthPage';
 import loginWithToken from 'universal/decorators/loginWithToken/loginWithToken';
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
 import auth0Login from 'universal/utils/auth0Login';
-import {THIRD_PARTY_AUTH_PROVIDERS} from 'universal/utils/constants';
+import {AUTH0_DB_CONNECTION, THIRD_PARTY_AUTH_PROVIDERS} from 'universal/utils/constants';
 import getWebAuth from 'universal/utils/getWebAuth';
 import SignUp from './SignUp';
 
@@ -47,7 +47,7 @@ class SignUpPage extends Component<Props, State> {
     return signup({
       email,
       password,
-      connection: 'Username-Password-Authentication',
+      connection: AUTH0_DB_CONNECTION,
       responseType: 'token'
     });
   };

--- a/src/universal/utils/constants.js
+++ b/src/universal/utils/constants.js
@@ -228,3 +228,6 @@ export const MENTIONEE = 'MENTIONEE';
 export const THIRD_PARTY_AUTH_PROVIDERS = [
   {displayName: 'Google', auth0Connection: 'google-oauth2', iconName: 'google'}
 ];
+
+/* Default auth0 email/password db */
+export const AUTH0_DB_CONNECTION = 'Username-Password-Authentication';


### PR DESCRIPTION
Fixes #1758.

Note that the "If you try to recover an account associated with 3rd party auth, the page complains at you" acceptance criteria is not currently met, since auth0 happily accepts a request to reset a password for a passwordless account. If we wanted to build this functionality, it would expand the scope of this work.

Testing:
- Check out the `password-recovery` branch locally
- Flip the `newSignIn` release flag to `true`
- Start the dev server
- Log out if you're already logged in
- Follow the link at the bottom of the new sign in page titled "Forgot your password?"
- Enter your email
- Check your email
- Open the email from auth0
- Reset your password using auth0's site
- Go back to your dev server
- Sign in successfully with your new credentials