### PR TITLE
Add activeProOrgCount query, implements #1803

### DIFF
--- a/src/server/graphql/queries/activeProOrgCount.js
+++ b/src/server/graphql/queries/activeProOrgCount.js
@@ -11,16 +11,14 @@ export default {
     requireSU(authToken);
 
     // RESOLUTION
+    //   per @mattkrick:
+    //
+    //     > stripe enforces at least 1 seat per customer,
+    //     > so there's no way a 1-person org could have an inactive person.
+    //
+    //   So, we can just count the pro-tier orgs:
     return r.table('Organization')
       .filter((org) => org('tier').eq('pro'))
-      .map((org) => org('orgUsers')
-        // calculate whether the org is active or not:
-        //   reduces [bool, bool, bool] => bool
-        //   where at least one false => true (active org)
-        //   all true => false (inactive org)
-        .fold(false, (acc, orgUser) => acc.or(r.not(orgUser('inactive'))))
-      )
-      // count true values in sequence (# of active orgs)
-      .count((possiblyActiveOrg) => possiblyActiveOrg);
+      .count();
   }
 };

--- a/src/server/graphql/queries/activeProOrgCount.js
+++ b/src/server/graphql/queries/activeProOrgCount.js
@@ -13,7 +13,7 @@ export default {
     // RESOLUTION
     return r.table('Organization')
       .filter((org) => org('tier').eq('pro'))
-      .map( (org) => org('orgUsers')
+      .map((org) => org('orgUsers')
         // calculate whether the org is active or not:
         //   reduces [bool, bool, bool] => bool
         //   where at least one false => true (active org)
@@ -21,6 +21,6 @@ export default {
         .fold(false, (acc, orgUser) => acc.or(r.not(orgUser('inactive'))))
       )
       // count true values in sequence (# of active orgs)
-      .count( (possiblyActiveOrg) => possiblyActiveOrg );
+      .count((possiblyActiveOrg) => possiblyActiveOrg);
   }
 };

--- a/src/server/graphql/queries/activeProOrgCount.js
+++ b/src/server/graphql/queries/activeProOrgCount.js
@@ -1,0 +1,26 @@
+import {GraphQLInt} from 'graphql';
+import getRethink from 'server/database/rethinkDriver';
+import {requireSU} from 'server/utils/authorization';
+
+export default {
+  type: GraphQLInt,
+  async resolve(source, args, {authToken}) {
+    const r = getRethink();
+
+    // AUTH
+    requireSU(authToken);
+
+    // RESOLUTION
+    return r.table('Organization')
+      .filter((org) => org('tier').eq('pro'))
+      .map( (org) => org('orgUsers')
+        // calculate whether the org is active or not:
+        //   reduces [bool, bool, bool] => bool
+        //   where at least one false => true (active org)
+        //   all true => false (inactive org)
+        .fold(false, (acc, orgUser) => acc.or(r.not(orgUser('inactive'))))
+      )
+      // count true values in sequence (# of active orgs)
+      .count( (possiblyActiveOrg) => possiblyActiveOrg );
+  }
+};

--- a/src/server/graphql/rootQuery.js
+++ b/src/server/graphql/rootQuery.js
@@ -1,11 +1,13 @@
 import {GraphQLObjectType} from 'graphql';
 import User from 'server/graphql/types/User';
 import {getUserId} from 'server/utils/authorization';
+import activeProOrgCount from 'server/graphql/queries/activeProOrgCount';
 import activeProUserCount from 'server/graphql/queries/activeProUserCount';
 
 export default new GraphQLObjectType({
   name: 'Query',
   fields: () => ({
+    activeProOrgCount,
     activeProUserCount,
     viewer: {
       type: User,


### PR DESCRIPTION
Implements #1803 

## Test Template

- [ ] go to /admin/graphql as a superuser.
type this:
```
query {
  activeProUserCount
}
```
- [ ] see the pro org user count
