### PR TITLE
Make TeamDashboard filter case-insensitive

### DIFF
--- a/src/universal/modules/teamDashboard/containers/TeamColumns/TeamColumnsContainer.js
+++ b/src/universal/modules/teamDashboard/containers/TeamColumns/TeamColumnsContainer.js
@@ -32,7 +32,7 @@ class TeamColumnsContainer extends Component {
 
   filterTasks(props) {
     const {teamMemberFilterId, viewer: {tasks, team: {contentFilter, teamMembers}}} = props;
-    const contentFilterRegex = new RegExp(contentFilter);
+    const contentFilterRegex = new RegExp(contentFilter, 'i');
     const contentFilteredEdges = contentFilter ?
       tasks.edges.filter(({node}) => {
         const {contentText} = node;
@@ -100,7 +100,7 @@ export default createFragmentContainer(
             # grab these so we can sort correctly
             id
             content @__clientField(handle: "contentText")
-            contentText 
+            contentText
             status
             sortOrder
             assignee {


### PR DESCRIPTION
Implements #1843.

Tests:

- [x] Add agenda items of mixed case to agenda
- [x] Add at least 3 Cards containing content with mixed case
- [x] Type text into the filter box, it should match agenda items
- [x] It should match also match Cards
