### PR TITLE
Stop the bork - gracefully handle server errors (Error PR 1 of 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
   },
   "pre-commit": [],
   "devDependencies": {
+    "@storybook/addon-actions": "^3.3.14",
+    "@storybook/addon-links": "^3.3.14",
+    "@storybook/addons": "^3.3.14",
+    "@storybook/react": "^3.3.14",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.1.1",
@@ -120,11 +124,7 @@
     "url-loader": "^0.5.9",
     "webpack": "^3.5.4",
     "webpack-dev-middleware": "^1.12.0",
-    "webpack-hot-middleware": "^2.18.2",
-    "@storybook/react": "^3.3.14",
-    "@storybook/addon-actions": "^3.3.14",
-    "@storybook/addon-links": "^3.3.14",
-    "@storybook/addons": "^3.3.14"
+    "webpack-hot-middleware": "^2.18.2"
   },
   "dependencies": {
     "@babel/plugin-syntax-export-default-from": "^7.0.0-beta.40",
@@ -184,8 +184,8 @@
     "node-fetch": "^1.7.2",
     "oy-vey": "0.9.0",
     "prop-types": "^15.5.10",
-    "raven": "^1.1.4",
-    "raven-js": "^3.17.0",
+    "raven": "^2.4.2",
+    "raven-js": "^3.23.1",
     "react": "^16.2.0",
     "react-addons-css-transition-group": "^15.4.2",
     "react-async-hoc": "^0.4.1",

--- a/src/server/billing/stripeWebhookHandler.js
+++ b/src/server/billing/stripeWebhookHandler.js
@@ -2,6 +2,7 @@ import schema from 'server/graphql/rootSchema';
 import {graphql} from 'graphql';
 import stripe from 'server/billing/stripe';
 import RethinkDataLoader from 'server/utils/RethinkDataLoader';
+import sendGraphQLErrorResult from 'server/utils/sendGraphQLErrorResult';
 
 const eventLookup = {
   invoice: {
@@ -100,7 +101,7 @@ const stripeWebhookHandler = (sharedDataLoader) => async (req, res) => {
   const context = {serverSecret: process.env.AUTH0_CLIENT_SECRET, dataLoader};
   const result = await graphql(schema, query, {}, context, variables);
   if (result.errors) {
-    console.log('Stripe GraphQL Error:', result.errors);
+    sendGraphQLErrorResult('Stripe', result.errors[0], query, variables);
   }
 };
 

--- a/src/server/graphql/httpGraphQLHandler.js
+++ b/src/server/graphql/httpGraphQLHandler.js
@@ -11,10 +11,7 @@ export default (sharedDataLoader) => async (req, res) => {
   const result = await graphql(Schema, query, {}, context, variables);
   dataLoader.dispose();
   if (result.errors) {
-    console.log('DEBUG GraphQL Error:', result.errors);
-  }
-  if (Array.isArray(result.errors)) {
-    result.errors = result.errors.map((err) => ({message: err.message}));
+    console.log('DEBUG GraphQL Error HTTP:', result.errors);
   }
   res.send(result);
 };

--- a/src/server/graphql/httpGraphQLHandler.js
+++ b/src/server/graphql/httpGraphQLHandler.js
@@ -2,6 +2,7 @@ import {graphql} from 'graphql';
 import RethinkDataLoader from 'server/utils/RethinkDataLoader';
 import IntranetSchema from 'server/graphql/intranetSchema/intranetSchema';
 import Schema from './rootSchema';
+import sendGraphQLErrorResult from 'server/utils/sendGraphQLErrorResult';
 
 export default (sharedDataLoader) => async (req, res) => {
   const {query, variables} = req.body;
@@ -11,7 +12,7 @@ export default (sharedDataLoader) => async (req, res) => {
   const result = await graphql(Schema, query, {}, context, variables);
   dataLoader.dispose();
   if (result.errors) {
-    console.log('DEBUG GraphQL Error HTTP:', result.errors);
+    sendGraphQLErrorResult('HTTP', result.errors[0], query, variables, authToken);
   }
   res.send(result);
 };
@@ -24,10 +25,7 @@ export const intranetHttpGraphQLHandler = (sharedDataLoader) => async (req, res)
   const result = await graphql(IntranetSchema, query, {}, context, variables);
   dataLoader.dispose();
   if (result.errors) {
-    console.log('DEBUG intranet-GraphQL Error:', result.errors);
-  }
-  if (Array.isArray(result.errors)) {
-    result.errors = result.errors.map((err) => ({message: err.message}));
+    sendGraphQLErrorResult('HTTP-Intranet', result.errors[0], query, variables, authToken);
   }
   res.send(result);
 };

--- a/src/server/integrations/handleGitHubWebhooks.js
+++ b/src/server/integrations/handleGitHubWebhooks.js
@@ -2,6 +2,7 @@ import {graphql} from 'graphql';
 import secureCompare from 'secure-compare';
 import schema from 'server/graphql/rootSchema';
 import signPayload from 'server/utils/signPayload';
+import sendGraphQLErrorResult from 'server/utils/sendGraphQLErrorResult';
 
 const getPublicKey = ({repository: {id}}) => String(id);
 
@@ -73,6 +74,6 @@ export default async (req, res) => {
   const context = {serverSecret: process.env.AUTH0_CLIENT_SECRET};
   const result = await graphql(schema, query, {}, context, variables);
   if (result.errors) {
-    console.log('GITHUB GraphQL Error:', result.errors);
+    sendGraphQLErrorResult('GitHub', result.errors[0], query, variables);
   }
 };

--- a/src/server/socketHandlers/handleMessage.js
+++ b/src/server/socketHandlers/handleMessage.js
@@ -46,8 +46,10 @@ const handleMessage = (connectionContext) => async (message) => {
       wsRelaySubscribeHandler(connectionContext, parsedMessage);
     } else {
       const result = await wsGraphQLHandler(connectionContext, parsedMessage);
-      const resultType = result.errors ? GQL_ERROR : GQL_DATA;
-      sendMessage(socket, resultType, result, opId);
+      // TODO Until we rewrite the client (because Apollo is wrong) don't send errors
+      // Even if the data is 99% good, the Apollo client nulls out the data, which brings blank screens and sads.
+      // const resultType = result.errors ? GQL_ERROR : GQL_DATA;
+      sendMessage(socket, GQL_DATA, result, opId);
     }
   } else if (type === GQL_STOP) {
     relayUnsubscribe(subs, opId);

--- a/src/server/socketHandlers/wsGraphQLHandler.js
+++ b/src/server/socketHandlers/wsGraphQLHandler.js
@@ -1,6 +1,7 @@
 import {graphql} from 'graphql';
 import Schema from 'server/graphql/rootSchema';
 import RethinkDataLoader from 'server/utils/RethinkDataLoader';
+import sendGraphQLErrorResult from 'server/utils/sendGraphQLErrorResult';
 
 export default async function wsGraphQLHandler(connectionContext, parsedMessage) {
   const {payload} = parsedMessage;
@@ -16,7 +17,7 @@ export default async function wsGraphQLHandler(connectionContext, parsedMessage)
   dataLoader.dispose();
 
   if (result.errors) {
-    console.log('DEBUG GraphQL Error:', result.errors);
+    sendGraphQLErrorResult('WebSocket', result.errors[0], query, variables, authToken);
   }
   return result;
 }

--- a/src/server/utils/RethinkDataLoader.js
+++ b/src/server/utils/RethinkDataLoader.js
@@ -17,14 +17,14 @@ const sendErrorToSentry = (authToken, key, keys, indexedResults) => {
   const error = new Error('Dataloader key not found');
   const breadcrumb = {
     message: 'Dataloader key not found',
-    category: 'graphql',
+    category: 'dataloader',
     data: {
       key,
       keys,
       indexedResults
     }
-  }
-  sendSentryEvent(error, authToken, breadcrumb)
+  };
+  sendSentryEvent(error, authToken, breadcrumb);
 };
 
 const normalizeRethinkDbResults = (keys, indexField, cacheKeyFn = defaultCacheKeyFn) => (results, authToken) => {

--- a/src/server/utils/RethinkDataLoader.js
+++ b/src/server/utils/RethinkDataLoader.js
@@ -1,6 +1,7 @@
 import DataLoader from 'dataloader';
 import getRethink from 'server/database/rethinkDriver';
 import {getUserId} from 'server/utils/authorization';
+import sendSentryEvent from 'server/utils/sendSentryEvent';
 
 const defaultCacheKeyFn = (key) => key;
 
@@ -12,20 +13,30 @@ const indexResults = (results, indexField, cacheKeyFn = defaultCacheKeyFn) => {
   return indexedResults;
 };
 
-const normalizeRethinkDbResults = (keys, indexField, cacheKeyFn = defaultCacheKeyFn) => (results) => {
-  const indexedResults = indexResults(results, indexField, cacheKeyFn);
-  // return keys.map((val) => indexedResults.get(cacheKeyFn(val)));
-  return keys.map((val) => indexedResults.get(cacheKeyFn(val)) || new Error(`Key not found : ${val}`));
+const sendErrorToSentry = (authToken, key, keys, indexedResults) => {
+  const error = new Error('Dataloader key not found');
+  const breadcrumb = {
+    message: 'Dataloader key not found',
+    category: 'graphql',
+    data: {
+      key,
+      keys,
+      indexedResults
+    }
+  }
+  sendSentryEvent(error, authToken, breadcrumb)
 };
 
-const makeStandardLoader = (table) => {
-  const batchFn = async (keys) => {
-    const r = getRethink();
-    const docs = await r.table(table)
-      .getAll(r.args(keys), {index: 'id'});
-    return normalizeRethinkDbResults(keys, 'id')(docs);
-  };
-  return new DataLoader(batchFn);
+const normalizeRethinkDbResults = (keys, indexField, cacheKeyFn = defaultCacheKeyFn) => (results, authToken) => {
+  const indexedResults = indexResults(results, indexField, cacheKeyFn);
+  // return keys.map((val) => indexedResults.get(cacheKeyFn(val)) || new Error(`Key not found : ${val}`));
+  return keys.map((val) => {
+    const res = indexedResults.get(cacheKeyFn(val));
+    if (!res) {
+      sendErrorToSentry(authToken, cacheKeyFn(val), keys, indexedResults);
+    }
+    return res;
+  });
 };
 
 const makeCustomLoader = (batchFn, options) => {
@@ -158,21 +169,30 @@ export default class RethinkDataLoader {
   _share() {
     this.authToken = null;
   }
+  makeStandardLoader(table) {
+    const batchFn = async (keys) => {
+      const r = getRethink();
+      const docs = await r.table(table)
+        .getAll(r.args(keys), {index: 'id'});
+      return normalizeRethinkDbResults(keys, 'id')(docs, this.authToken);
+    };
+    return new DataLoader(batchFn);
+  }
 
-  agendaItems = makeStandardLoader('AgendaItem');
-  customPhaseItems = makeStandardLoader('CustomPhaseItem');
-  invitations = makeStandardLoader('Invitation');
-  meetings = makeStandardLoader('Meeting');
-  meetingSettings = makeStandardLoader('MeetingSettings');
-  newMeetings = makeStandardLoader('NewMeeting');
-  notifications = makeStandardLoader('Notification');
-  orgApprovals = makeStandardLoader('OrgApproval');
-  organizations = makeStandardLoader('Organization');
-  retroThoughtGroups = makeStandardLoader('RetroThoughtGroup');
-  retroThoughts = makeStandardLoader('RetroThought');
-  softTeamMembers = makeStandardLoader('SoftTeamMember');
-  tasks = makeStandardLoader('Task');
-  teamMembers = makeStandardLoader('TeamMember');
-  teams = makeStandardLoader('Team');
-  users = makeStandardLoader('User');
+  agendaItems = this.makeStandardLoader('AgendaItem');
+  customPhaseItems = this.makeStandardLoader('CustomPhaseItem');
+  invitations = this.makeStandardLoader('Invitation');
+  meetings = this.makeStandardLoader('Meeting');
+  meetingSettings = this.makeStandardLoader('MeetingSettings');
+  newMeetings = this.makeStandardLoader('NewMeeting');
+  notifications = this.makeStandardLoader('Notification');
+  orgApprovals = this.makeStandardLoader('OrgApproval');
+  organizations = this.makeStandardLoader('Organization');
+  retroThoughtGroups = this.makeStandardLoader('RetroThoughtGroup');
+  retroThoughts = this.makeStandardLoader('RetroThought');
+  softTeamMembers = this.makeStandardLoader('SoftTeamMember');
+  tasks = this.makeStandardLoader('Task');
+  teamMembers = this.makeStandardLoader('TeamMember');
+  teams = this.makeStandardLoader('Team');
+  users = this.makeStandardLoader('User');
 }

--- a/src/server/utils/sendGraphQLErrorResult.js
+++ b/src/server/utils/sendGraphQLErrorResult.js
@@ -1,0 +1,22 @@
+import sendSentryEvent from 'server/utils/sendSentryEvent';
+
+const sendGraphQLErrorResult = (protocol, firstError, query, variables, authToken) => {
+  const message = `${protocol} GraphQL Error`;
+  if (process.env.NODE_ENV !== 'production') {
+    const error = new Error(message);
+    const breadcrumb = {
+      message,
+      category: 'graphql',
+      data: {
+        query,
+        variables,
+        firstError
+      }
+    };
+    sendSentryEvent(error, authToken, breadcrumb);
+  } else {
+    console.error(message, firstError);
+  }
+};
+
+export default sendGraphQLErrorResult;

--- a/src/server/utils/sendSentryEvent.js
+++ b/src/server/utils/sendSentryEvent.js
@@ -1,0 +1,25 @@
+import getRethink from 'server/database/rethinkDriver';
+import {getUserId} from 'server/utils/authorization';
+import Raven from 'raven';
+
+const sendSegmentEvent = async (event, authToken, breadcrumb) => {
+  const r = getRethink();
+  let user;
+  if (authToken) {
+    const userId = getUserId(authToken);
+    user = await r.table('User')
+      .get(userId)
+      .pluck('id', 'email', 'preferredName', 'picture');
+  }
+  Raven.context(() => {
+    if (user) {
+      Raven.setContext({user})
+    }
+    if (breadcrumb) {
+      Raven.captureBreadcrumb(breadcrumb);
+    }
+    Raven.captureException(event);
+  })
+};
+
+export default sendSegmentEvent;

--- a/src/server/utils/sendSentryEvent.js
+++ b/src/server/utils/sendSentryEvent.js
@@ -13,13 +13,13 @@ const sendSegmentEvent = async (event, authToken, breadcrumb) => {
   }
   Raven.context(() => {
     if (user) {
-      Raven.setContext({user})
+      Raven.setContext({user});
     }
     if (breadcrumb) {
       Raven.captureBreadcrumb(breadcrumb);
     }
     Raven.captureException(event);
-  })
+  });
 };
 
 export default sendSegmentEvent;

--- a/src/universal/Atmosphere.js
+++ b/src/universal/Atmosphere.js
@@ -116,11 +116,11 @@ export default class Atmosphere extends Environment {
       this.subscriptionClient.operations[opId] = {
         options: payload,
         handler: (errors, result) => {
-          if (errors) {
-            reject(errors[0]);
-          } else {
-            delete this.subscriptionClient.operations[opId];
+          delete this.subscriptionClient.operations[opId];
+          if (result) {
             resolve(result);
+          } else {
+            reject(errors && errors[0]);
           }
         }
       };
@@ -144,12 +144,7 @@ export default class Atmosphere extends Environment {
         variables
       })
     });
-    const resJson = await res.json();
-    const {errors} = resJson;
-    if (errors) {
-      throw new Error(errors[0].message);
-    }
-    return resJson;
+    return res.json();
   };
 
   setSocket = () => {

--- a/src/universal/utils/jwtFields.js
+++ b/src/universal/utils/jwtFields.js
@@ -1,0 +1,1 @@
+export default ['iss', 'sub', 'aud', 'iat', 'exp', 'tms', 'bet'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,6 +2472,10 @@ change-case@^2.3.0:
     upper-case "^1.1.1"
     upper-case-first "^1.1.0"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -2970,6 +2974,10 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -5387,6 +5395,10 @@ is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
+is-buffer@~1.1.1:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
 is-builtin-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
@@ -6204,7 +6216,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@5.0.1, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -6782,10 +6794,6 @@ lru-memoizer@^1.11.1:
     lru-cache "~4.0.0"
     very-fast-args "^1.1.0"
 
-lsmod@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
-
 macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
@@ -6872,6 +6880,14 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+md5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 mdurl@^1.0.1:
   version "1.0.1"
@@ -8439,18 +8455,22 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@^3.1.1, raven-js@^3.17.0:
+raven-js@^3.1.1:
   version "3.19.1"
   resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.19.1.tgz#a5d25646556fc2c86d2b188ae4f425c144c08dd8"
 
-raven@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/raven/-/raven-1.2.1.tgz#949c134db028a190b7bbf8f790aae541b7c020bd"
+raven-js@^3.23.1:
+  version "3.23.1"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.23.1.tgz#34a5d7b5b3dd626a3d59e7a264e1d19a4c799cdb"
+
+raven@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/raven/-/raven-2.4.2.tgz#0129e2adc30788646fd530b67d08a8ce25d4f6dc"
   dependencies:
     cookie "0.3.1"
-    json-stringify-safe "5.0.1"
-    lsmod "1.0.0"
+    md5 "^2.2.1"
     stack-trace "0.0.9"
+    timed-out "4.0.1"
     uuid "3.0.0"
 
 raw-body@2.3.2, raw-body@^2.2.0:
@@ -10290,6 +10310,10 @@ thunkify@^2.1.2:
 time-stamp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357"
+
+timed-out@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
 timers-browserify@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
Recently, we've been fighting too many fires.
We goof up, and instead of that goof up gracefully landing in sentry, the customer's screen goes white & there are no errors in the console.
This fixes that. Fixes #1774

There were a few things going wrong:
- The dataloader would throw an error if there was a missing foreign key. Albeit if a foreign key doesn't exist, it is 100% our fault, but the penalty for failure was too severe (blank screen of death). Now, we log it and send down the null value to the client. It's then up to the client to handle it gracefully
- The client was not handling errors gracefully for HTTP requests. This was my fault. I now pass whatever values, good or bad, into relay & then we can handle it with onError callbacks if need be.
- The client was not handling errors gracefully for websocket requests. This was Apollo's fault. When GraphQL encounters an error, it sends the data that it _could_ fetch, plus the error that it encountered. _Apollo ignores all that beautiful 99% correct data_. I can't fix this without rewriting the client, so for now, I trick it by having the server tell it it's not an error. 
- We weren't sending any errors to sentry from the server. Now we do, so we no longer have to `dokku logs web`. yay! 

TEST
- [ ] Create 2 users, as user A, assign a task to user B so they get a "TASK_INVOLVES" notification, exit the browser for user A.
- [ ] go into the database (localhost:8080) find that notification & change the type to "X"
- [ ] Refresh the page, notice it doesn't white screen.
- [ ] look at the server log (locally), notice it shows an error
- [ ] run `yarn bs` & use the SENTRY_DNS key that's on the staging server environment, or just run this on the dev server. Repeat the steps. Instead of seeing an error in the server console, you see nothing, but an error does show up in sentry (example: https://sentry.io/parabol/action-staging/issues/484351180/)
- [ ] go into the database & revert the type back to TASK_INVOLVES but now set the notification's taskId to 'X'.
- [ ] Refresh & notice there isn't a blank white page
- [ ] Get a similar message sent to sentry (example: https://sentry.io/parabol/action-staging/issues/484298502/events/15455592846/)