### PR TITLE
trivial fix to tierProBillingLeaderCount

### DIFF
--- a/src/server/graphql/queries/helpers/countTiersForUserId.js
+++ b/src/server/graphql/queries/helpers/countTiersForUserId.js
@@ -36,7 +36,10 @@ const countTiersForUserId = (userId) => {
           acc('tierProBillingLeaderCount'),
           r.branch(
             org('tier').default(PERSONAL).eq(PRO),
-            org('orgUsers').count((ou) => ou('role').eq('billingLeader')),
+            org('orgUsers').count((ou) => r.and(
+              ou('id').eq(userId),
+              ou('role').default('').eq('billingLeader')
+            )),
             0
           )
         )


### PR DESCRIPTION
Counts the orgs for only which userId is a billing leader