### PR TITLE
1746 voting backend [BASE: #1910]

### DIFF
--- a/src/server/database/migrations/20180320152455-voteSettings.js
+++ b/src/server/database/migrations/20180320152455-voteSettings.js
@@ -1,0 +1,43 @@
+import {RETROSPECTIVE} from 'universal/utils/constants';
+
+exports.up = async (r) => {
+  try {
+    await r.tableCreate('MeetingMember');
+  } catch (e) {
+    // noop
+  }
+  try {
+    await Promise.all([
+      r.table('MeetingMember').indexCreate('meetingId'),
+      r.table('MeetingMember').indexCreate('teamId'),
+      r.table('MeetingMember').indexCreate('userId')
+    ]);
+  } catch (e) {
+    // noop
+  }
+  try {
+    await r.table('MeetingSettings')
+      .filter({meetingType: RETROSPECTIVE})
+      .update({
+        totalVotes: 5,
+        maxVotesPerGroup: 3
+      });
+  } catch (e) {
+    // noop
+  }
+};
+
+exports.down = async (r) => {
+  try {
+    await r.table('MeetingSettings')
+      .filter({meetingType: RETROSPECTIVE})
+      .replace((settings) => settings.without('totalVotes', 'maxVotesPerGroup'));
+  } catch (e) {
+    // noop
+  }
+  try {
+    await r.tableDrop('MeetingMember');
+  } catch (e) {
+    // noop
+  }
+};

--- a/src/server/database/migrations/20180320200910-fix-retroReflection.js
+++ b/src/server/database/migrations/20180320200910-fix-retroReflection.js
@@ -1,0 +1,17 @@
+import {CHECKIN, DISCUSS, GROUP, REFLECT, RETROSPECTIVE, VOTE} from 'universal/utils/constants';
+
+exports.up = async (r) => {
+  try {
+    await r.table('MeetingSettings')
+      .filter({meetingType: RETROSPECTIVE})
+      .update({
+        phaseTypes: [CHECKIN, REFLECT, GROUP, VOTE, DISCUSS]
+      });
+  } catch (e) {
+    // noop
+  }
+};
+
+exports.down = async () => {
+  // noop
+};

--- a/src/server/graphql/mutations/helpers/addTeamMemberToNewMeeting.js
+++ b/src/server/graphql/mutations/helpers/addTeamMemberToNewMeeting.js
@@ -25,13 +25,13 @@ const addTeamMemberToNewMeeting = async (teamMember, teamId, dataLoader) => {
   const meetingMember = createMeetingMember(meetingId, meetingType)(teamMember);
   await r({
     meeting: r.table('NewMeeting')
-    .get(meetingId)
-    .update({
-      phases,
-      updatedAt: now
-    }),
+      .get(meetingId)
+      .update({
+        phases,
+        updatedAt: now
+      }),
     member: r.table('MeetingMember').insert(meetingMember)
-});
+  });
   return true;
 };
 

--- a/src/server/graphql/mutations/helpers/addTeamMemberToNewMeeting.js
+++ b/src/server/graphql/mutations/helpers/addTeamMemberToNewMeeting.js
@@ -1,6 +1,7 @@
 import {CHECKIN} from 'universal/utils/constants';
 import getRethink from 'server/database/rethinkDriver';
 import {makeCheckInStage} from 'server/graphql/mutations/helpers/makeCheckinStages';
+import createMeetingMember from 'server/graphql/mutations/helpers/createMeetingMember';
 
 /*
  * NewMeetings have a predefined set of stages, we need to add the new team member manually
@@ -14,19 +15,23 @@ const addTeamMemberToNewMeeting = async (teamMember, teamId, dataLoader) => {
   // make sure it's a new meeting
   const newMeeting = await r.table('NewMeeting').get(meetingId).default(null);
   if (!newMeeting) return false;
-  const {phases} = newMeeting;
+  const {meetingType, phases} = newMeeting;
   const checkInPhase = phases.find((phase) => phase.phaseType === CHECKIN);
   if (!checkInPhase) return false;
 
   const {stages} = checkInPhase;
   const newStage = makeCheckInStage(teamMember, meetingId, false);
   stages.push(newStage);
-  await r.table('NewMeeting')
+  const meetingMember = createMeetingMember(meetingId, meetingType)(teamMember);
+  await r({
+    meeting: r.table('NewMeeting')
     .get(meetingId)
     .update({
       phases,
       updatedAt: now
-    });
+    }),
+    member: r.table('MeetingMember').insert(meetingMember)
+});
   return true;
 };
 

--- a/src/server/graphql/mutations/helpers/createMeetingMember.js
+++ b/src/server/graphql/mutations/helpers/createMeetingMember.js
@@ -1,0 +1,13 @@
+import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
+
+const createMeetingMember = (meetingId, meetingType) => (teamMember) => ({
+  id: toTeamMemberId(meetingId, teamMember.userId),
+  isCheckedIn: null,
+  meetingId,
+  meetingType,
+  teamId: teamMember.teamId,
+  userId: teamMember.userId,
+  updatedAt: new Date()
+});
+
+export default createMeetingMember;

--- a/src/server/graphql/mutations/helpers/extendMeetingMembersForType.js
+++ b/src/server/graphql/mutations/helpers/extendMeetingMembersForType.js
@@ -3,8 +3,9 @@ import {RETROSPECTIVE} from 'universal/utils/constants';
 const extendNewMeetingForType = async (meetingMembers, dataLoader) => {
   const {meetingType, teamId} = meetingMembers[0];
   if (meetingType === RETROSPECTIVE) {
-    const meetingSettings = await dataLoader.get('meetingSettingsByTeamId').load(teamId);
-    const {totalVotes} = meetingSettings;
+    const allSettings = await dataLoader.get('meetingSettingsByTeamId').load(teamId);
+    const retroSettings = allSettings.find((settings) => settings.meetingType === RETROSPECTIVE);
+    const {totalVotes} = retroSettings;
     return meetingMembers.map((member) => ({
       ...member,
       votesRemaining: totalVotes

--- a/src/server/graphql/mutations/helpers/extendMeetingMembersForType.js
+++ b/src/server/graphql/mutations/helpers/extendMeetingMembersForType.js
@@ -1,0 +1,16 @@
+import {RETROSPECTIVE} from 'universal/utils/constants';
+
+const extendNewMeetingForType = async (meetingMembers, dataLoader) => {
+  const {meetingType, teamId} = meetingMembers[0];
+  if (meetingType === RETROSPECTIVE) {
+    const meetingSettings = await dataLoader.get('meetingSettingsByTeamId').load(teamId);
+    const {totalVotes} = meetingSettings;
+    return meetingMembers.map((member) => ({
+      ...member,
+      votesRemaining: totalVotes
+    }));
+  }
+  return meetingMembers;
+};
+
+export default extendNewMeetingForType;

--- a/src/server/graphql/mutations/helpers/safelyCastVote.js
+++ b/src/server/graphql/mutations/helpers/safelyCastVote.js
@@ -1,0 +1,49 @@
+import {sendMaxVotesPerGroupError, sendNoVotesLeftError} from 'server/utils/alreadyMutatedErrors';
+import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
+import getRethink from 'server/database/rethinkDriver';
+
+const safelyCastVote = async (authToken, meetingId, userId, reflectionGroupId, maxVotesPerGroup) => {
+  const meetingMemberId = toTeamMemberId(meetingId, userId);
+  const r = getRethink();
+  const now = new Date();
+
+  const isVoteRemovedFromUser = await r.table('MeetingMember')
+    .get(meetingMemberId)
+    .update((member) => {
+      // go atomic. no cheating allowed
+      return r.branch(
+        member('votesRemaining').ge(1),
+        {
+          updatedAt: now,
+          votesRemaining: member('votesRemaining').sub(1)
+        },
+        {}
+      );
+    })('replaced')
+    .eq(1);
+  if (!isVoteRemovedFromUser) return sendNoVotesLeftError(authToken, reflectionGroupId, maxVotesPerGroup);
+  const isVoteAddedToGroup = await r.table('RetroReflectionGroup')
+    .get(reflectionGroupId)
+    .update((group) => {
+      return r.branch(
+        group('voterIds').count(userId).lt(maxVotesPerGroup),
+        {
+          updatedAt: now,
+          voterIds: group('voterIds').append(userId)
+        },
+        {}
+      );
+    })('replaced')
+    .eq(1);
+  if (!isVoteAddedToGroup) {
+    await r.table('MeetingMember')
+      .get(meetingMemberId)
+      .update((member) => ({
+        votesRemaining: member('votesRemaining').add(1)
+      }));
+    return sendMaxVotesPerGroupError(authToken, reflectionGroupId);
+  }
+  return undefined;
+};
+
+export default safelyCastVote;

--- a/src/server/graphql/mutations/helpers/safelyWithdrawVote.js
+++ b/src/server/graphql/mutations/helpers/safelyWithdrawVote.js
@@ -1,0 +1,33 @@
+import {sendAlreadyRemovedVoteError} from 'server/utils/alreadyMutatedErrors';
+import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
+import getRethink from 'server/database/rethinkDriver';
+
+const safelyWithdrawVote = async (authToken, meetingId, userId, reflectionGroupId) => {
+  const meetingMemberId = toTeamMemberId(meetingId, userId);
+  const r = getRethink();
+  const now = new Date();
+
+  const isVoteRemovedFromGroup = await r.table('RetroReflectionGroup')
+    .get(reflectionGroupId)
+    .update((group) => {
+      return r.branch(
+        group('voterIds').offsetsOf(userId).count().ge(1),
+        {
+          updatedAt: now,
+          voterIds: group('voterIds').deleteAt(group('voterIds').offsetsOf(userId).nth(0))
+        },
+        {}
+      );
+    })('replaced')
+    .eq(1);
+  if (!isVoteRemovedFromGroup) return sendAlreadyRemovedVoteError(authToken, reflectionGroupId);
+  await r.table('MeetingMember')
+    .get(meetingMemberId)
+    .update((member) => ({
+      updatedAt: now,
+      votesRemaining: member('votesRemaining').add(1)
+    }));
+  return undefined;
+};
+
+export default safelyWithdrawVote;

--- a/src/server/graphql/mutations/newMeetingCheckIn.js
+++ b/src/server/graphql/mutations/newMeetingCheckIn.js
@@ -6,7 +6,7 @@ import {TEAM} from 'universal/utils/constants';
 import {sendTeamAccessError} from 'server/utils/authorizationErrors';
 import NewMeetingCheckInPayload from 'server/graphql/types/NewMeetingCheckInPayload';
 import {sendAlreadyEndedMeetingError} from 'server/utils/alreadyMutatedErrors';
-import {sendMeetingMemberNotFoundError, sendMeetingNotFoundError} from 'server/utils/docNotFoundErrors';
+import {sendMeetingNotFoundError} from 'server/utils/docNotFoundErrors';
 import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
 
 export default {
@@ -40,13 +40,9 @@ export default {
 
     // RESOLUTION
     const meetingMemberId = toTeamMemberId(meetingId, userId);
-    const success = await r.table('MeetingMember')
+    await r.table('MeetingMember')
       .get(meetingMemberId)
-      .update({isCheckedIn})
-      .default(null)('replaced')
-      .eq(1);
-
-    if (!success) return sendMeetingMemberNotFoundError(authToken, meetingId);
+      .update({isCheckedIn});
 
     const data = {meetingId, userId};
     publish(TEAM, teamId, NewMeetingCheckInPayload, data, subOptions);

--- a/src/server/graphql/mutations/newMeetingCheckIn.js
+++ b/src/server/graphql/mutations/newMeetingCheckIn.js
@@ -1,0 +1,55 @@
+import {GraphQLBoolean, GraphQLID, GraphQLNonNull} from 'graphql';
+import getRethink from 'server/database/rethinkDriver';
+import {isTeamMember} from 'server/utils/authorization';
+import publish from 'server/utils/publish';
+import {TEAM} from 'universal/utils/constants';
+import {sendTeamAccessError} from 'server/utils/authorizationErrors';
+import NewMeetingCheckInPayload from 'server/graphql/types/NewMeetingCheckInPayload';
+import {sendAlreadyEndedMeetingError} from 'server/utils/alreadyMutatedErrors';
+import {sendMeetingMemberNotFoundError, sendMeetingNotFoundError} from 'server/utils/docNotFoundErrors';
+import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
+
+export default {
+  type: NewMeetingCheckInPayload,
+  description: 'Check a member in as present or absent',
+  args: {
+    userId: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'The id of the user being marked present or absent'
+    },
+    meetingId: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'the meeting currently in progress'
+    },
+    isCheckedIn: {
+      type: GraphQLBoolean,
+      description: 'true if the member is present, false if absent, null if undecided'
+    }
+  },
+  async resolve(source, {userId, meetingId, isCheckedIn}, {authToken, dataLoader, socketId: mutatorId}) {
+    const r = getRethink();
+    const operationId = dataLoader.share();
+    const subOptions = {mutatorId, operationId};
+
+    // AUTH
+    const meeting = await r.table('NewMeeting').get(meetingId).default(null);
+    if (!meeting) return sendMeetingNotFoundError(authToken, meetingId);
+    const {endedAt, teamId} = meeting;
+    if (endedAt) return sendAlreadyEndedMeetingError(authToken, meetingId);
+    if (!isTeamMember(authToken, teamId)) return sendTeamAccessError(authToken, teamId);
+
+    // RESOLUTION
+    const meetingMemberId = toTeamMemberId(meetingId, userId);
+    const success = await r.table('MeetingMember')
+      .get(meetingMemberId)
+      .update({isCheckedIn})
+      .default(null)('replaced')
+      .eq(1);
+
+    if (!success) return sendMeetingMemberNotFoundError(authToken, meetingId);
+
+    const data = {meetingId, userId};
+    publish(TEAM, teamId, NewMeetingCheckInPayload, data, subOptions);
+    return data;
+  }
+};

--- a/src/server/graphql/mutations/startNewMeeting.js
+++ b/src/server/graphql/mutations/startNewMeeting.js
@@ -12,8 +12,8 @@ import {startSlackMeeting} from 'server/graphql/mutations/helpers/notifySlack';
 import {sendTeamAccessError} from 'server/utils/authorizationErrors';
 import {sendAlreadyStartedMeetingError} from 'server/utils/alreadyMutatedErrors';
 import sendAuthRaven from 'server/utils/sendAuthRaven';
-import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
 import extendMeetingMembersForType from 'server/graphql/mutations/helpers/extendMeetingMembersForType';
+import createMeetingMember from 'server/graphql/mutations/helpers/createMeetingMember';
 
 export default {
   type: StartNewMeetingPayload,
@@ -76,15 +76,8 @@ export default {
     };
     const newMeeting = extendNewMeetingForType(newMeetingBase);
     const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId);
-    const meetingMembersBase = teamMembers.map((teamMember) => ({
-      id: toTeamMemberId(meetingId, teamMember.userId),
-      isCheckedIn: null,
-      meetingId,
-      meetingType,
-      teamId,
-      userId: teamMember.userId,
-      updatedAt: now
-    }));
+    const createMemberForMeeting = createMeetingMember(meetingId, meetingType);
+    const meetingMembersBase = teamMembers.map(createMemberForMeeting);
     const meetingMembers = await extendMeetingMembersForType(meetingMembersBase);
     await r({
       team: r.table('Team').get(teamId)

--- a/src/server/graphql/mutations/startNewMeeting.js
+++ b/src/server/graphql/mutations/startNewMeeting.js
@@ -78,7 +78,7 @@ export default {
     const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId);
     const createMemberForMeeting = createMeetingMember(meetingId, meetingType);
     const meetingMembersBase = teamMembers.map(createMemberForMeeting);
-    const meetingMembers = await extendMeetingMembersForType(meetingMembersBase);
+    const meetingMembers = await extendMeetingMembersForType(meetingMembersBase, dataLoader);
     await r({
       team: r.table('Team').get(teamId)
         .update({meetingId}),

--- a/src/server/graphql/mutations/voteForReflectionGroup.js
+++ b/src/server/graphql/mutations/voteForReflectionGroup.js
@@ -1,0 +1,67 @@
+import {GraphQLBoolean, GraphQLID, GraphQLNonNull} from 'graphql';
+import getRethink from 'server/database/rethinkDriver';
+import {getUserId, isTeamMember} from 'server/utils/authorization';
+import {sendTeamAccessError} from 'server/utils/authorizationErrors';
+import {sendMeetingMemberNotFoundError, sendReflectionGroupNotFoundError} from 'server/utils/docNotFoundErrors';
+import {sendAlreadyCompletedMeetingPhaseError, sendAlreadyEndedMeetingError} from 'server/utils/alreadyMutatedErrors';
+import publish from 'server/utils/publish';
+import {TEAM, VOTE} from 'universal/utils/constants';
+import isPhaseComplete from 'universal/utils/meetings/isPhaseComplete';
+import VoteForReflectionGroupPayload from 'server/graphql/types/VoteForReflectionGroupPayload';
+import safelyCastVote from 'server/graphql/mutations/helpers/safelyCastVote';
+import safelyWithdrawVote from 'server/graphql/mutations/helpers/safelyWithdrawVote';
+
+
+export default {
+  type: VoteForReflectionGroupPayload,
+  description: 'Cast your vote for a reflection group',
+  args: {
+    isUnvote: {
+      type: GraphQLBoolean,
+      description: 'true if the user wants to remove one of their votes'
+    },
+    reflectionGroupId: {
+      type: new GraphQLNonNull(GraphQLID)
+    }
+  },
+  async resolve(source, {isUnvote, reflectionGroupId}, {authToken, dataLoader, socketId: mutatorId}) {
+    const r = getRethink();
+    const operationId = dataLoader.share();
+    const subOptions = {operationId, mutatorId};
+
+    // AUTH
+    const viewerId = getUserId(authToken);
+    const reflectionGroup = await r.table('RetroReflectionGroup').get(reflectionGroupId);
+    if (!reflectionGroup) return sendReflectionGroupNotFoundError(authToken, reflectionGroupId);
+    const {meetingId} = reflectionGroup;
+    const meeting = await dataLoader.get('newMeetings').load(meetingId);
+    const {endedAt, phases, teamId} = meeting;
+    if (!isTeamMember(authToken, teamId)) return sendTeamAccessError(authToken, teamId);
+    if (endedAt) return sendAlreadyEndedMeetingError(authToken, meetingId);
+    if (isPhaseComplete(VOTE, phases)) return sendAlreadyCompletedMeetingPhaseError(authToken, VOTE);
+
+    // VALIDATION
+    const meetingMember = await r.table('MeetingMember')
+      .getAll(meetingId, {index: 'meetingId'})
+      .filter({userId: viewerId})
+      .nth(0)
+      .default(null);
+    if (!meetingMember) return sendMeetingMemberNotFoundError(authToken, meetingId);
+
+    // RESOLUTION
+    if (isUnvote) {
+      const votingError = await safelyWithdrawVote(authToken, meetingId, viewerId, reflectionGroupId);
+      if (votingError) return votingError;
+    } else {
+      const meetingSettings = dataLoader.get('meetingSettingsByTeamId').load(teamId);
+      const {maxVotesPerGroup} = meetingSettings;
+      const votingError = await safelyCastVote(authToken, meetingId, viewerId, reflectionGroupId, maxVotesPerGroup);
+      if (votingError) return votingError;
+    }
+
+    const data = {meetingId, userId: viewerId, reflectionGroupId};
+    publish(TEAM, teamId, VoteForReflectionGroupPayload, data, subOptions);
+    return data;
+  }
+};
+

--- a/src/server/graphql/mutations/voteForReflectionGroup.js
+++ b/src/server/graphql/mutations/voteForReflectionGroup.js
@@ -5,7 +5,7 @@ import {sendTeamAccessError} from 'server/utils/authorizationErrors';
 import {sendMeetingMemberNotFoundError, sendReflectionGroupNotFoundError} from 'server/utils/docNotFoundErrors';
 import {sendAlreadyCompletedMeetingPhaseError, sendAlreadyEndedMeetingError} from 'server/utils/alreadyMutatedErrors';
 import publish from 'server/utils/publish';
-import {TEAM, VOTE} from 'universal/utils/constants';
+import {RETROSPECTIVE, TEAM, VOTE} from 'universal/utils/constants';
 import isPhaseComplete from 'universal/utils/meetings/isPhaseComplete';
 import VoteForReflectionGroupPayload from 'server/graphql/types/VoteForReflectionGroupPayload';
 import safelyCastVote from 'server/graphql/mutations/helpers/safelyCastVote';
@@ -53,8 +53,9 @@ export default {
       const votingError = await safelyWithdrawVote(authToken, meetingId, viewerId, reflectionGroupId);
       if (votingError) return votingError;
     } else {
-      const meetingSettings = dataLoader.get('meetingSettingsByTeamId').load(teamId);
-      const {maxVotesPerGroup} = meetingSettings;
+      const allSettings = await dataLoader.get('meetingSettingsByTeamId').load(teamId);
+      const retroSettings = allSettings.find((settings) => settings.meetingType === RETROSPECTIVE);
+      const {maxVotesPerGroup} = retroSettings;
       const votingError = await safelyCastVote(authToken, meetingId, viewerId, reflectionGroupId, maxVotesPerGroup);
       if (votingError) return votingError;
     }

--- a/src/server/graphql/resolvers.js
+++ b/src/server/graphql/resolvers.js
@@ -1,5 +1,6 @@
 import {getUserId, isSuperUser} from 'server/utils/authorization';
 import nullIfEmpty from 'universal/utils/nullIfEmpty';
+import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
 
 export const resolveAgendaItem = ({agendaItemId, agendaItem}, args, {dataLoader}) => {
   return agendaItemId ? dataLoader.get('agendaItems').load(agendaItemId) : agendaItem;
@@ -51,6 +52,11 @@ export const makeResolveNotificationsForViewer = (idArray, docArray) => async (s
   if (!notificationDocs) return null;
   const viewerNotifications = notificationDocs.filter((n) => n.userIds.includes(viewerId));
   return nullIfEmpty(viewerNotifications);
+};
+
+export const resolveMeetingMember = ({meetingId, userId}, args, {dataLoader}) => {
+  const meetingMemberId = toTeamMemberId(meetingId, userId);
+  return dataLoader.get('meetingMembers').load(meetingMemberId);
 };
 
 export const resolveNotifications = ({notificationIds, notifications}, args, {dataLoader}) => {

--- a/src/server/graphql/rootMutation.js
+++ b/src/server/graphql/rootMutation.js
@@ -75,6 +75,7 @@ import updateReflectionLocation from 'server/graphql/mutations/updateReflectionL
 import removeReflection from 'server/graphql/mutations/removeReflection';
 import createReflectionGroup from 'server/graphql/mutations/createReflectionGroup';
 import updateReflectionGroupTitle from 'server/graphql/mutations/updateReflectionGroupTitle';
+import voteForReflectionGroup from 'server/graphql/mutations/voteForReflectionGroup';
 
 export default new GraphQLObjectType({
   name: 'Mutation',
@@ -153,6 +154,7 @@ export default new GraphQLObjectType({
     updateTask,
     updateTeamName,
     updateUserProfile,
+    voteForReflectionGroup,
     login,
     upgradeToPro
   })

--- a/src/server/graphql/rootMutation.js
+++ b/src/server/graphql/rootMutation.js
@@ -76,6 +76,7 @@ import removeReflection from 'server/graphql/mutations/removeReflection';
 import createReflectionGroup from 'server/graphql/mutations/createReflectionGroup';
 import updateReflectionGroupTitle from 'server/graphql/mutations/updateReflectionGroupTitle';
 import voteForReflectionGroup from 'server/graphql/mutations/voteForReflectionGroup';
+import newMeetingCheckIn from 'server/graphql/mutations/newMeetingCheckIn';
 
 export default new GraphQLObjectType({
   name: 'Mutation',
@@ -120,6 +121,7 @@ export default new GraphQLObjectType({
     moveMeeting,
     moveTeamToOrg,
     navigateMeeting,
+    newMeetingCheckIn,
     promoteFacilitator,
     promoteNewMeetingFacilitator,
     promoteToTeamLead,

--- a/src/server/graphql/rootSchema.js
+++ b/src/server/graphql/rootSchema.js
@@ -11,6 +11,7 @@ import ReflectPhase from 'server/graphql/types/ReflectPhase';
 import CheckInPhase from 'server/graphql/types/CheckInPhase';
 import RetrospectiveMeetingSettings from 'server/graphql/types/RetrospectiveMeetingSettings';
 import ActionMeetingSettings from 'server/graphql/types/ActionMeetingSettings';
+import RetrospectiveMeetingMember from 'server/graphql/types/RetrospectiveMeetingMember';
 
 export default new GraphQLSchema({
   query,
@@ -24,6 +25,7 @@ export default new GraphQLSchema({
     NotifyPromoteToOrgLeader,
     RetroPhaseItem,
     RetrospectiveMeeting,
+    RetrospectiveMeetingMember,
     RetrospectiveMeetingSettings,
     ActionMeetingSettings
   ]

--- a/src/server/graphql/types/MeetingMember.js
+++ b/src/server/graphql/types/MeetingMember.js
@@ -1,8 +1,8 @@
 import {GraphQLBoolean, GraphQLID, GraphQLInterfaceType, GraphQLNonNull} from 'graphql';
 import GraphQLISO8601Type from 'server/graphql/types/GraphQLISO8601Type';
-import RetrospectiveMeeting from 'server/graphql/types/RetrospectiveMeeting';
 import MeetingTypeEnum from 'server/graphql/types/MeetingTypeEnum';
 import {RETROSPECTIVE} from 'universal/utils/constants';
+import RetrospectiveMeetingMember from 'server/graphql/types/RetrospectiveMeetingMember';
 
 export const meetingMemberFields = () => ({
   id: {
@@ -31,15 +31,16 @@ export const meetingMemberFields = () => ({
   }
 });
 
-const resolveTypeLookup = {
-  [RETROSPECTIVE]: RetrospectiveMeeting
-};
-
 const MeetingMember = new GraphQLInterfaceType({
   name: 'MeetingMember',
   description: 'All the user details for a specific meeting',
   fields: meetingMemberFields,
-  resolveType: ({meetingType}) => resolveTypeLookup[meetingType]
+  resolveType: ({meetingType}) => {
+    const resolveTypeLookup = {
+      [RETROSPECTIVE]: RetrospectiveMeetingMember
+    };
+    return resolveTypeLookup[meetingType];
+  }
 });
 
 export default MeetingMember;

--- a/src/server/graphql/types/MeetingMember.js
+++ b/src/server/graphql/types/MeetingMember.js
@@ -1,0 +1,45 @@
+import {GraphQLBoolean, GraphQLID, GraphQLInterfaceType, GraphQLNonNull} from 'graphql';
+import GraphQLISO8601Type from 'server/graphql/types/GraphQLISO8601Type';
+import RetrospectiveMeeting from 'server/graphql/types/RetrospectiveMeeting';
+import MeetingTypeEnum from 'server/graphql/types/MeetingTypeEnum';
+import {RETROSPECTIVE} from 'universal/utils/constants';
+
+export const meetingMemberFields = () => ({
+  id: {
+    type: new GraphQLNonNull(GraphQLID),
+    description: 'A composite of userId::meetingId'
+  },
+  isCheckedIn: {
+    type: GraphQLBoolean,
+    description: 'true if present, false if absent, else null'
+  },
+  meetingId: {
+    type: GraphQLID
+  },
+  meetingType: {
+    type: new GraphQLNonNull(MeetingTypeEnum)
+  },
+  teamId: {
+    type: GraphQLID
+  },
+  userId: {
+    type: GraphQLID
+  },
+  updatedAt: {
+    type: GraphQLISO8601Type,
+    description: 'The last time a meeting was updated (stage completed, finished, etc)'
+  }
+});
+
+const resolveTypeLookup = {
+  [RETROSPECTIVE]: RetrospectiveMeeting
+};
+
+const MeetingMember = new GraphQLInterfaceType({
+  name: 'MeetingMember',
+  description: 'All the user details for a specific meeting',
+  fields: meetingMemberFields,
+  resolveType: ({meetingType}) => resolveTypeLookup[meetingType]
+});
+
+export default MeetingMember;

--- a/src/server/graphql/types/NewMeeting.js
+++ b/src/server/graphql/types/NewMeeting.js
@@ -64,15 +64,16 @@ export const newMeetingFields = () => ({
   }
 });
 
-const resolveTypeLookup = {
-  [RETROSPECTIVE]: RetrospectiveMeeting
-};
-
 const NewMeeting = new GraphQLInterfaceType({
   name: 'NewMeeting',
   description: 'A team meeting history for all previous meetings',
   fields: newMeetingFields,
-  resolveType: ({meetingType}) => resolveTypeLookup[meetingType]
+  resolveType: ({meetingType}) => {
+    const resolveTypeLookup = {
+      [RETROSPECTIVE]: RetrospectiveMeeting
+    };
+    return resolveTypeLookup[meetingType];
+  }
 });
 
 export default NewMeeting;

--- a/src/server/graphql/types/NewMeetingCheckInPayload.js
+++ b/src/server/graphql/types/NewMeetingCheckInPayload.js
@@ -1,0 +1,19 @@
+import {GraphQLObjectType} from 'graphql';
+import {resolveMeetingMember} from 'server/graphql/resolvers';
+import StandardMutationError from 'server/graphql/types/StandardMutationError';
+import MeetingMember from 'server/graphql/types/MeetingMember';
+
+const NewMeetingCheckInPayload = new GraphQLObjectType({
+  name: 'NewMeetingCheckInPayload',
+  fields: () => ({
+    error: {
+      type: StandardMutationError
+    },
+    meetingMember: {
+      type: MeetingMember,
+      resolve: resolveMeetingMember
+    }
+  })
+});
+
+export default NewMeetingCheckInPayload;

--- a/src/server/graphql/types/RetroReflectionGroup.js
+++ b/src/server/graphql/types/RetroReflectionGroup.js
@@ -58,7 +58,7 @@ const RetroReflectionGroup = new GraphQLObjectType({
     },
     voterIds: {
       type: new GraphQLList(GraphQLID),
-      description: 'A list of voterIds (teamMemberId or anonymousTeamMemberId). Not available to team to preserve anonymity',
+      description: 'A list of voterIds (userIds). Not available to team to preserve anonymity',
       resolve: resolveForSU('voterIds')
     },
     voteCount: {

--- a/src/server/graphql/types/RetrospectiveMeetingMember.js
+++ b/src/server/graphql/types/RetrospectiveMeetingMember.js
@@ -1,0 +1,16 @@
+import {GraphQLInt, GraphQLNonNull, GraphQLObjectType} from 'graphql';
+import MeetingMember, {meetingMemberFields} from 'server/graphql/types/MeetingMember';
+
+const RetrospectiveMeetingMember = new GraphQLObjectType({
+  name: 'RetrospectiveMeetingMember',
+  interfaces: () => [MeetingMember],
+  description: 'All the meeting specifics for a user in a retro meeting',
+  fields: () => ({
+    ...meetingMemberFields(),
+    votesRemaining: {
+      type: new GraphQLNonNull(GraphQLInt)
+    }
+  })
+});
+
+export default RetrospectiveMeetingMember;

--- a/src/server/graphql/types/RetrospectiveMeetingSettings.js
+++ b/src/server/graphql/types/RetrospectiveMeetingSettings.js
@@ -1,4 +1,4 @@
-import {GraphQLList, GraphQLNonNull, GraphQLObjectType} from 'graphql';
+import {GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType} from 'graphql';
 import CustomPhaseItem from 'server/graphql/types/CustomPhaseItem';
 import TeamMeetingSettings, {teamMeetingSettingsFields} from 'server/graphql/types/TeamMeetingSettings';
 import {RETROSPECTIVE} from 'universal/utils/constants';
@@ -16,6 +16,14 @@ const RetrospectiveMeetingSettings = new GraphQLObjectType({
         const customPhaseItems = await dataLoader.get('customPhaseItemsByTeamId').load(teamId);
         return customPhaseItems.filter(({phaseItemType}) => phaseItemType === RETROSPECTIVE);
       }
+    },
+    totalVotes: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: 'The total number of votes each team member receives for the voting phase'
+    },
+    maxVotesPerGroup: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: 'The maximum number of votes a team member can vote for a single reflection group'
     }
   })
 });

--- a/src/server/graphql/types/Team.js
+++ b/src/server/graphql/types/Team.js
@@ -21,7 +21,7 @@ import {TaskConnection} from 'server/graphql/types/Task';
 import TeamMember from 'server/graphql/types/TeamMember';
 import TierEnum from 'server/graphql/types/TierEnum';
 import {PENDING} from 'server/utils/serverConstants';
-import {resolveOrganization} from 'server/graphql/resolvers';
+import {resolveNewMeeting, resolveOrganization} from 'server/graphql/resolvers';
 import SoftTeamMember from 'server/graphql/types/SoftTeamMember';
 import CustomPhaseItem from 'server/graphql/types/CustomPhaseItem';
 import NewMeeting from 'server/graphql/types/NewMeeting';
@@ -139,9 +139,7 @@ const Team = new GraphQLObjectType({
     newMeeting: {
       type: NewMeeting,
       description: 'The new meeting in progress, if any',
-      resolve: ({meetingId}, args, {dataLoader}) => {
-        return meetingId ? dataLoader.get('newMeetings').load(meetingId) : null;
-      }
+      resolve: resolveNewMeeting
     },
     tier: {
       type: TierEnum,

--- a/src/server/graphql/types/TeamMember.js
+++ b/src/server/graphql/types/TeamMember.js
@@ -1,4 +1,4 @@
-import {GraphQLBoolean, GraphQLID, GraphQLInt, GraphQLObjectType, GraphQLString} from 'graphql';
+import {GraphQLNonNull, GraphQLBoolean, GraphQLID, GraphQLInt, GraphQLObjectType, GraphQLString} from 'graphql';
 import {forwardConnectionArgs} from 'graphql-relay';
 import connectionFromTasks from 'server/graphql/queries/helpers/connectionFromTasks';
 import {resolveTeam} from 'server/graphql/resolvers';
@@ -11,6 +11,8 @@ import Team from 'server/graphql/types/Team';
 import User from 'server/graphql/types/User';
 import {getUserId} from 'server/utils/authorization';
 import Assignee from 'server/graphql/types/Assignee';
+import MeetingMember from 'server/graphql/types/MeetingMember';
+import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
 
 const TeamMember = new GraphQLObjectType({
   name: 'TeamMember',
@@ -71,6 +73,19 @@ const TeamMember = new GraphQLObjectType({
       resolve: (source, args, {authToken}) => {
         const userId = getUserId(authToken);
         return source.userId === userId;
+      }
+    },
+    meetingMember: {
+      type: MeetingMember,
+      description: 'The meeting specifics for the meeting the team member is currently in',
+      args: {
+        meetingId: {
+          type: new GraphQLNonNull(GraphQLID)
+        }
+      },
+      resolve: ({userId}, {meetingId}, {dataLoader}) => {
+        const meetingMemberId = toTeamMemberId(meetingId, userId);
+        return dataLoader.get('meetingMembers').load(meetingMemberId);
       }
     },
     /* Foreign keys */

--- a/src/server/graphql/types/TeamSubscriptionPayload.js
+++ b/src/server/graphql/types/TeamSubscriptionPayload.js
@@ -26,6 +26,7 @@ import RemoveReflectionPayload from 'server/graphql/types/RemoveReflectionPayloa
 import CreateReflectionGroupPayload from 'server/graphql/types/CreateReflectionGroupPayload';
 import UpdateReflectionGroupTitlePayload from 'server/graphql/types/UpdateReflectionGroupTitlePayload';
 import VoteForReflectionGroupPayload from 'server/graphql/types/VoteForReflectionGroupPayload';
+import NewMeetingCheckInPayload from 'server/graphql/types/NewMeetingCheckInPayload';
 
 
 const types = [
@@ -39,6 +40,7 @@ const types = [
   KillNewMeetingPayload,
   MoveMeetingPayload,
   NavigateMeetingPayload,
+  NewMeetingCheckInPayload,
   PromoteFacilitatorPayload,
   PromoteNewMeetingFacilitatorPayload,
   RequestFacilitatorPayload,

--- a/src/server/graphql/types/TeamSubscriptionPayload.js
+++ b/src/server/graphql/types/TeamSubscriptionPayload.js
@@ -25,6 +25,7 @@ import UpdateReflectionLocationPayload from 'server/graphql/types/UpdateReflecti
 import RemoveReflectionPayload from 'server/graphql/types/RemoveReflectionPayload';
 import CreateReflectionGroupPayload from 'server/graphql/types/CreateReflectionGroupPayload';
 import UpdateReflectionGroupTitlePayload from 'server/graphql/types/UpdateReflectionGroupTitlePayload';
+import VoteForReflectionGroupPayload from 'server/graphql/types/VoteForReflectionGroupPayload';
 
 
 const types = [
@@ -53,7 +54,8 @@ const types = [
   UpdateReflectionGroupTitlePayload,
   UpdateReflectionLocationPayload,
   UpdateTeamNamePayload,
-  UpgradeToProPayload
+  UpgradeToProPayload,
+  VoteForReflectionGroupPayload
 ];
 
 export default graphQLSubscriptionType('TeamSubscriptionPayload', types);

--- a/src/server/graphql/types/VoteForReflectionGroupPayload.js
+++ b/src/server/graphql/types/VoteForReflectionGroupPayload.js
@@ -1,0 +1,33 @@
+import {GraphQLObjectType} from 'graphql';
+import {makeResolve, resolveNewMeeting} from 'server/graphql/resolvers';
+import StandardMutationError from 'server/graphql/types/StandardMutationError';
+import NewMeeting from 'server/graphql/types/NewMeeting';
+import RetroReflectionGroup from 'server/graphql/types/RetroReflectionGroup';
+import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
+import MeetingMember from 'server/graphql/types/MeetingMember';
+
+const VoteForReflectionGroupPayload = new GraphQLObjectType({
+  name: 'VoteForReflectionGroupPayload',
+  fields: () => ({
+    error: {
+      type: StandardMutationError
+    },
+    meeting: {
+      type: NewMeeting,
+      resolve: resolveNewMeeting
+    },
+    reflectionGroup: {
+      type: RetroReflectionGroup,
+      resolve: makeResolve('reflectionGroupId', 'reflectionGroup', 'retroReflectionGroups')
+    },
+    meetingMember: {
+      type: MeetingMember,
+      resolve: ({meetingId, userId}, args, {dataLoader}) => {
+        const meetingMemberId = toTeamMemberId(meetingId, userId);
+        return dataLoader.get('meetingMembers').load(meetingMemberId);
+      }
+    }
+  })
+});
+
+export default VoteForReflectionGroupPayload;

--- a/src/server/graphql/types/VoteForReflectionGroupPayload.js
+++ b/src/server/graphql/types/VoteForReflectionGroupPayload.js
@@ -1,9 +1,8 @@
 import {GraphQLObjectType} from 'graphql';
-import {makeResolve, resolveNewMeeting} from 'server/graphql/resolvers';
+import {makeResolve, resolveMeetingMember, resolveNewMeeting} from 'server/graphql/resolvers';
 import StandardMutationError from 'server/graphql/types/StandardMutationError';
 import NewMeeting from 'server/graphql/types/NewMeeting';
 import RetroReflectionGroup from 'server/graphql/types/RetroReflectionGroup';
-import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
 import MeetingMember from 'server/graphql/types/MeetingMember';
 
 const VoteForReflectionGroupPayload = new GraphQLObjectType({
@@ -22,10 +21,7 @@ const VoteForReflectionGroupPayload = new GraphQLObjectType({
     },
     meetingMember: {
       type: MeetingMember,
-      resolve: ({meetingId, userId}, args, {dataLoader}) => {
-        const meetingMemberId = toTeamMemberId(meetingId, userId);
-        return dataLoader.get('meetingMembers').load(meetingMemberId);
-      }
+      resolve: resolveMeetingMember
     }
   })
 });

--- a/src/server/utils/RethinkDataLoader.js
+++ b/src/server/utils/RethinkDataLoader.js
@@ -185,6 +185,7 @@ export default class RethinkDataLoader {
   invitations = this.makeStandardLoader('Invitation');
   meetings = this.makeStandardLoader('Meeting');
   meetingSettings = this.makeStandardLoader('MeetingSettings');
+  meetingMembers = this.makeStandardLoader('MeetingMember');
   newMeetings = this.makeStandardLoader('NewMeeting');
   notifications = this.makeStandardLoader('Notification');
   orgApprovals = this.makeStandardLoader('OrgApproval');

--- a/src/server/utils/alreadyMutatedErrors.js
+++ b/src/server/utils/alreadyMutatedErrors.js
@@ -100,3 +100,29 @@ export const sendAlreadyProTierError = (authToken, orgId) => {
   return sendAuthRaven(authToken, 'Easy there', breadcrumb);
 };
 
+export const sendAlreadyRemovedVoteError = (authToken, reflectionGroupId) => {
+  const breadcrumb = {
+    message: 'You’ve already removed that vote',
+    category: 'Already removed vote',
+    data: {reflectionGroupId}
+  };
+  return sendAuthRaven(authToken, 'Easy there', breadcrumb);
+};
+
+export const sendNoVotesLeftError = (authToken, reflectionGroupId) => {
+  const breadcrumb = {
+    message: 'You’re all out of votes!',
+    category: 'Out of votes',
+    data: {reflectionGroupId}
+  };
+  return sendAuthRaven(authToken, 'Easy there', breadcrumb);
+};
+
+export const sendMaxVotesPerGroupError = (authToken, reflectionGroupId, maxVotesPerGroup) => {
+  const breadcrumb = {
+    message: `Unfortunately, you can only vote ${maxVotesPerGroup} times per theme`,
+    category: 'Max votes per theme',
+    data: {reflectionGroupId}
+  };
+  return sendAuthRaven(authToken, 'Feeling passionate? We like that', breadcrumb);
+};

--- a/src/server/utils/docNotFoundErrors.js
+++ b/src/server/utils/docNotFoundErrors.js
@@ -72,15 +72,6 @@ export const sendMeetingNotFoundError = (authToken, meetingId, returnValue) => {
   return sendAuthRaven(authToken, 'Meeting Not Found', breadcrumb, returnValue);
 };
 
-export const sendMeetingMemberNotFoundError = (authToken, meetingId, returnValue) => {
-  const breadcrumb = {
-    message: 'Meeting member not found',
-    category: 'Not found',
-    data: {meetingId}
-  };
-  return sendAuthRaven(authToken, 'Meeting details for user not found', breadcrumb, returnValue);
-};
-
 export const sendReflectionNotFoundError = (authToken, reflectionId, returnValue) => {
   const breadcrumb = {
     message: 'Reflection ID not found',

--- a/src/server/utils/docNotFoundErrors.js
+++ b/src/server/utils/docNotFoundErrors.js
@@ -72,6 +72,15 @@ export const sendMeetingNotFoundError = (authToken, meetingId, returnValue) => {
   return sendAuthRaven(authToken, 'Meeting Not Found', breadcrumb, returnValue);
 };
 
+export const sendMeetingMemberNotFoundError = (authToken, meetingId, returnValue) => {
+  const breadcrumb = {
+    message: 'Meeting member not found',
+    category: 'Not found',
+    data: {meetingId}
+  };
+  return sendAuthRaven(authToken, 'Meeting details for user not found', breadcrumb, returnValue);
+};
+
 export const sendReflectionNotFoundError = (authToken, reflectionId, returnValue) => {
   const breadcrumb = {
     message: 'Reflection ID not found',

--- a/src/server/utils/sendSentryEvent.js
+++ b/src/server/utils/sendSentryEvent.js
@@ -36,7 +36,7 @@ type AuthToken = {
 
 const sendSentryEvent = async (authToken?: AuthToken, breadcrumb?: Breadcrumb) => {
   if (process.env.NODE_ENV !== 'production') {
-    console.error(breadcrumb);
+    console.error(JSON.stringify(breadcrumb));
     return;
   }
   const r = getRethink();

--- a/src/universal/components/NewMeetingCheckIn.js
+++ b/src/universal/components/NewMeetingCheckIn.js
@@ -13,12 +13,12 @@ import MeetingSection from 'universal/modules/meeting/components/MeetingSection/
 import MeetingFacilitationHint from 'universal/modules/meeting/components/MeetingFacilitationHint/MeetingFacilitationHint';
 import MeetingControlBar from 'universal/modules/meeting/components/MeetingControlBar/MeetingControlBar';
 import CheckInControls from 'universal/modules/meeting/components/CheckInControls/CheckInControls';
-import MeetingCheckInMutation from 'universal/mutations/MeetingCheckInMutation';
 import ui from 'universal/styles/ui';
 import styled from 'react-emotion';
 import NewMeetingCheckInPrompt from 'universal/modules/meeting/components/MeetingCheckInPrompt/NewMeetingCheckInPrompt';
 import findStageAfterId from 'universal/utils/meetings/findStageAfterId';
 import {CHECKIN} from 'universal/utils/constants';
+import NewMeetingCheckInMutation from 'universal/mutations/NewMeetingCheckInMutation';
 
 const CheckIn = styled('div')({
   display: 'flex',
@@ -55,11 +55,11 @@ type Props = {
 const NewMeetingCheckIn = (props: Props) => {
   const {atmosphere, gotoNext, onError, onCompleted, submitMutation, submitting, team} = props;
   const {newMeeting} = team;
-  const {facilitator: {facilitatorName, facilitatorUserId}, localStage: {localStageId, teamMember}, phases} = newMeeting;
-  const makeCheckinPressFactory = (teamMemberId) => (isCheckedIn) => () => {
+  const {meetingId, facilitator: {facilitatorName, facilitatorUserId}, localStage: {localStageId, teamMember}, phases} = newMeeting;
+  const makeCheckinPressFactory = (userId) => (isCheckedIn) => () => {
     if (submitting) return;
     submitMutation();
-    MeetingCheckInMutation(atmosphere, teamMemberId, isCheckedIn, onError, onCompleted);
+    NewMeetingCheckInMutation(atmosphere, {meetingId, userId, isCheckedIn}, onError, onCompleted);
     gotoNext(localStageId);
   };
   const {isSelf: isMyMeetingSection} = teamMember;
@@ -99,7 +99,7 @@ const NewMeetingCheckIn = (props: Props) => {
       {isFacilitating &&
       <MeetingControlBar>
         <CheckInControls
-          checkInPressFactory={makeCheckinPressFactory(teamMember.id)}
+          checkInPressFactory={makeCheckinPressFactory(teamMember.userId)}
           currentMemberName={teamMember.preferredName}
           nextMemberName={nextMemberName}
         />
@@ -115,6 +115,7 @@ export default createFragmentContainer(
     fragment NewMeetingCheckIn_team on Team {
       ...NewMeetingCheckInPrompt_team
       newMeeting {
+        meetingId: id
         facilitatorStageId
         facilitator {
           facilitatorUserId: id

--- a/src/universal/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatar.js
+++ b/src/universal/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatar.js
@@ -92,7 +92,7 @@ const NewMeetingAvatar = (props: Props) => {
   const {facilitatorUserId, localPhase, localStage} = newMeeting || {};
   const localPhaseType = localPhase && localPhase.phaseType;
   const canNavigate = localPhaseType === CHECKIN || localPhaseType === UPDATES;
-  const {teamMemberId, isConnected, isSelf, isCheckedIn, picture = defaultUserAvatar, userId} = teamMember;
+  const {teamMemberId, isConnected, isSelf, meetingMember: {isCheckedIn}, picture = defaultUserAvatar, userId} = teamMember;
   const avatarIsFacilitating = userId === facilitatorUserId;
   const handleNavigate = canNavigate ? gotoStage : undefined;
   return (
@@ -137,7 +137,9 @@ export default createFragmentContainer(
   graphql`
     fragment NewMeetingAvatar_teamMember on TeamMember {
       teamMemberId: id
-      isCheckedIn
+      meetingMember(meetingId: $meetingId) {
+        isCheckedIn 
+      }
       isConnected
       isSelf
       picture

--- a/src/universal/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatar.js
+++ b/src/universal/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatar.js
@@ -92,7 +92,8 @@ const NewMeetingAvatar = (props: Props) => {
   const {facilitatorUserId, localPhase, localStage} = newMeeting || {};
   const localPhaseType = localPhase && localPhase.phaseType;
   const canNavigate = localPhaseType === CHECKIN || localPhaseType === UPDATES;
-  const {teamMemberId, isConnected, isSelf, meetingMember: {isCheckedIn}, picture = defaultUserAvatar, userId} = teamMember;
+  const {teamMemberId, isConnected, isSelf, meetingMember, picture = defaultUserAvatar, userId} = teamMember;
+  const isCheckedIn = meetingMember ? meetingMember.isCheckedIn : null;
   const avatarIsFacilitating = userId === facilitatorUserId;
   const handleNavigate = canNavigate ? gotoStage : undefined;
   return (
@@ -137,7 +138,7 @@ export default createFragmentContainer(
   graphql`
     fragment NewMeetingAvatar_teamMember on TeamMember {
       teamMemberId: id
-      meetingMember(meetingId: $meetingId) {
+      meetingMember {
         isCheckedIn 
       }
       isConnected

--- a/src/universal/modules/meeting/components/NewMeetingAvatarMenu.js
+++ b/src/universal/modules/meeting/components/NewMeetingAvatarMenu.js
@@ -38,7 +38,7 @@ type Props = {
 const NewMeetingAvatarMenu = (props: Props) => {
   const {atmosphere, dispatch, newMeeting, teamMember, closePortal, handleNavigate} = props;
   const {localPhase, facilitatorUserId, meetingId} = newMeeting || {};
-  const {isCheckedIn, isConnected, isSelf, preferredName, userId} = teamMember;
+  const {meetingMember: {isCheckedIn}, isConnected, isSelf, preferredName, userId} = teamMember;
   const connected = isConnected ? 'connected' : 'disconnected';
   const checkedIn = isCheckedIn ? ' and checked in' : '';
   const headerLabel = `${isSelf ? 'You are' : `${preferredName} is`} ${connected} ${checkedIn}`;
@@ -84,7 +84,9 @@ export default createFragmentContainer(
       }
     }
     fragment NewMeetingAvatarMenu_teamMember on TeamMember {
-      isCheckedIn
+      meetingMember(meetingId: $meetingId) {
+        isCheckedIn
+      }
       isConnected
       isSelf
       preferredName

--- a/src/universal/modules/meeting/components/NewMeetingAvatarMenu.js
+++ b/src/universal/modules/meeting/components/NewMeetingAvatarMenu.js
@@ -38,7 +38,8 @@ type Props = {
 const NewMeetingAvatarMenu = (props: Props) => {
   const {atmosphere, dispatch, newMeeting, teamMember, closePortal, handleNavigate} = props;
   const {localPhase, facilitatorUserId, meetingId} = newMeeting || {};
-  const {meetingMember: {isCheckedIn}, isConnected, isSelf, preferredName, userId} = teamMember;
+  const {meetingMember, isConnected, isSelf, preferredName, userId} = teamMember;
+  const isCheckedIn = meetingMember ? meetingMember.isCheckedIn : null;
   const connected = isConnected ? 'connected' : 'disconnected';
   const checkedIn = isCheckedIn ? ' and checked in' : '';
   const headerLabel = `${isSelf ? 'You are' : `${preferredName} is`} ${connected} ${checkedIn}`;
@@ -84,7 +85,7 @@ export default createFragmentContainer(
       }
     }
     fragment NewMeetingAvatarMenu_teamMember on TeamMember {
-      meetingMember(meetingId: $meetingId) {
+      meetingMember {
         isCheckedIn
       }
       isConnected

--- a/src/universal/mutations/NewMeetingCheckInMutation.js
+++ b/src/universal/mutations/NewMeetingCheckInMutation.js
@@ -1,0 +1,38 @@
+import {commitMutation} from 'react-relay';
+import toTeamMemberId from 'universal/utils/relay/toTeamMemberId';
+
+graphql`
+  fragment NewMeetingCheckInMutation_team on NewMeetingCheckInPayload {
+    meetingMember {
+      isCheckedIn
+    }
+  }
+`;
+
+const mutation = graphql`
+  mutation NewMeetingCheckInMutation($meetingId: ID!, $userId: ID!, $isCheckedIn: Boolean) {
+    newMeetingCheckIn(meetingId: $meetingId, userId: $userId, isCheckedIn: $isCheckedIn) {
+      error {
+        message
+      }
+      ...NewMeetingCheckInMutation_team @relay(mask: false)
+    }
+  }
+`;
+
+const NewMeetingCheckInMutation = (environment, variables, onError, onCompleted) => {
+  return commitMutation(environment, {
+    mutation,
+    variables,
+    optimisticUpdater: (store) => {
+      const {meetingId, userId, isCheckedIn} = variables;
+      const meetingMemberId = toTeamMemberId(meetingId, userId);
+      store.get(meetingMemberId)
+        .setValue(isCheckedIn, 'isCheckedIn');
+    },
+    onCompleted,
+    onError
+  });
+};
+
+export default NewMeetingCheckInMutation;

--- a/src/universal/subscriptions/TeamSubscription.js
+++ b/src/universal/subscriptions/TeamSubscription.js
@@ -26,6 +26,7 @@ const subscription = graphql`
       ...KillNewMeetingMutation_team @relay(mask: false)
       ...MoveMeetingMutation_team @relay(mask: false)
       ...NavigateMeetingMutation_team @relay(mask: false)
+      ...NewMeetingCheckInMutation_team @relay(mask: false)
       ...PromoteFacilitatorMutation_team @relay(mask: false)
       ...PromoteNewMeetingFacilitatorMutation_team @relay(mask: false)
       ...RemoveTeamMemberMutation_team @relay(mask: false)
@@ -99,6 +100,8 @@ const TeamSubscription = (environment, queryVariables, subParams) => {
         case 'MoveMeetingPayload':
           break;
         case 'NavigateMeetingPayload':
+          break;
+        case 'NewMeetingCheckInPayload':
           break;
         case 'PromoteFacilitatorPayload':
           promoteFacilitatorTeamUpdater(payload, viewerId, dispatch);


### PR DESCRIPTION
adds a single mutation that handles casting a vote & withdrawing a vote.
Since a vote is transactional (take something from table A, put it in table B), i had to write it in such a way that guaranteed atomicity. It's pretty verbose, but this is one of the most common attacks there is (think starbucks giftcards, apple giftcards... basically it's a way to get free giftcards)

fixes #1746 

this also fixes #1915 because that was required in order to build voting.