### PR TITLE
Fix incorrect flow type import

### DIFF
--- a/src/universal/components/NewMeetingWithLocalState.js
+++ b/src/universal/components/NewMeetingWithLocalState.js
@@ -2,6 +2,7 @@
 import React, {Component} from 'react';
 
 import type {Match, RouterHistory} from 'react-router-dom';
+import type {MeetingTypeEnum} from 'universal/types/schema.flow';
 import {withRouter} from 'react-router-dom';
 import {createFragmentContainer} from 'react-relay';
 import findKeyByValue from 'universal/utils/findKeyByValue';
@@ -9,7 +10,6 @@ import {meetingTypeToSlug, phaseTypeToSlug} from 'universal/utils/meetings/looku
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
 import {withLocationMeetingState_viewer as Viewer} from './__generated__/NewMeetingWithLocalState_viewer.graphql';
 import NewMeeting from 'universal/components/NewMeeting';
-import MeetingTypeEnum from 'server/graphql/types/MeetingTypeEnum';
 import fromStageIdToUrl from 'universal/utils/meetings/fromStageIdToUrl';
 import updateLocalStage from 'universal/utils/relay/updateLocalStage';
 import getIsNavigable from 'universal/utils/meetings/getIsNavigable';


### PR DESCRIPTION
Fixes #1918

Test: run `npm NODE_ENV=production WEBPACK_MIN=true webpack --config ./webpack/prod.babel.js` and do NOT see red warning about unexpected `[` token.