### PR TITLE
fix #1863 assign private tasks to others

### DIFF
--- a/src/server/graphql/mutations/updateTask.js
+++ b/src/server/graphql/mutations/updateTask.js
@@ -131,7 +131,7 @@ export default {
     const {notificationsToRemove, notificationsToAdd} = await publishChangeNotifications(newTask, task, viewerId, usersToIgnore);
     const data = {isPrivatized, taskId, notificationsToAdd, notificationsToRemove};
     teamMembers.forEach(({userId}) => {
-      if (isPublic || userId === newTask.userId) {
+      if (isPublic || userId === newTask.userId || userId === viewerId) {
         publish(TASK, userId, UpdateTaskPayload, data, subOptions);
       }
     });

--- a/src/universal/mutations/UpdateTaskMutation.js
+++ b/src/universal/mutations/UpdateTaskMutation.js
@@ -48,7 +48,10 @@ export const updateTaskTaskUpdater = (payload, store, viewerId, options) => {
 
   const addedNotification = payload.getLinkedRecord('addedNotification');
   handleAddNotifications(addedNotification, store, viewerId);
-  ContentFilterHandler.update(store, {dataID: task.getDataID(), fieldKey: 'content'});
+  if (task) {
+    ContentFilterHandler.update(store, {dataID: task.getDataID(), fieldKey: 'content'});
+  }
+
   if (options) {
     popInvolvementToast(addedNotification, options);
   }


### PR DESCRIPTION
TEST
- [ ] go to team dash, create a new task, assign it to someone else, mark it as private, see it go away
