### PR TITLE
1871 fix filter

### DIFF
--- a/src/universal/components/LoadableTeamDashTeamMemberMenu.js
+++ b/src/universal/components/LoadableTeamDashTeamMemberMenu.js
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react';
+import {DEFAULT_MENU_HEIGHT, DEFAULT_MENU_WIDTH, HUMAN_ADDICTION_THRESH, MAX_WAIT_TIME} from 'universal/styles/ui';
+import Loadable from 'react-loadable';
+import LoadableLoading from 'universal/components/LoadableLoading';
+
+const LoadableTeamDashTeamMemberMenu = Loadable({
+  loader: () => System.import(
+    /* webpackChunkName: 'TeamDashTeamMemberMenu' */
+    'universal/components/TeamDashTeamMemberMenu'
+  ),
+  loading: (props) => <LoadableLoading {...props} height={DEFAULT_MENU_HEIGHT} width={DEFAULT_MENU_WIDTH} />,
+  delay: HUMAN_ADDICTION_THRESH,
+  timeout: MAX_WAIT_TIME
+});
+
+export default LoadableTeamDashTeamMemberMenu;

--- a/src/universal/components/LoadableUserDashTeamMenu.js
+++ b/src/universal/components/LoadableUserDashTeamMenu.js
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react';
+import {DEFAULT_MENU_HEIGHT, DEFAULT_MENU_WIDTH, HUMAN_ADDICTION_THRESH, MAX_WAIT_TIME} from 'universal/styles/ui';
+import Loadable from 'react-loadable';
+import LoadableLoading from 'universal/components/LoadableLoading';
+
+const LoadableUserDashTeamMenu = Loadable({
+  loader: () => System.import(
+    /* webpackChunkName: 'UserDashTeamMenu' */
+    'universal/components/UserDashTeamMenu'
+  ),
+  loading: (props) => <LoadableLoading {...props} height={DEFAULT_MENU_HEIGHT} width={DEFAULT_MENU_WIDTH} />,
+  delay: HUMAN_ADDICTION_THRESH,
+  timeout: MAX_WAIT_TIME
+});
+
+export default LoadableUserDashTeamMenu;

--- a/src/universal/components/TeamDashTeamMemberMenu.js
+++ b/src/universal/components/TeamDashTeamMemberMenu.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import {createFragmentContainer} from 'react-relay';
+import MenuWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuWithShortcuts';
+import MenuItemWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuItemWithShortcuts';
+import {filterTeamMember} from 'universal/modules/teamDashboard/ducks/teamDashDuck';
+import type {TeamDashTeamMemberMenu_team as Team} from './__generated__/TeamDashTeamMemberMenu_team.graphql';
+
+import type {Dispatch} from 'react-redux';
+import {connect} from 'react-redux';
+import {textOverflow} from 'universal/styles/helpers';
+import ui from 'universal/styles/ui';
+import appTheme from 'universal/styles/theme/appTheme';
+import styled from 'react-emotion';
+
+type Props = {
+  closePortal: () => void,
+  dispatch: Dispatch<*>,
+  team: Team,
+  teamMemberFilterId: ?string,
+}
+
+const Label = styled('div')({
+  ...textOverflow,
+  borderBottom: `1px solid ${appTheme.palette.mid30l}`,
+  color: ui.palette.dark,
+  fontSize: ui.menuItemFontSize,
+  fontWeight: 600,
+  lineHeight: ui.menuItemHeight,
+  marginBottom: ui.menuGutterVertical,
+  padding: `0 ${ui.menuGutterHorizontal}`
+});
+
+const TeamDashTeamMemberMenu = (props: Props) => {
+  const {closePortal, dispatch, team, teamMemberFilterId} = props;
+  const {teamMembers} = team;
+  const defaultActiveIdx = teamMembers.findIndex((teamMember) => teamMember.id === teamMemberFilterId) + 2;
+  return (
+    <MenuWithShortcuts
+      ariaLabel={'Select the team member to filter by'}
+      closePortal={closePortal}
+      defaultActiveIdx={defaultActiveIdx}
+    >
+      <Label notMenuItem>{'Filter by:'}</Label>
+      <MenuItemWithShortcuts
+        key={'teamMemberFilterNULL'}
+        label={'All members'}
+        onClick={() => dispatch(filterTeamMember(null))}
+      />
+      {
+        teamMembers.map((teamMember) => (
+          <MenuItemWithShortcuts
+            key={`teamMemberFilter${teamMember.id}`}
+            label={teamMember.preferredName}
+            onClick={() => dispatch(filterTeamMember(teamMember.id, teamMember.preferredName))}
+          />
+        ))
+      }
+    </MenuWithShortcuts>
+  );
+};
+
+export default createFragmentContainer(
+  connect()(TeamDashTeamMemberMenu),
+  graphql`
+    fragment TeamDashTeamMemberMenu_team on Team {
+      teamMembers(sortBy: "preferredName") {
+        id
+        preferredName
+      }
+    }
+  `
+);

--- a/src/universal/components/UserDashTeamMenu.js
+++ b/src/universal/components/UserDashTeamMenu.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import MenuWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuWithShortcuts';
+import MenuItemWithShortcuts from 'universal/modules/menu/components/MenuItem/MenuItemWithShortcuts';
+import type {Team} from 'universal/types/schema.flow';
+import type {Dispatch} from 'react-redux';
+import {connect} from 'react-redux';
+import {textOverflow} from 'universal/styles/helpers';
+import ui from 'universal/styles/ui';
+import appTheme from 'universal/styles/theme/appTheme';
+import styled from 'react-emotion';
+import {filterTeam} from 'universal/modules/userDashboard/ducks/userDashDuck';
+
+type Props = {
+  closePortal: () => void,
+  dispatch: Dispatch<*>,
+  teams: Array<Team>,
+  teamFilterId: ?string,
+}
+
+const Label = styled('div')({
+  ...textOverflow,
+  borderBottom: `1px solid ${appTheme.palette.mid30l}`,
+  color: ui.palette.dark,
+  fontSize: ui.menuItemFontSize,
+  fontWeight: 600,
+  lineHeight: ui.menuItemHeight,
+  marginBottom: ui.menuGutterVertical,
+  padding: `0 ${ui.menuGutterHorizontal}`
+});
+
+const UserDashTeamMenu = (props: Props) => {
+  const {closePortal, dispatch, teams, teamFilterId} = props;
+  const defaultActiveIdx = teams.findIndex((team) => team.id === teamFilterId) + 2;
+  return (
+    <MenuWithShortcuts
+      ariaLabel={'Select the team to filter by'}
+      closePortal={closePortal}
+      defaultActiveIdx={defaultActiveIdx}
+    >
+      <Label>{'Filter by:'}</Label>
+      <MenuItemWithShortcuts
+        key={'teamFilterNULL'}
+        label={'All teams'}
+        onClick={() => dispatch(filterTeam(null))}
+      />
+      {
+        teams.map((team) => (
+          <MenuItemWithShortcuts
+            key={`teamFilter${team.id}`}
+            label={team.name}
+            onClick={() => dispatch(filterTeam(team.id, team.name))}
+          />
+        ))
+      }
+    </MenuWithShortcuts>
+  );
+};
+
+export default connect()(UserDashTeamMenu);

--- a/src/universal/modules/menu/components/MenuItem/MenuItemWithShortcuts.js
+++ b/src/universal/modules/menu/components/MenuItem/MenuItemWithShortcuts.js
@@ -56,6 +56,12 @@ class MenuItemWithShortcuts extends Component {
     title: PropTypes.string
   };
 
+  componentDidMount() {
+    const {isActive} = this.props;
+    if (isActive) {
+      this.itemRef.scrollIntoViewIfNeeded();
+    }
+  }
   componentWillReceiveProps(nextProps) {
     const {isActive} = nextProps;
     if (isActive && !this.props.isActive) {

--- a/src/universal/modules/menu/components/MenuItem/MenuWithShortcuts.js
+++ b/src/universal/modules/menu/components/MenuItem/MenuWithShortcuts.js
@@ -11,7 +11,8 @@ class MenuWithShortcuts extends Component {
   static propTypes = {
     ariaLabel: PropTypes.string,
     children: PropTypes.any.isRequired,
-    closePortal: PropTypes.func.isRequired
+    closePortal: PropTypes.func.isRequired,
+    defaultActiveIdx: PropTypes.number
   };
 
   state = {
@@ -19,10 +20,9 @@ class MenuWithShortcuts extends Component {
   }
 
   componentWillMount() {
-    const {children} = this.props;
+    const {children, defaultActiveIdx} = this.props;
     const childArr = Children.toArray(children);
-    const startIdx = childArr.findIndex((child) => isValidMenuItem(child));
-    this.state.active = startIdx;
+    this.state.active = defaultActiveIdx || childArr.findIndex((child) => isValidMenuItem(child));
   }
 
   componentDidMount() {
@@ -47,6 +47,9 @@ class MenuWithShortcuts extends Component {
         if (isValidMenuItem(nextChild)) {
           nextIdx = ii;
           break;
+        } else {
+          // if we're at the top & there's a header, put the header into view
+          this.menuRef.scrollIntoView();
         }
       }
     }

--- a/src/universal/modules/teamDashboard/components/Team/Team.js
+++ b/src/universal/modules/teamDashboard/components/Team/Team.js
@@ -1,6 +1,6 @@
 import {css} from 'aphrodite-local-styles/no-important';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {Component} from 'react';
 import {commitLocalUpdate, createFragmentContainer} from 'react-relay';
 import {withRouter} from 'react-router-dom';
 import Button from 'universal/components/Button/Button';
@@ -19,96 +19,120 @@ import {ACTION} from 'universal/utils/constants';
 // use the same object so the EditTeamName doesn't rerender so gosh darn always
 const initialValues = {teamName: ''};
 
-const Team = (props) => {
-  const {
-    atmosphere,
-    children,
-    hasMeetingAlert,
-    isSettings,
-    history,
-    styles,
-    team
-  } = props;
-  if (!team) return <LoadingView />;
-  const {teamId, teamName, isPaid, meetingId, newMeeting} = team;
-  const updateFilter = (e) => {
-    const nextValue = e.target.value;
+class Team extends Component {
+  componentWillReceiveProps(nextProps) {
+    const {team: oldTeam} = this.props;
+    if (oldTeam && oldTeam.contentFilter) {
+      if (!nextProps.team || nextProps.team.id !== oldTeam.id) {
+        this.setContentFilter('');
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.team && this.props.team.contentFilter) {
+      this.setContentFilter('');
+    }
+  }
+  setContentFilter(nextValue) {
+    const {atmosphere, team: {teamId}} = this.props;
     commitLocalUpdate(atmosphere, (store) => {
       const teamProxy = store.get(teamId);
       teamProxy.setValue(nextValue, 'contentFilter');
     });
+  }
+
+  updateFilter = (e) => {
+    this.setContentFilter(e.target.value);
   };
-  const hasActiveMeeting = Boolean(meetingId);
-  const hasOverlay = hasActiveMeeting || !isPaid;
-  initialValues.teamName = teamName;
-  const DashHeaderInfoTitle = isSettings ?
-    <EditTeamName initialValues={initialValues} teamName={teamName} teamId={teamId} /> : '';
-  const modalLayout = hasMeetingAlert ? ui.modalLayoutMainWithDashAlert : ui.modalLayoutMain;
-  const goToTeamSettings = () =>
+  goToTeamSettings = () => {
+    const {history, team: {teamId}} = this.props;
     history.push(`/team/${teamId}/settings/`);
-  const goToTeamDashboard = () =>
-    history.push(`/team/${teamId}`);
-  return (
-    <DashMain>
-      <MeetingInProgressModal
-        isOpen={hasActiveMeeting}
-        meetingType={newMeeting ? newMeeting.meetingType : ACTION}
-        modalLayout={modalLayout}
-        teamId={teamId}
-        teamName={teamName}
-        key={`${teamId}MeetingModal`}
-      />
-      <UnpaidTeamModalRoot
-        isOpen={!isPaid}
-        teamId={teamId}
-        modalLayout={modalLayout}
-        key={`${teamId}UnpaidModal`}
-      />
-      <DashHeader
-        area={isSettings ? 'teamSettings' : 'teamDash'}
-        hasOverlay={hasOverlay}
-        key={`team${isSettings ? 'Dash' : 'Settings'}Header`}
-      >
-        <DashHeaderInfo title={DashHeaderInfoTitle}>
-          {!isSettings && <DashSearchControl onChange={updateFilter} placeholder="Search Team Tasks & Agenda" />}
-        </DashHeaderInfo>
-        <div className={css(styles.teamLinks)}>
-          {isSettings ?
-            <Button
-              key="1"
-              buttonStyle="flat"
-              colorPalette="dark"
-              icon="arrow-circle-left"
-              iconPlacement="left"
-              isBlock
-              label="Back to Team Dashboard"
-              onClick={goToTeamDashboard}
-              buttonSize="small"
-            /> :
-            <Button
-              buttonSize="small"
-              buttonStyle="flat"
-              colorPalette="dark"
-              icon="cog"
-              iconPlacement="left"
-              key="2"
-              isBlock
-              label="Team Settings"
-              onClick={goToTeamSettings}
-            />
-          }
-          <DashboardAvatars team={team} />
-          {!isSettings &&
+  };
+  goToTeamDashboard = () => {
+    const {history, team: {teamId}} = this.props;
+    history.push(`/team/${teamId}/`);
+  };
+
+  render() {
+    const {
+      children,
+      hasMeetingAlert,
+      isSettings,
+      styles,
+      team
+    } = this.props;
+    if (!team) return <LoadingView />;
+    const {teamId, teamName, isPaid, meetingId, newMeeting} = team;
+    const hasActiveMeeting = Boolean(meetingId);
+    const hasOverlay = hasActiveMeeting || !isPaid;
+    initialValues.teamName = teamName;
+    const DashHeaderInfoTitle = isSettings ?
+      <EditTeamName initialValues={initialValues} teamName={teamName} teamId={teamId} /> : '';
+    const modalLayout = hasMeetingAlert ? ui.modalLayoutMainWithDashAlert : ui.modalLayoutMain;
+
+    return (
+      <DashMain>
+        <MeetingInProgressModal
+          isOpen={hasActiveMeeting}
+          meetingType={newMeeting ? newMeeting.meetingType : ACTION}
+          modalLayout={modalLayout}
+          teamId={teamId}
+          teamName={teamName}
+          key={`${teamId}MeetingModal`}
+        />
+        <UnpaidTeamModalRoot
+          isOpen={!isPaid}
+          teamId={teamId}
+          modalLayout={modalLayout}
+          key={`${teamId}UnpaidModal`}
+        />
+        <DashHeader
+          area={isSettings ? 'teamSettings' : 'teamDash'}
+          hasOverlay={hasOverlay}
+          key={`team${isSettings ? 'Dash' : 'Settings'}Header`}
+        >
+          <DashHeaderInfo title={DashHeaderInfoTitle}>
+            {!isSettings && <DashSearchControl onChange={this.updateFilter} placeholder="Search Team Tasks & Agenda" />}
+          </DashHeaderInfo>
+          <div className={css(styles.teamLinks)}>
+            {isSettings ?
+              <Button
+                key="1"
+                buttonStyle="flat"
+                colorPalette="dark"
+                icon="arrow-circle-left"
+                iconPlacement="left"
+                isBlock
+                label="Back to Team Dashboard"
+                onClick={this.goToTeamDashboard}
+                buttonSize="small"
+              /> :
+              <Button
+                buttonSize="small"
+                buttonStyle="flat"
+                colorPalette="dark"
+                icon="cog"
+                iconPlacement="left"
+                key="2"
+                isBlock
+                label="Team Settings"
+                onClick={this.goToTeamSettings}
+              />
+            }
+            <DashboardAvatars team={team} />
+            {!isSettings &&
             <TeamCallsToAction teamId={teamId} />
-          }
-        </div>
-      </DashHeader>
-      <DashContent hasOverlay={hasOverlay} padding="0">
-        {children}
-      </DashContent>
-    </DashMain>
-  );
-};
+            }
+          </div>
+        </DashHeader>
+        <DashContent hasOverlay={hasOverlay} padding="0">
+          {children}
+        </DashContent>
+      </DashMain>
+    );
+  }
+}
 
 Team.propTypes = {
   atmosphere: PropTypes.object.isRequired,

--- a/src/universal/modules/teamDashboard/components/TeamTasksHeader/TeamTasksHeader.js
+++ b/src/universal/modules/teamDashboard/components/TeamTasksHeader/TeamTasksHeader.js
@@ -2,18 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {createFragmentContainer} from 'react-relay';
 import {withRouter} from 'react-router-dom';
-import {
-  DashSectionControl,
-  DashSectionControls,
-  DashSectionHeader,
-  DashHeading
-} from 'universal/components/Dashboard';
+import {DashHeading, DashSectionControl, DashSectionControls, DashSectionHeader} from 'universal/components/Dashboard';
 import {DashNavControl, LabelHeading} from 'universal/components';
 import DashFilterLabel from 'universal/components/DashFilterLabel/DashFilterLabel';
 import DashFilterToggle from 'universal/components/DashFilterToggle/DashFilterToggle';
-import {Menu, MenuItem} from 'universal/modules/menu';
-import {filterTeamMember} from 'universal/modules/teamDashboard/ducks/teamDashDuck';
 import ui from 'universal/styles/ui';
+import LoadableTeamDashTeamMemberMenu from 'universal/components/LoadableTeamDashTeamMemberMenu';
+import LoadableMenu from 'universal/components/LoadableMenu';
 
 const originAnchor = {
   vertical: 'bottom',
@@ -26,26 +21,8 @@ const targetAnchor = {
 };
 
 const TeamTasksHeader = (props) => {
-  const {dispatch, history, teamMemberFilterId, teamMemberFilterName, team} = props;
-  const {teamId, teamMembers, teamName} = team;
-  const toggle = <DashFilterToggle label={teamMemberFilterName} />;
-
-  const itemFactory = () => {
-    return [<MenuItem
-      isActive={teamMemberFilterId === null}
-      key={'teamMemberFilterNULL'}
-      label={'All members'}
-      onClick={() => dispatch(filterTeamMember(null))}
-    />].concat(
-      teamMembers.map((teamMember) =>
-        (<MenuItem
-          isActive={teamMember.id === teamMemberFilterId}
-          key={`teamMemberFilter${teamMember.id}`}
-          label={teamMember.preferredName}
-          onClick={() => dispatch(filterTeamMember(teamMember.id, teamMember.preferredName))}
-        />)
-      ));
-  };
+  const {history, teamMemberFilterId, teamMemberFilterName, team} = props;
+  const {teamId, teamName} = team;
 
   const goToArchive = () => history.push(`/team/${teamId}/archive`);
 
@@ -69,13 +46,17 @@ const TeamTasksHeader = (props) => {
         {/* Filter by Owner */}
         <DashSectionControl>
           <DashFilterLabel><b>{'Show Tasks for'}</b>{': '}</DashFilterLabel>
-          <Menu
-            itemFactory={itemFactory}
-            label="Filter by:"
-            maxHeight={ui.dashMenuHeight}
-            toggle={toggle}
+          <LoadableMenu
+            LoadableComponent={LoadableTeamDashTeamMemberMenu}
+            maxWidth={350}
+            maxHeight={parseInt(ui.dashMenuHeight, 10) * 16}
             originAnchor={originAnchor}
+            queryVars={{
+              team,
+              teamMemberFilterId
+            }}
             targetAnchor={targetAnchor}
+            toggle={<DashFilterToggle label={teamMemberFilterName} />}
           />
         </DashSectionControl>
       </DashSectionControls>
@@ -98,10 +79,7 @@ export default createFragmentContainer(
     fragment TeamTasksHeader_team on Team {
       teamId: id
       teamName: name
-      teamMembers(sortBy: "preferredName") {
-        id
-        preferredName
-      }
+      ...TeamDashTeamMemberMenu_team
     }
   `
 );

--- a/src/universal/modules/userDashboard/components/UserTasksHeader/UserTasksHeader.js
+++ b/src/universal/modules/userDashboard/components/UserTasksHeader/UserTasksHeader.js
@@ -1,16 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ui from 'universal/styles/ui';
-import {
-  DashHeading,
-  DashSectionControl,
-  DashSectionControls,
-  DashSectionHeader
-} from 'universal/components/Dashboard';
-import {Menu, MenuItem} from 'universal/modules/menu';
-import {filterTeam} from 'universal/modules/userDashboard/ducks/userDashDuck';
+import {DashHeading, DashSectionControl, DashSectionControls, DashSectionHeader} from 'universal/components/Dashboard';
 import DashFilterLabel from 'universal/components/DashFilterLabel/DashFilterLabel';
 import DashFilterToggle from 'universal/components/DashFilterToggle/DashFilterToggle';
+import LoadableMenu from 'universal/components/LoadableMenu';
+import LoadableUserDashTeamMenu from 'universal/components/LoadableUserDashTeamMenu';
 
 const originAnchor = {
   vertical: 'bottom',
@@ -23,8 +18,7 @@ const targetAnchor = {
 };
 
 const UserTasksHeader = (props) => {
-  const {dispatch, teams, teamFilterId, teamFilterName} = props;
-  const toggle = <DashFilterToggle label={teamFilterName} />;
+  const {teams, teamFilterId, teamFilterName} = props;
   // TODO refactor so we can pull teams from the relay cache instead of feeding it down a long tree
   return (
     <DashSectionHeader>
@@ -34,29 +28,18 @@ const UserTasksHeader = (props) => {
       <DashSectionControls>
         <DashSectionControl>
           <DashFilterLabel><b>{'Show Tasks for'}</b>{': '}</DashFilterLabel>
-          <Menu
-            label="Filter by:"
-            maxHeight={ui.dashMenuHeight}
-            menuWidth={ui.dashMenuWidth}
+          <LoadableMenu
+            LoadableComponent={LoadableUserDashTeamMenu}
+            maxWidth={350}
+            maxHeight={parseInt(ui.dashMenuHeight, 10) * 16}
             originAnchor={originAnchor}
+            queryVars={{
+              teams,
+              teamFilterId
+            }}
             targetAnchor={targetAnchor}
-            toggle={toggle}
-          >
-            <MenuItem
-              isActive={teamFilterId === null}
-              key={'teamFilterNULL'}
-              label={'All teams'}
-              onClick={() => dispatch(filterTeam(null))}
-            />
-            {teams.map((team) =>
-              (<MenuItem
-                isActive={team.id === teamFilterId}
-                key={`teamFilter${team.id}`}
-                label={team.name}
-                onClick={() => dispatch(filterTeam(team.id, team.name))}
-              />)
-            )}
-          </Menu>
+            toggle={<DashFilterToggle label={teamFilterName} />}
+          />
         </DashSectionControl>
       </DashSectionControls>
     </DashSectionHeader>


### PR DESCRIPTION
Fixes #1871 

TEST
- [ ] go to a team dash, type in a filter to reduce the number of cards. navigate to another team, then back to the starting team. the filter is removed.

This also fixes the weird console error that was complaining about refs & stateless components. Not sure which PR caused it, but it exists on master. I fixed it by moving it to the new MenuWithShortcuts component. So now it's keyboard accessible & has a little animation & all that jazz.

TEST
- [ ] go to Team Dash, filter by a team member using the keyboard. Re-open the menu, the highlighted team member is correct. 
- [ ] Select the last team member. Reopen & that team member is highlighted & the menu is scrolled there.
- [ ] with the menu open & the last team member selection, use arrow keys to scroll up until the "All team members" option. With that option highlighted, hit the arrow up key one more time. the header is scrolled into view, but the All team members option is still highlighted.
- [ ] rerun the test for the UserDash team filter