### PR TITLE
Fix segment identify #1901

### DIFF
--- a/src/server/graphql/mutations/login.js
+++ b/src/server/graphql/mutations/login.js
@@ -81,6 +81,7 @@ const login = {
       welcomeSentAt: now
     };
     await r.table('User').insert(newUser);
+    await sendSegmentIdentify(user.id);
 
     // don't await
     setTimeout(() => sendEmail(newUser.email, 'welcomeEmail', newUser), 0);

--- a/src/server/graphql/mutations/login.js
+++ b/src/server/graphql/mutations/login.js
@@ -81,7 +81,7 @@ const login = {
       welcomeSentAt: now
     };
     await r.table('User').insert(newUser);
-    await sendSegmentIdentify(user.id);
+    await sendSegmentIdentify(newUser.id);
 
     // don't await
     setTimeout(() => sendEmail(newUser.email, 'welcomeEmail', newUser), 0);

--- a/src/server/graphql/mutations/login.js
+++ b/src/server/graphql/mutations/login.js
@@ -43,6 +43,17 @@ const login = {
       const user = await dataLoader.get('users').load(viewerId);
       // LOGIN
       if (user) {
+        /*
+         * The segment docs are inconsistent, and warn against sending
+         * identify() on each log in. However, calling identify is the
+         * only way to synchronize changing user properties with certain
+         * services (such as Hubspot). After checking with support
+         * and combing the forums, it turns out sending identify()
+         * on each login is just fine.
+         *
+         * See also: https://community.segment.com/t/631m9s/identify-per-signup-or-signin
+         */
+        await sendSegmentIdentify(user.id);
         return {
           userId: viewerId,
           // create a brand new auth token using the tms in our DB, not auth0s
@@ -70,16 +81,6 @@ const login = {
       welcomeSentAt: now
     };
     await r.table('User').insert(newUser);
-    /*
-    * From segment docs:
-    *
-    * We recommend calling identify a single time when the
-    * user’s account is first created, and only identifying
-    * again later when their traits change.
-    *
-    * see: https://segment.com/docs/sources/server/node/
-    */
-    await sendSegmentIdentify(newUser.id);
 
     // don't await
     setTimeout(() => sendEmail(newUser.email, 'welcomeEmail', newUser), 0);

--- a/src/server/graphql/mutations/setOrgUserRole.js
+++ b/src/server/graphql/mutations/setOrgUserRole.js
@@ -7,6 +7,8 @@ import shortid from 'shortid';
 import {BILLING_LEADER, billingLeaderTypes, ORGANIZATION, PROMOTE_TO_BILLING_LEADER} from 'universal/utils/constants';
 import {sendOrgLeadAccessError} from 'server/utils/authorizationErrors';
 import sendAuthRaven from 'server/utils/sendAuthRaven';
+import {sendSegmentIdentify} from 'server/utils/sendSegmentEvent';
+
 
 export default {
   type: SetOrgUserRolePayload,
@@ -119,6 +121,7 @@ export default {
       const data = {orgId, userId, notificationIdsAdded};
       publish(ORGANIZATION, userId, SetOrgUserRolePayload, data, subOptions);
       publish(ORGANIZATION, orgId, SetOrgUserRolePayload, data, subOptions);
+      await sendSegmentIdentify(userId);
       return data;
     }
     if (role === null) {
@@ -142,6 +145,7 @@ export default {
       const data = {orgId, userId, notificationsRemoved};
       publish(ORGANIZATION, userId, SetOrgUserRolePayload, data, subOptions);
       publish(ORGANIZATION, orgId, SetOrgUserRolePayload, data, subOptions);
+      await sendSegmentIdentify(userId);
       return data;
     }
     return null;

--- a/src/universal/redux/__tests__/authDuck.test.js
+++ b/src/universal/redux/__tests__/authDuck.test.js
@@ -29,7 +29,7 @@ test('can setAuthToken w/token decode', () => {
   const user = {id: testTokenData.sub, email: 'a@a.co'};
   store.dispatch(setAuthToken(testToken, user));
   expect(raven.setUserContext).toBeCalledWith({id: testTokenData.sub, email: 'a@a.co'});
-  expect(segmentActions.segmentEventIdentify).toBeCalled();
+  expect(segmentActions.selectSegmentTraits).toBeCalled();
   expect(store.getState()).toMatchSnapshot();
 });
 

--- a/src/universal/redux/authDuck.js
+++ b/src/universal/redux/authDuck.js
@@ -1,6 +1,6 @@
 import jwtDecode from 'jwt-decode';
 import raven from 'raven-js';
-import {segmentEventIdentify, segmentEventReset} from 'universal/redux/segmentActions';
+import {selectSegmentTraits, segmentEventReset} from 'universal/redux/segmentActions';
 
 const SET_AUTH_TOKEN = '@@authToken/SET_AUTH_TOKEN';
 const REMOVE_AUTH_TOKEN = '@@authToken/REMOVE_AUTH_TOKEN';
@@ -93,7 +93,11 @@ export function setAuthToken(authToken, user) {
       }
     });
     if (user) {
-      dispatch(segmentEventIdentify(user));
+      /*
+       * Update our segment store with the user's traits so they may be
+       * included on future calls to segment:
+       */
+      selectSegmentTraits(user);
     }
   };
 }


### PR DESCRIPTION
See #1901.

This changes when we call segment identify to synchronize user traits with some of our integrated services upon each login. See the issue for more information on why we're doing this.