### PR TITLE
Enable new auth pages

### DIFF
--- a/e2e/lib.js
+++ b/e2e/lib.js
@@ -37,5 +37,6 @@ export async function newUserSession({ browser, behaviors }) {
  */
 export const waitTimes = {
   short: 2000,
-  long: 5000
-}
+  medium: 5000,
+  long: 10000
+};

--- a/e2e/scripts/drivers.js
+++ b/e2e/scripts/drivers.js
@@ -45,7 +45,7 @@ export function addDriversToPATH() {
 export const DRIVERS = [
   new Driver({
     browser: 'chrome',
-    url: `https://chromedriver.storage.googleapis.com/2.36/chromedriver_${getOsName()}${getOsArch()}.zip`,
+    url: `https://chromedriver.storage.googleapis.com/2.37/chromedriver_${getOsName()}${getOsArch()}.zip`,
     driverFilename: 'chromedriver'
   })
 ];

--- a/e2e/tests/authentication.test.js
+++ b/e2e/tests/authentication.test.js
@@ -11,9 +11,6 @@ import shortid from 'shortid';
 import {all, newUserSession, waitTimes} from '../lib';
 
 const BASE_URL = global.E2E_APP_SERVER_URL;
-const BASE_URL_REGEX = BASE_URL.endsWith('/')
-  ? new RegExp(`^${BASE_URL}?$`)
-  : new RegExp(`^${BASE_URL}(/)?$`);
 
 function generateCredentials() {
   // Note that we want to generate unique credentials, since we're testing

--- a/e2e/tests/authentication.test.js
+++ b/e2e/tests/authentication.test.js
@@ -27,46 +27,26 @@ function generateCredentials() {
 }
 
 const actions = {
-  goToHomepage: (driver) => () => driver.get(BASE_URL),
-
-  openLoginModal: (driver) => async () => {
-    const loginButtonSeletor = 'button[title="Log In"]';
+  goToSignInPage: (driver) => async () => {
+    await driver.get(`${BASE_URL}/signin`);
+    const signInFormSelector = '.signin-form';
     await driver
-      .wait(until.elementLocated(By.css(loginButtonSeletor)));
-    await driver
-      .findElement(By.css(loginButtonSeletor))
-      .click();
-    const modalContainerSelector = '#a0-onestep';
-    const loginSignupToggleSelector = '.a0-sign-up';
-    await all(
-      driver
-        .wait(until.elementLocated(By.css(modalContainerSelector))),
-      driver
-        .wait(until.elementLocated(By.css(loginSignupToggleSelector)))
-    );
+      .wait(until.elementLocated(By.css(signInFormSelector)));
   },
 
-  login: (driver) => async ({email, password}) => {
+  goToSignUpPage: (driver) => async () => {
+    await driver.get(`${BASE_URL}/signup`);
+    const signUpFormSelector = '.signup-form';
     await driver
-      .findElement(By.id('a0-signin_easy_email'))
-      .sendKeys(email);
-    await driver
-      .findElement(By.id('a0-signin_easy_password'))
-      .sendKeys(password);
-    await driver
-      .findElement(By.css('button[type="submit"]'))
-      .click();
+      .wait(until.elementLocated(By.css(signUpFormSelector)));
   },
 
-  signUp: (driver) => async ({email, password}) => {
+  authenticate: (driver) => async ({email, password}) => {
     await driver
-      .findElement(By.css('.a0-sign-up'))
-      .click();
-    await driver
-      .findElement(By.id('a0-signup_easy_email'))
+      .findElement(By.css('input[type="email"]'))
       .sendKeys(email);
     await driver
-      .findElement(By.id('a0-signup_easy_password'))
+      .findElement(By.css('input[type="password"]'))
       .sendKeys(password);
     await driver
       .findElement(By.css('button[type="submit"]'))
@@ -74,21 +54,19 @@ const actions = {
   },
 
   logout: (driver) => async () => {
+    const signOutButtonSelector = 'a[title="Sign Out"]';
+    await driver.wait(until.elementLocated(By.css(signOutButtonSelector)));
     await driver
-      .findElement(By.css('a[title="Sign Out"]'))
+      .findElement(By.css(signOutButtonSelector))
       .click();
-    await all(
-      driver
-        .wait(until.urlMatches(BASE_URL_REGEX), waitTimes.short, 'Logging out did not redirect to the base URL'),
-      driver
-        .wait(until.titleMatches(/Parabol/), waitTimes.short, 'Logging out did not redirect to the Parabol Homepage')
-    );
   }
 };
 
 const expectations = {
   shouldSeeLoginWarning: (driver) => async (warningRegex) => {
-    const warningElement = await driver.findElement(By.css('h2.a0-error'));
+    const warningElementSelector = '[role="alert"]';
+    await driver.wait(until.elementLocated(By.css(warningElementSelector)));
+    const warningElement = await driver.findElement(By.css(warningElementSelector));
     await driver.wait(
       () => warningElement.getText().then((txt) => !!(txt.trim().length)),
       waitTimes.short,
@@ -108,15 +86,14 @@ const expectations = {
     return expect(url).toMatch(/welcome/);
   },
 
-  shouldSeeHomepage: (driver) => async () => {
-    const title = await driver.getTitle();
-    expect(title).toMatch(/Parabol/);
-    const url = await driver.getCurrentUrl();
-    expect(url).toMatch(BASE_URL_REGEX);
-    const headingEl = await driver.findElement(By.css('h1'));
-    const headingText = await headingEl.getText();
-    expect(headingText.trim()).toEqual('The Unified Dashboard for All Disciplines');
-  }
+  shouldSeeHomepage: (driver) => async () => (
+    all(
+      driver
+        .wait(until.urlMatches(/signin$/), waitTimes.short, 'Logging out did not redirect to signin page'),
+      driver
+        .wait(until.titleMatches(/Sign In | Parabol/), waitTimes.short, 'Logging out did not redirect to the Parabol Homepage')
+    )
+  )
 };
 
 const behaviors = {
@@ -147,17 +124,15 @@ describe('Authentication', () => {
   });
 
   it('shows an error when the incorrect credentials are provided', async () => {
-    await user.goToHomepage();
-    await user.openLoginModal();
-    await user.login(generateCredentials());
+    await user.goToSignInPage();
+    await user.authenticate(generateCredentials());
     await user.shouldSeeLoginWarning(/Wrong email or password/);
   });
 
   it('can sign up', async () => {
-    await user.goToHomepage();
-    await user.openLoginModal();
+    await user.goToSignUpPage();
     const credentials = generateCredentials();
-    await user.signUp(credentials);
+    await user.authenticate(credentials);
     await user.shouldSeeWelcomeWizard();
     cache.credentials = credentials;
   });
@@ -165,9 +140,8 @@ describe('Authentication', () => {
   it('can log in (and out) with valid credentials', async () => {
     const {credentials} = cache;
     expect(credentials).toBeTruthy();
-    await user.goToHomepage();
-    await user.openLoginModal();
-    await user.login(credentials);
+    await user.goToSignInPage();
+    await user.authenticate(credentials);
     await user.shouldSeeWelcomeWizard();
     await user.logout();
     await user.shouldSeeHomepage();

--- a/src/universal/components/SignInPage/SignInEmailPasswordForm.js
+++ b/src/universal/components/SignInPage/SignInEmailPasswordForm.js
@@ -40,7 +40,7 @@ const ForgotPasswordLink = styled(Link)({
 });
 
 const SignInEmailPasswordForm = (props: Props) => (
-  <Form onSubmit={props.handleSubmit}>
+  <Form className="signin-form" onSubmit={props.handleSubmit}>
     <Block margin="1rem 0 2rem" width="16rem">
       <Block margin="0 0 1.5rem">
         <Field

--- a/src/universal/components/SignUpPage/SignUpEmailPasswordForm.js
+++ b/src/universal/components/SignUpPage/SignUpEmailPasswordForm.js
@@ -26,7 +26,7 @@ const Form = styled('form')({
 const Block = styled('div')(({margin, width}) => ({margin, width}));
 
 const SignInEmailPasswordForm = (props: Props) => (
-  <Form onSubmit={props.handleSubmit}>
+  <Form className="signup-form" onSubmit={props.handleSubmit}>
     <Block margin="1rem 0 2rem" width="16rem">
       <Block margin="0 0 1.5rem">
         <Field

--- a/src/universal/releaseFlags.js
+++ b/src/universal/releaseFlags.js
@@ -20,7 +20,7 @@
 
 export default {
   // The single-page embedded signin
-  newSignIn: false,
+  newSignIn: true,
   // The retrospective meeting
   retro: false,
   userDashFilter: false

--- a/src/universal/utils/auth0Login.js
+++ b/src/universal/utils/auth0Login.js
@@ -6,7 +6,7 @@
  *
  * @flow
  */
-import WebAuth from 'auth0-js';
+import {WebAuth} from 'auth0-js/build/auth0';
 import promisify from 'es6-promisify';
 
 import type {Credentials} from 'universal/types/auth';

--- a/src/universal/utils/getWebAuth.js
+++ b/src/universal/utils/getWebAuth.js
@@ -1,4 +1,4 @@
-import {WebAuth} from 'auth0-js';
+import {WebAuth} from 'auth0-js/build/auth0';
 
 export default function getWebAuth() {
   return new WebAuth({


### PR DESCRIPTION
This enables the new signin/signup/password recovery pages.

It also updates the end-to-end tests of those pages.