### PR TITLE
Adds help dialogs in action meeting

### DIFF
--- a/src/universal/modules/meeting/components/MeetingAgendaFirstCall/MeetingAgendaFirstCall.js
+++ b/src/universal/modules/meeting/components/MeetingAgendaFirstCall/MeetingAgendaFirstCall.js
@@ -13,7 +13,7 @@ import ui from 'universal/styles/ui';
 import appTheme from 'universal/styles/theme/appTheme';
 import {css} from 'aphrodite-local-styles/no-important';
 import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
-import {AGENDA_ITEM_LABEL} from 'universal/utils/constants';
+import {AGENDA_ITEM_LABEL, FIRST_CALL} from 'universal/utils/constants';
 
 const MeetingAgendaFirstCall = (props) => {
   const {
@@ -24,7 +24,7 @@ const MeetingAgendaFirstCall = (props) => {
   } = props;
   const phaseName = actionMeeting.agendaitems.name;
   return (
-    <MeetingMain>
+    <MeetingMain hasHelpFor={FIRST_CALL}>
       <MeetingSection flexToFill paddingBottom="2rem">
         <MeetingSection paddingBottom="2rem">
           <div className={css(styles.main)}>

--- a/src/universal/modules/meeting/components/MeetingAgendaItems/MeetingAgendaItems.js
+++ b/src/universal/modules/meeting/components/MeetingAgendaItems/MeetingAgendaItems.js
@@ -14,7 +14,7 @@ import MeetingControlBar from 'universal/modules/meeting/components/MeetingContr
 import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 import ui from 'universal/styles/ui';
 import withStyles from 'universal/styles/withStyles';
-import {AGENDA_ITEM_LABEL} from 'universal/utils/constants';
+import {AGENDA_ITEM_LABEL, AGENDA_ITEMS} from 'universal/utils/constants';
 
 class MeetingAgendaItems extends Component {
   state = {agendaTasks: []};
@@ -61,7 +61,7 @@ class MeetingAgendaItems extends Component {
     const isLast = agendaItems.length === localPhaseItem;
     const subHeading = (<span><b>{currentTeamMember.preferredName}</b>{', what do you need?'}</span>);
     return (
-      <MeetingMain>
+      <MeetingMain hasHelpFor={AGENDA_ITEMS} isFacilitating={showMoveMeetingControls}>
         <MeetingSection flexToFill paddingBottom="2rem">
           <MeetingSection flexToFill>
             <div className={css(styles.layout)}>

--- a/src/universal/modules/meeting/components/MeetingAgendaLastCall/MeetingAgendaLastCall.js
+++ b/src/universal/modules/meeting/components/MeetingAgendaLastCall/MeetingAgendaLastCall.js
@@ -13,7 +13,7 @@ import MeetingSection from 'universal/modules/meeting/components/MeetingSection/
 import ui from 'universal/styles/ui';
 import appTheme from 'universal/styles/theme/appTheme';
 import withStyles from 'universal/styles/withStyles';
-import {AGENDA_ITEM_LABEL} from 'universal/utils/constants';
+import {AGENDA_ITEM_LABEL, LAST_CALL} from 'universal/utils/constants';
 import plural from 'universal/utils/plural';
 
 const MeetingAgendaLastCall = (props) => {
@@ -30,7 +30,7 @@ const MeetingAgendaLastCall = (props) => {
   const hintName = hideMoveMeetingControls ? facilitatorName : 'you';
 
   return (
-    <MeetingMain>
+    <MeetingMain hasHelpFor={LAST_CALL}>
       <MeetingSection flexToFill paddingBottom="2rem">
         <MeetingSection paddingBottom="2rem">
           <div className={css(styles.main)}>

--- a/src/universal/modules/meeting/components/MeetingCheckIn/MeetingCheckIn.js
+++ b/src/universal/modules/meeting/components/MeetingCheckIn/MeetingCheckIn.js
@@ -14,6 +14,7 @@ import MeetingCheckInMutation from 'universal/mutations/MeetingCheckInMutation';
 import ui from 'universal/styles/ui';
 import withStyles from 'universal/styles/withStyles';
 import withMutationProps from 'universal/utils/relay/withMutationProps';
+import {CHECKIN} from 'universal/utils/constants';
 
 const MeetingCheckin = (props) => {
   const {
@@ -44,7 +45,7 @@ const MeetingCheckin = (props) => {
   const {isSelf: isMyMeetingSection} = currentMember;
   const nextMember = teamMembers[memberIdx + 1];
   return (
-    <MeetingMain>
+    <MeetingMain hasHelpFor={CHECKIN} isFacilitating={isFacilitating}>
       <MeetingSection flexToFill paddingBottom="1rem">
         <MeetingCheckInPrompt
           isFacilitating={isFacilitating}

--- a/src/universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialog.js
+++ b/src/universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialog.js
@@ -35,6 +35,7 @@ const MeetingHelpDialog = ({phase}: Props) => {
         buttonSize="small"
         buttonStyle="solid"
         colorPalette="white"
+        depth={2}
         icon="question"
         isBlock
       />

--- a/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
+++ b/src/universal/modules/meeting/components/MeetingLobby/MeetingLobby.js
@@ -17,6 +17,7 @@ import ui from 'universal/styles/ui';
 import withStyles from 'universal/styles/withStyles';
 import makeHref from 'universal/utils/makeHref';
 import withMutationProps from 'universal/utils/relay/withMutationProps';
+import {LOBBY} from 'universal/utils/constants';
 
 const MeetingLobby = (props) => {
   const {atmosphere, history, onError, onCompleted, submitMutation, submitting, team, styles} = props;
@@ -27,7 +28,7 @@ const MeetingLobby = (props) => {
   };
   const meetingUrl = makeHref(`/meeting/${teamId}`);
   return (
-    <MeetingMain>
+    <MeetingMain hasHelpFor={LOBBY}>
       {/* */}
       <div className={css(styles.root)}>
         <LabelHeading>{'Welcome to the Meeting Lobby'}</LabelHeading>

--- a/src/universal/modules/meeting/components/MeetingMain/MeetingMain.js
+++ b/src/universal/modules/meeting/components/MeetingMain/MeetingMain.js
@@ -4,17 +4,33 @@ import React from 'react';
 import ErrorBoundary from 'universal/components/ErrorBoundary';
 import withStyles from 'universal/styles/withStyles';
 import ui from 'universal/styles/ui';
+import MeetingHelpDialog from 'universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialog';
 
 const MeetingMain = (props) => {
-  const {children, hasBoxShadow, styles} = props;
+  const {children, hasBoxShadow, hasHelpFor, isFacilitating, styles} = props;
   const rootStyles = css(
     styles.meetingMainRoot,
     hasBoxShadow && styles.hasBoxShadow
   );
+  const innerBlockStyles = css(
+    styles.meetingMainRoot,
+    styles.innerBlockStyles
+  );
+  const helpStyles = css(
+    styles.helpStyles,
+    isFacilitating && styles.helpIsFacilitating
+  );
   return (
     <ErrorBoundary>
       <div className={rootStyles}>
-        {children}
+        {hasHelpFor &&
+          <div className={helpStyles}>
+            <MeetingHelpDialog phase={hasHelpFor} />
+          </div>
+        }
+        <div className={innerBlockStyles}>
+          {children}
+        </div>
       </div>
     </ErrorBoundary>
   );
@@ -24,6 +40,8 @@ const MeetingMain = (props) => {
 MeetingMain.propTypes = {
   children: PropTypes.any,
   hasBoxShadow: PropTypes.bool,
+  hasHelpFor: PropTypes.string,
+  isFacilitating: PropTypes.bool,
   styles: PropTypes.object
 };
 
@@ -33,13 +51,27 @@ const styleThunk = () => ({
     flex: 1,
     flexDirection: 'column',
     minWidth: '60rem',
+    position: 'relative',
     width: '100%'
   },
 
   hasBoxShadow: {
-    // similar to shadow[2] (depth .25rem, blur-radius .5rem)
-    // boxShadow: 'inset .25rem 0 .5rem rgba(0, 0, 0, .25), inset 0 0 .0625rem rgba(0, 0, 0, .15)'
     boxShadow: ui.meetingChromeBoxShadow
+  },
+
+  innerBlockStyles: {
+    zIndex: 100
+  },
+
+  helpStyles: {
+    bottom: '1.25rem',
+    position: 'absolute',
+    right: '1.25rem',
+    zIndex: 200
+  },
+
+  helpIsFacilitating: {
+    bottom: '5.25rem'
   }
 });
 

--- a/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
+++ b/src/universal/modules/meeting/components/MeetingUpdates/MeetingUpdates.js
@@ -10,7 +10,7 @@ import MeetingSection from 'universal/modules/meeting/components/MeetingSection/
 import MeetingControlBar from 'universal/modules/meeting/components/MeetingControlBar/MeetingControlBar';
 import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 import withStyles from 'universal/styles/withStyles';
-import {MEETING} from 'universal/utils/constants';
+import {MEETING, UPDATES} from 'universal/utils/constants';
 import getTaskById from 'universal/utils/getTaskById';
 import isTaskPrivate from 'universal/utils/isTaskPrivate';
 
@@ -56,7 +56,7 @@ class MeetingUpdates extends Component {
     const myTeamMemberId = self && self.id;
     const {isSelf: isMyMeetingSection} = currentTeamMember;
     return (
-      <MeetingMain>
+      <MeetingMain hasHelpFor={UPDATES} isFacilitating={showMoveMeetingControls}>
         <MeetingSection flexToFill>
           <div className={css(styles.body)}>
             <TaskColumns

--- a/src/universal/modules/meeting/components/RejoinFacilitatorButton/RejoinFacilitatorButton.js
+++ b/src/universal/modules/meeting/components/RejoinFacilitatorButton/RejoinFacilitatorButton.js
@@ -5,9 +5,9 @@ import Button from 'universal/components/Button/Button';
 import styled from 'react-emotion';
 
 const RejoinButton = styled('div')({
-  bottom: '2.75rem',
+  bottom: '1.25rem',
   position: 'fixed',
-  right: '2rem',
+  right: '4.5rem',
   zIndex: ui.ziRejoinFacilitatorButton
 });
 
@@ -21,7 +21,7 @@ const RejoinFacilitatorButton = (props) => {
         icon="user"
         label="Rejoin Facilitator"
         onClick={onClickHandler}
-        buttonSize="medium"
+        buttonSize="small"
       />
     </RejoinButton>
   );


### PR DESCRIPTION
This was easy enough to shim in (I know we will refactor Action Meetings soon) and have a look at the help content for action meetings. I can submit a separate PR to add to Retro and do it in a smarter way than this using `NewMeeting` and new phase views.

### Test
- [x] The (?) shows for all views in the action meeting, and has the correct content via lookup: lobby, check-in, updates, first/last call, agenda item
- [x] The links in the help content work (new tab to Getting Started Guide and section anchors)
- [x] The (?) is positioned correctly in the main space when the meeting control bar for the facilitator is present
- [x] The “Rejoin Facilitator” button is positioned to the left of the (?) toggle for non-facilitators when not tethered with the facilitator