### PR TITLE
Scrollable block indicates overflow in retro meeting UI

### DIFF
--- a/src/universal/components/MeetingPhaseWrapper.js
+++ b/src/universal/components/MeetingPhaseWrapper.js
@@ -1,0 +1,12 @@
+import ui from 'universal/styles/ui';
+import styled from 'react-emotion';
+
+const MeetingPhaseWrapper = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-around',
+  margin: '0 auto',
+  maxWidth: ui.meetingTopicPhaseMaxWidth,
+  width: '100%'
+});
+
+export default MeetingPhaseWrapper;

--- a/src/universal/components/NewMeeting.js
+++ b/src/universal/components/NewMeeting.js
@@ -63,8 +63,11 @@ const MeetingAreaHeader = styled('div')({
   justifyContent: 'space-between',
   margin: 0,
   maxWidth: '100%',
-  padding: '0 1rem 2rem',
-  width: '100%'
+  padding: '0 1rem 1rem',
+  width: '100%',
+  [ui.breakpoint.wide]: {
+    padding: '0 1rem 2rem'
+  }
 });
 
 const MeetingHelpBlock = styled('div')(({isFacilitating}) => ({

--- a/src/universal/components/NewMeetingSidebar.js
+++ b/src/universal/components/NewMeetingSidebar.js
@@ -16,14 +16,6 @@ import makeHref from 'universal/utils/makeHref';
 import type {MeetingTypeEnum} from 'universal/types/schema.flow';
 import {meetingTypeToLabel, meetingTypeToSlug} from 'universal/utils/meetings/lookups';
 
-// const Nav = styled('nav')({
-//   display: 'flex',
-//   flex: 1,
-//   flexDirection: 'column',
-//   overflowY: 'auto',
-//   width: '100%'
-// });
-
 const SidebarHeader = styled('div')({
   paddingLeft: '3.75rem',
   position: 'relative'

--- a/src/universal/components/NewMeetingSidebar.js
+++ b/src/universal/components/NewMeetingSidebar.js
@@ -11,16 +11,18 @@ import LabelHeading from 'universal/components/LabelHeading/LabelHeading';
 import LogoBlock from 'universal/components/LogoBlock/LogoBlock';
 import NewMeetingSidebarPhaseList from 'universal/components/NewMeetingSidebarPhaseList';
 import MeetingSidebarLabelBlock from 'universal/components/MeetingSidebarLabelBlock';
+import ScrollableBlock from 'universal/components/ScrollableBlock';
 import makeHref from 'universal/utils/makeHref';
 import type {MeetingTypeEnum} from 'universal/types/schema.flow';
 import {meetingTypeToLabel, meetingTypeToSlug} from 'universal/utils/meetings/lookups';
 
-const Nav = styled('nav')({
-  display: 'flex',
-  flex: 1,
-  flexDirection: 'column',
-  width: '100%'
-});
+// const Nav = styled('nav')({
+//   display: 'flex',
+//   flex: 1,
+//   flexDirection: 'column',
+//   overflowY: 'auto',
+//   width: '100%'
+// });
 
 const SidebarHeader = styled('div')({
   paddingLeft: '3.75rem',
@@ -75,9 +77,9 @@ const NewMeetingSidebar = (props: Props) => {
       <MeetingSidebarLabelBlock>
         <LabelHeading>{`${meetingLabel} Meeting`}</LabelHeading>
       </MeetingSidebarLabelBlock>
-      <Nav>
+      <ScrollableBlock>
         <NewMeetingSidebarPhaseList gotoStageId={gotoStageId} viewer={viewer} />
-      </Nav>
+      </ScrollableBlock>
       <LogoBlock variant="primary" />
     </SidebarParent>
   );

--- a/src/universal/components/RetroDiscussPhase.js
+++ b/src/universal/components/RetroDiscussPhase.js
@@ -14,6 +14,7 @@ import findStageAfterId from 'universal/utils/meetings/findStageAfterId';
 import EndNewMeetingMutation from 'universal/mutations/EndNewMeetingMutation';
 import {withRouter} from 'react-router-dom';
 import type {RouterHistory} from 'react-router-dom';
+import ScrollableBlock from 'universal/components/ScrollableBlock';
 
 type Props = {|
   atmosphere: Object,
@@ -55,12 +56,13 @@ const PhaseWrapper = styled('div')({
 
 const ReflectionSection = styled('div')({
   borderBottom: `.0625rem solid ${ui.dashBorderColor}`,
+  display: 'flex',
+  flexDirection: 'column',
   height: '100%',
   margin: '0 auto',
   maxHeight: '35%',
   maxWidth: ui.meetingTopicPhaseMaxWidth,
-  overflowY: 'scroll',
-  padding: '0 1.375rem .875rem 2.5rem',
+  overflowY: 'auto',
   width: '100%',
 
   [ui.breakpoint.wide]: {
@@ -76,6 +78,10 @@ const ReflectionSection = styled('div')({
   }
 });
 
+const ReflectionSectionInner = styled('div')({
+  padding: '0 1.375rem .875rem 2.5rem'
+});
+
 const ReflectionGrid = styled('div')({
   display: 'grid',
   gridTemplateColumns: 'repeat(auto-fill, calc(100% / 3))'
@@ -89,7 +95,7 @@ const TaskCardBlock = styled('div')({
   flex: 1,
   margin: '0 auto',
   maxWidth: ui.meetingTopicPhaseMaxWidth,
-  overflowY: 'scroll',
+  overflowY: 'auto',
   padding: '1rem 2rem',
   width: '100%',
 
@@ -122,30 +128,36 @@ const RetroDiscussPhase = (props: Props) => {
     <React.Fragment>
       <PhaseWrapper>
         <ReflectionSection>
-          <DiscussHeader>
-            <TopicHeading><span>{'“'}</span>{`${title}”`}</TopicHeading>
-            <CheckColumn>
-              {checkMarks.map((idx) => <CheckIcon key={idx} name="check" color={ui.palette.mid} />)}
-            </CheckColumn>
-          </DiscussHeader>
-          <ReflectionGrid>
-            {reflections.map((reflection) => {
-              return (
-                <ReflectionGridBlock key={`GridBlock-${reflection.id}`}>
-                  <ReflectionCard key={reflection.id} meeting={newMeeting} reflection={reflection} />
-                </ReflectionGridBlock>
-              );
-            })}
-          </ReflectionGrid>
+          <ScrollableBlock>
+            <ReflectionSectionInner>
+              <DiscussHeader>
+                <TopicHeading><span>{'“'}</span>{`${title}”`}</TopicHeading>
+                <CheckColumn>
+                  {checkMarks.map((idx) => <CheckIcon key={idx} name="check" color={ui.palette.mid} />)}
+                </CheckColumn>
+              </DiscussHeader>
+              <ReflectionGrid>
+                {reflections.map((reflection) => {
+                  return (
+                    <ReflectionGridBlock key={`GridBlock-${reflection.id}`}>
+                      <ReflectionCard key={reflection.id} meeting={newMeeting} reflection={reflection} />
+                    </ReflectionGridBlock>
+                  );
+                })}
+              </ReflectionGrid>
+            </ReflectionSectionInner>
+          </ScrollableBlock>
         </ReflectionSection>
-        <TaskCardBlock>
-          <MeetingAgendaCards
-            meetingId={meetingId}
-            reflectionGroupId={reflectionGroupId}
-            tasks={tasks}
-            teamId={teamId}
-          />
-        </TaskCardBlock>
+        <ScrollableBlock>
+          <TaskCardBlock>
+            <MeetingAgendaCards
+              meetingId={meetingId}
+              reflectionGroupId={reflectionGroupId}
+              tasks={tasks}
+              teamId={teamId}
+            />
+          </TaskCardBlock>
+        </ScrollableBlock>
       </PhaseWrapper>
       {isFacilitating &&
       <MeetingControlBar>

--- a/src/universal/components/RetroDiscussPhase.js
+++ b/src/universal/components/RetroDiscussPhase.js
@@ -62,7 +62,6 @@ const ReflectionSection = styled('div')({
   margin: '0 auto',
   maxHeight: '35%',
   maxWidth: ui.meetingTopicPhaseMaxWidth,
-  overflowY: 'auto',
   width: '100%',
 
   [ui.breakpoint.wide]: {
@@ -92,10 +91,8 @@ const ReflectionGridBlock = styled('div')({
 });
 
 const TaskCardBlock = styled('div')({
-  flex: 1,
   margin: '0 auto',
   maxWidth: ui.meetingTopicPhaseMaxWidth,
-  overflowY: 'auto',
   padding: '1rem 2rem',
   width: '100%',
 

--- a/src/universal/components/RetroGroupPhase.js
+++ b/src/universal/components/RetroGroupPhase.js
@@ -4,7 +4,6 @@
  * @flow
  */
 import * as React from 'react';
-import styled from 'react-emotion';
 // import type {RetroGroupPhase_team as Team} from './__generated__/RetroGroupPhase_team.graphql';
 import PhaseItemColumn from 'universal/components/RetroReflectPhase/PhaseItemColumn';
 import {commitLocalUpdate, createFragmentContainer} from 'react-relay';
@@ -16,8 +15,8 @@ import dndNoise from 'universal/utils/dndNoise';
 import DragReflectionMutation from 'universal/mutations/DragReflectionMutation';
 import MeetingControlBar from 'universal/modules/meeting/components/MeetingControlBar/MeetingControlBar';
 import {Button} from 'universal/components';
-import ui from 'universal/styles/ui';
 import ScrollableBlock from 'universal/components/ScrollableBlock';
+import MeetingPhaseWrapper from 'universal/components/MeetingPhaseWrapper';
 
 const {Component} = React;
 
@@ -27,17 +26,6 @@ type Props = {
   // flow or relay-compiler is getting really confused here, so I don't use the flow type here
   team: Object,
 };
-
-const GroupPhaseWrapper = styled('div')({
-  display: 'flex',
-  // flex: 1,
-  // height: '100%',
-  justifyContent: 'space-around',
-  margin: '0 auto',
-  maxWidth: ui.meetingTopicPhaseMaxWidth,
-  // overflowY: 'auto',
-  width: '100%'
-});
 
 const getSortOrder = (index, children, inSameGroup) => {
   if (index === 0) return children[0] ? children[0].sortOrder - 1 : 0;
@@ -183,11 +171,11 @@ class RetroGroupPhase extends Component<Props> {
             onDragStart={this.onDragStart}
             onDragEnd={this.onDragEnd}
           >
-            <GroupPhaseWrapper>
+            <MeetingPhaseWrapper>
               {phaseItems.map((phaseItem, idx) =>
                 <PhaseItemColumn dndIndex={idx} meeting={newMeeting} key={phaseItem.id} retroPhaseItem={phaseItem} />
               )}
-            </GroupPhaseWrapper>
+            </MeetingPhaseWrapper>
           </DragDropContext>
         </ScrollableBlock>
         {isFacilitating &&

--- a/src/universal/components/RetroGroupPhase.js
+++ b/src/universal/components/RetroGroupPhase.js
@@ -17,6 +17,7 @@ import DragReflectionMutation from 'universal/mutations/DragReflectionMutation';
 import MeetingControlBar from 'universal/modules/meeting/components/MeetingControlBar/MeetingControlBar';
 import {Button} from 'universal/components';
 import ui from 'universal/styles/ui';
+import ScrollableBlock from 'universal/components/ScrollableBlock';
 
 const {Component} = React;
 
@@ -29,12 +30,12 @@ type Props = {
 
 const GroupPhaseWrapper = styled('div')({
   display: 'flex',
-  flex: 1,
-  height: '100%',
+  // flex: 1,
+  // height: '100%',
   justifyContent: 'space-around',
   margin: '0 auto',
   maxWidth: ui.meetingTopicPhaseMaxWidth,
-  overflowY: 'scroll',
+  // overflowY: 'auto',
   width: '100%'
 });
 
@@ -177,16 +178,18 @@ class RetroGroupPhase extends Component<Props> {
     const isFacilitating = facilitatorUserId === viewerId;
     return (
       <React.Fragment>
-        <DragDropContext
-          onDragStart={this.onDragStart}
-          onDragEnd={this.onDragEnd}
-        >
-          <GroupPhaseWrapper>
-            {phaseItems.map((phaseItem, idx) =>
-              <PhaseItemColumn dndIndex={idx} meeting={newMeeting} key={phaseItem.id} retroPhaseItem={phaseItem} />
-            )}
-          </GroupPhaseWrapper>
-        </DragDropContext>
+        <ScrollableBlock>
+          <DragDropContext
+            onDragStart={this.onDragStart}
+            onDragEnd={this.onDragEnd}
+          >
+            <GroupPhaseWrapper>
+              {phaseItems.map((phaseItem, idx) =>
+                <PhaseItemColumn dndIndex={idx} meeting={newMeeting} key={phaseItem.id} retroPhaseItem={phaseItem} />
+              )}
+            </GroupPhaseWrapper>
+          </DragDropContext>
+        </ScrollableBlock>
         {isFacilitating &&
         <MeetingControlBar>
           <Button

--- a/src/universal/components/RetroReflectPhase/RetroReflectPhase.js
+++ b/src/universal/components/RetroReflectPhase/RetroReflectPhase.js
@@ -4,7 +4,6 @@
  * @flow
  */
 import * as React from 'react';
-import styled from 'react-emotion';
 import {createFragmentContainer} from 'react-relay';
 import type {RetroReflectPhase_team as Team} from './__generated__/RetroReflectPhase_team.graphql';
 import PhaseItemColumn from 'universal/components/RetroReflectPhase/PhaseItemColumn';
@@ -12,25 +11,14 @@ import MeetingControlBar from 'universal/modules/meeting/components/MeetingContr
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
 import {Button} from 'universal/components';
 import {REFLECT} from 'universal/utils/constants';
-import ui from 'universal/styles/ui';
 import ScrollableBlock from 'universal/components/ScrollableBlock';
+import MeetingPhaseWrapper from 'universal/components/MeetingPhaseWrapper';
 
 type Props = {
   atmosphere: Object,
   gotoNext: () => void,
   team: Team,
 };
-
-const ReflectPhaseWrapper = styled('div')({
-  // height: '100%',
-  display: 'flex',
-  // flex: 1,
-  justifyContent: 'space-around',
-  margin: '0 auto',
-  maxWidth: ui.meetingTopicPhaseMaxWidth,
-  // overflowY: 'auto',
-  width: '100%'
-});
 
 const RetroReflectPhase = (props: Props) => {
   const {atmosphere: {viewerId}, team, gotoNext} = props;
@@ -41,12 +29,12 @@ const RetroReflectPhase = (props: Props) => {
   return (
     <React.Fragment>
       <ScrollableBlock>
-        <ReflectPhaseWrapper>
+        <MeetingPhaseWrapper>
           {phaseType === REFLECT &&
           phaseItems.map((phaseItem) =>
             <PhaseItemColumn meeting={newMeeting} key={phaseItem.id} retroPhaseItem={phaseItem} />
           )}
-        </ReflectPhaseWrapper>
+        </MeetingPhaseWrapper>
       </ScrollableBlock>
       {isFacilitating &&
       <MeetingControlBar>

--- a/src/universal/components/RetroReflectPhase/RetroReflectPhase.js
+++ b/src/universal/components/RetroReflectPhase/RetroReflectPhase.js
@@ -13,6 +13,7 @@ import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
 import {Button} from 'universal/components';
 import {REFLECT} from 'universal/utils/constants';
 import ui from 'universal/styles/ui';
+import ScrollableBlock from 'universal/components/ScrollableBlock';
 
 type Props = {
   atmosphere: Object,
@@ -21,13 +22,13 @@ type Props = {
 };
 
 const ReflectPhaseWrapper = styled('div')({
-  height: '100%',
+  // height: '100%',
   display: 'flex',
-  flex: 1,
+  // flex: 1,
   justifyContent: 'space-around',
   margin: '0 auto',
   maxWidth: ui.meetingTopicPhaseMaxWidth,
-  overflowY: 'scroll',
+  // overflowY: 'auto',
   width: '100%'
 });
 
@@ -39,12 +40,14 @@ const RetroReflectPhase = (props: Props) => {
   const isFacilitating = facilitatorUserId === viewerId;
   return (
     <React.Fragment>
-      <ReflectPhaseWrapper>
-        {phaseType === REFLECT &&
-        phaseItems.map((phaseItem) =>
-          <PhaseItemColumn meeting={newMeeting} key={phaseItem.id} retroPhaseItem={phaseItem} />
-        )}
-      </ReflectPhaseWrapper>
+      <ScrollableBlock>
+        <ReflectPhaseWrapper>
+          {phaseType === REFLECT &&
+          phaseItems.map((phaseItem) =>
+            <PhaseItemColumn meeting={newMeeting} key={phaseItem.id} retroPhaseItem={phaseItem} />
+          )}
+        </ReflectPhaseWrapper>
+      </ScrollableBlock>
       {isFacilitating &&
       <MeetingControlBar>
         <Button

--- a/src/universal/components/RetroSidebarDiscussSection.js
+++ b/src/universal/components/RetroSidebarDiscussSection.js
@@ -15,6 +15,7 @@ type Props = {|
 
 const SidebarPhaseItemChild = styled('div')({
   display: 'flex',
+  flex: 1,
   flexDirection: 'column'
 });
 
@@ -53,6 +54,11 @@ const CheckIcon = styled(StyledFontAwesome)({
   color: ui.palette.mid
 });
 
+const ScrollableNavList = styled('div')({
+  flex: 1,
+  overflowY: 'auto'
+});
+
 const RetroSidebarDiscussSection = (props: Props) => {
   const {gotoStageId, viewer: {team: {newMeeting}}} = props;
   const {localPhase} = newMeeting || {};
@@ -63,22 +69,24 @@ const RetroSidebarDiscussSection = (props: Props) => {
       <MeetingSidebarLabelBlock>
         <LabelHeading>{'Upvoted Topics'}</LabelHeading>
       </MeetingSidebarLabelBlock>
-      {stages.map((stage, idx) => {
-        const {reflectionGroup} = stage;
-        if (!reflectionGroup) return null;
-        const {title, voteCount} = reflectionGroup;
-        return (
-          <TopicRow key={stage.id} onClick={() => gotoStageId(stage.id)}>
-            <IndexBlock>{`${idx + 1}.`}</IndexBlock>
-            <Title>{title}</Title>
-            <VoteTally>
-              <CheckIcon name="check" />
-              {' x '}
-              {voteCount}
-            </VoteTally>
-          </TopicRow>
-        );
-      })}
+      <ScrollableNavList>
+        {stages.map((stage, idx) => {
+          const {reflectionGroup} = stage;
+          if (!reflectionGroup) return null;
+          const {title, voteCount} = reflectionGroup;
+          return (
+            <TopicRow key={stage.id} onClick={() => gotoStageId(stage.id)}>
+              <IndexBlock>{`${idx + 1}.`}</IndexBlock>
+              <Title>{title}</Title>
+              <VoteTally>
+                <CheckIcon name="check" />
+                {' x '}
+                {voteCount}
+              </VoteTally>
+            </TopicRow>
+          );
+        })}
+      </ScrollableNavList>
     </SidebarPhaseItemChild>
   );
 };

--- a/src/universal/components/RetroSidebarDiscussSection.js
+++ b/src/universal/components/RetroSidebarDiscussSection.js
@@ -15,7 +15,6 @@ type Props = {|
 
 const SidebarPhaseItemChild = styled('div')({
   display: 'flex',
-  flex: 1,
   flexDirection: 'column'
 });
 
@@ -54,11 +53,6 @@ const CheckIcon = styled(StyledFontAwesome)({
   color: ui.palette.mid
 });
 
-const ScrollableNavList = styled('div')({
-  flex: 1,
-  overflowY: 'auto'
-});
-
 const RetroSidebarDiscussSection = (props: Props) => {
   const {gotoStageId, viewer: {team: {newMeeting}}} = props;
   const {localPhase} = newMeeting || {};
@@ -69,24 +63,22 @@ const RetroSidebarDiscussSection = (props: Props) => {
       <MeetingSidebarLabelBlock>
         <LabelHeading>{'Upvoted Topics'}</LabelHeading>
       </MeetingSidebarLabelBlock>
-      <ScrollableNavList>
-        {stages.map((stage, idx) => {
-          const {reflectionGroup} = stage;
-          if (!reflectionGroup) return null;
-          const {title, voteCount} = reflectionGroup;
-          return (
-            <TopicRow key={stage.id} onClick={() => gotoStageId(stage.id)}>
-              <IndexBlock>{`${idx + 1}.`}</IndexBlock>
-              <Title>{title}</Title>
-              <VoteTally>
-                <CheckIcon name="check" />
-                {' x '}
-                {voteCount}
-              </VoteTally>
-            </TopicRow>
-          );
-        })}
-      </ScrollableNavList>
+      {stages.map((stage, idx) => {
+        const {reflectionGroup} = stage;
+        if (!reflectionGroup) return null;
+        const {title, voteCount} = reflectionGroup;
+        return (
+          <TopicRow key={stage.id} onClick={() => gotoStageId(stage.id)}>
+            <IndexBlock>{`${idx + 1}.`}</IndexBlock>
+            <Title>{title}</Title>
+            <VoteTally>
+              <CheckIcon name="check" />
+              {' x '}
+              {voteCount}
+            </VoteTally>
+          </TopicRow>
+        );
+      })}
     </SidebarPhaseItemChild>
   );
 };

--- a/src/universal/components/RetroVotePhase.js
+++ b/src/universal/components/RetroVotePhase.js
@@ -7,6 +7,7 @@ import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
 import MeetingControlBar from 'universal/modules/meeting/components/MeetingControlBar/MeetingControlBar';
 import {Button} from 'universal/components';
 import ui from 'universal/styles/ui';
+import ScrollableBlock from 'universal/components/ScrollableBlock';
 
 type Props = {|
   atmosphere: Object,
@@ -17,12 +18,12 @@ type Props = {|
 
 const VotePhaseWrapper = styled('div')({
   display: 'flex',
-  flex: 1,
-  height: '100%',
+  // flex: 1,
+  // height: '100%',
   justifyContent: 'space-around',
   margin: '0 auto',
   maxWidth: ui.meetingTopicPhaseMaxWidth,
-  overflowY: 'scroll',
+  // overflowY: 'auto',
   width: '100%'
 });
 
@@ -34,11 +35,13 @@ const RetroVotePhase = (props: Props) => {
   const isFacilitating = facilitatorUserId === viewerId;
   return (
     <React.Fragment>
-      <VotePhaseWrapper>
-        {phaseItems.map((phaseItem) =>
-          <PhaseItemColumn meeting={newMeeting} key={phaseItem.id} retroPhaseItem={phaseItem} />
-        )}
-      </VotePhaseWrapper>
+      <ScrollableBlock>
+        <VotePhaseWrapper>
+          {phaseItems.map((phaseItem) =>
+            <PhaseItemColumn meeting={newMeeting} key={phaseItem.id} retroPhaseItem={phaseItem} />
+          )}
+        </VotePhaseWrapper>
+      </ScrollableBlock>
       {isFacilitating &&
       <MeetingControlBar>
         <Button

--- a/src/universal/components/RetroVotePhase.js
+++ b/src/universal/components/RetroVotePhase.js
@@ -1,13 +1,12 @@
 // @flow
 import * as React from 'react';
-import styled from 'react-emotion';
 import PhaseItemColumn from 'universal/components/RetroReflectPhase/PhaseItemColumn';
 import {createFragmentContainer} from 'react-relay';
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
 import MeetingControlBar from 'universal/modules/meeting/components/MeetingControlBar/MeetingControlBar';
 import {Button} from 'universal/components';
-import ui from 'universal/styles/ui';
 import ScrollableBlock from 'universal/components/ScrollableBlock';
+import MeetingPhaseWrapper from 'universal/components/MeetingPhaseWrapper';
 
 type Props = {|
   atmosphere: Object,
@@ -15,17 +14,6 @@ type Props = {|
   // flow or relay-compiler is getting really confused here, so I don't use the flow type here
   team: Object,
 |};
-
-const VotePhaseWrapper = styled('div')({
-  display: 'flex',
-  // flex: 1,
-  // height: '100%',
-  justifyContent: 'space-around',
-  margin: '0 auto',
-  maxWidth: ui.meetingTopicPhaseMaxWidth,
-  // overflowY: 'auto',
-  width: '100%'
-});
 
 const RetroVotePhase = (props: Props) => {
   const {atmosphere: {viewerId}, gotoNext, team} = props;
@@ -36,11 +24,11 @@ const RetroVotePhase = (props: Props) => {
   return (
     <React.Fragment>
       <ScrollableBlock>
-        <VotePhaseWrapper>
+        <MeetingPhaseWrapper>
           {phaseItems.map((phaseItem) =>
             <PhaseItemColumn meeting={newMeeting} key={phaseItem.id} retroPhaseItem={phaseItem} />
           )}
-        </VotePhaseWrapper>
+        </MeetingPhaseWrapper>
       </ScrollableBlock>
       {isFacilitating &&
       <MeetingControlBar>

--- a/src/universal/components/ScrollableBlock.js
+++ b/src/universal/components/ScrollableBlock.js
@@ -1,11 +1,13 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import styled, {css} from 'react-emotion';
+import ui from 'universal/styles/ui';
 
 const ScrollableRoot = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   flex: 1,
+  overflow: 'hidden',
   width: '100%'
 });
 
@@ -18,16 +20,14 @@ const ScrollableInner = css({
 
 const ScrollableShadow = styled('div')(
   {
+    backgroundColor: ui.scrollableBackgroundColor,
     minHeight: '.0625rem',
-    position: 'relative'
+    position: 'relative',
+    zIndex: 200
   },
-  ({positionTop}) => positionTop && ({
-    boxShadow: '0 .0625rem .0625rem rgba(0, 0, 0, 0.2)',
-    top: '-.0625rem'
-  }),
-  ({positionBottom}) => positionBottom && ({
-    boxShadow: '0 -.0625rem .0625rem rgba(0, 0, 0, 0.2)',
-    top: '.0625rem'
+  ({overflown}) => overflown && ({
+    boxShadow: overflown === 'top' ? ui.scrollableTopShadow : ui.scrollableBottomShadow,
+    top: overflown === 'top' ? '-.0625rem' : '.0625rem'
   })
 );
 
@@ -84,11 +84,11 @@ class ScrollableBlock extends Component {
     const {overflownAbove, overflownBelow} = this.state;
     return (
       <ScrollableRoot>
-        {overflownAbove && <ScrollableShadow positionTop />}
+        {overflownAbove && <ScrollableShadow overflown="top" />}
         <div className={ScrollableInner} ref={this.setOverflowContainerElRef}>
           {children}
         </div>
-        {overflownBelow && <ScrollableShadow positionBottom />}
+        {overflownBelow && <ScrollableShadow overflown="bottom" />}
       </ScrollableRoot>
     );
   }

--- a/src/universal/components/ScrollableBlock.js
+++ b/src/universal/components/ScrollableBlock.js
@@ -1,0 +1,97 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import styled, {css} from 'react-emotion';
+
+const ScrollableRoot = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  width: '100%'
+});
+
+const ScrollableInner = css({
+  flex: 1,
+  overflowY: 'auto',
+  '-webkit-overflow-scrolling': 'touch',
+  width: '100%'
+});
+
+const ScrollableShadow = styled('div')(
+  {
+    minHeight: '.0625rem',
+    position: 'relative'
+  },
+  ({positionTop}) => positionTop && ({
+    boxShadow: '0 .0625rem .0625rem rgba(0, 0, 0, 0.2)',
+    top: '-.0625rem'
+  }),
+  ({positionBottom}) => positionBottom && ({
+    boxShadow: '0 -.0625rem .0625rem rgba(0, 0, 0, 0.2)',
+    top: '.0625rem'
+  })
+);
+
+class ScrollableBlock extends Component {
+  static propTypes = {
+    children: PropTypes.any
+  };
+
+  state = {
+    filteredAgendaItems: [],
+    overflownAbove: false,
+    overflownBelow: false
+  };
+
+  setOverflowContainerElRef = (el) => {
+    this.overflowContainerEl = el;
+    this.setState({
+      overflownAbove: this.isOverflownAbove(),
+      overflownBelow: this.isOverflownBelow()
+    });
+    if (!el) { return; }
+    this.overflowContainerEl.addEventListener('scroll', () => {
+      const overflownAbove = this.isOverflownAbove();
+      const overflownBelow = this.isOverflownBelow();
+      const newState = {};
+      if (this.state.overflownAbove !== overflownAbove) {
+        newState.overflownAbove = overflownAbove;
+      }
+      if (this.state.overflownBelow !== overflownBelow) {
+        newState.overflownBelow = overflownBelow;
+      }
+      if (Object.keys(newState).length) {
+        this.setState(newState);
+      }
+    });
+  }
+
+  overflowContainerEl = null;
+
+  isOverflownAbove = () => {
+    const {overflowContainerEl} = this;
+    if (!overflowContainerEl) { return false; }
+    return overflowContainerEl.scrollTop > 0;
+  };
+
+  isOverflownBelow = () => {
+    const {overflowContainerEl} = this;
+    if (!overflowContainerEl) { return false; }
+    return overflowContainerEl.scrollHeight - overflowContainerEl.scrollTop > overflowContainerEl.clientHeight;
+  };
+
+  render() {
+    const {children} = this.props;
+    const {overflownAbove, overflownBelow} = this.state;
+    return (
+      <ScrollableRoot>
+        {overflownAbove && <ScrollableShadow positionTop />}
+        <div className={ScrollableInner} ref={this.setOverflowContainerElRef}>
+          {children}
+        </div>
+        {overflownBelow && <ScrollableShadow positionBottom />}
+      </ScrollableRoot>
+    );
+  }
+}
+
+export default ScrollableBlock;

--- a/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
+++ b/src/universal/modules/teamDashboard/components/AgendaList/AgendaList.js
@@ -121,7 +121,7 @@ class AgendaList extends Component {
         style={{
           position: 'relative',
           top: '-1px',
-          boxShadow: '0 1px 1px rgba(0, 0, 0, 0.25)',
+          boxShadow: '0 1px 1px rgba(0, 0, 0, 0.2)',
           minHeight: '1px'
         }}
       />
@@ -134,7 +134,7 @@ class AgendaList extends Component {
         style={{
           position: 'relative',
           top: '1px',
-          boxShadow: '0 -1px 1px rgba(0, 0, 0, 0.25)',
+          boxShadow: '0 -1px 1px rgba(0, 0, 0, 0.2)',
           minHeight: '1px'
         }}
       />

--- a/src/universal/styles/ui.js
+++ b/src/universal/styles/ui.js
@@ -667,6 +667,9 @@ const ui = {
 
   // Shadows
   shadow,
+  scrollableBackgroundColor: appTheme.palette.mid10a,
+  scrollableBottomShadow: `0 -.125rem .5rem ${makeShadowColor('.4')}`,
+  scrollableTopShadow: `0 .125rem .5rem ${makeShadowColor('.4')}`,
 
   // Tags
   // ---------------------------------------------------------------------------

--- a/src/universal/types/schema.flow.js
+++ b/src/universal/types/schema.flow.js
@@ -957,8 +957,6 @@ export type SlackIntegration = {
 export type OrgTierEnum = "personal" | "pro" | "enterprise";
 
 export type SuProOrgInfo = {
-  /** The count of active users within the org */
-  activeCount: ?number;
   /** The PRO organization */
   organization: ?Organization;
   /** The id of the Organization */


### PR DESCRIPTION
This fixes #2013 and improves phase view overflow.

The following Retro UI components can overflow in a small viewport:

- The left nav with many discussion topics
- The reflect phase with many cards
- The group phase with many cards
- The vote phase with many cards
- The reflections and/or the new tasks in the discuss phase

This component abstracts what we did on the team agenda list when it overflows. It adds a box-shadow at the top or bottom depending on where the overflow is with the idea that it helps indicate visually that there is more to scroll to.

We can improve the component to better listen and detect overflow on initial load and on changes, but I think it’s safe to try.