### PR TITLE
small retro fixes

### DIFF
--- a/src/server/graphql/mutations/endNewMeeting.js
+++ b/src/server/graphql/mutations/endNewMeeting.js
@@ -60,7 +60,7 @@ export default {
     const meetingMembers = await dataLoader.get('meetingMembersByMeetingId').load(meetingId);
     const presentMembers = meetingMembers.filter((meetingMember) => meetingMember.isCheckedIn === true);
     const presentMemberUserIds = presentMembers.map(({userId}) => userId);
-    endSlackMeeting(meetingId, teamId);
+    endSlackMeeting(meetingId, teamId, true);
 
     if (lastPhaseStarted) {
       sendSegmentEvent('Retro Meeting Completed', presentMemberUserIds, {teamId, meetingNumber});

--- a/src/server/graphql/mutations/startNewMeeting.js
+++ b/src/server/graphql/mutations/startNewMeeting.js
@@ -87,7 +87,7 @@ export default {
       members: r.table('MeetingMember').insert(meetingMembers)
     });
 
-    startSlackMeeting(teamId);
+    startSlackMeeting(teamId, meetingType);
     const data = {teamId, meetingId};
     publish(TEAM, teamId, StartNewMeetingPayload, data, subOptions);
     return data;

--- a/src/universal/components/ReflectionCard/ReflectionCard.js
+++ b/src/universal/components/ReflectionCard/ReflectionCard.js
@@ -126,12 +126,9 @@ class ReflectionCard extends Component<Props, State> {
   render() {
     const {atmosphere, error, isCollapsed, meeting, reflection, showOriginFooter} = this.props;
     const {editorState} = this.state;
-    const {localPhase: {phaseType}, phases, teamId} = meeting;
+    const {localPhase: {phaseType}, localStage: {isComplete}, teamId} = meeting;
     const {draggerUser, isViewerCreator, phaseItem: {question}} = reflection;
-    const meetingStageRes = findMeetingStage(phases);
-    if (!meetingStageRes) return null;
-    const {phase: {phaseType: meetingPhaseType}} = meetingStageRes;
-    const canDelete = isViewerCreator && phaseType === REFLECT && meetingPhaseType === REFLECT;
+    const canDelete = isViewerCreator && phaseType === REFLECT && !isComplete;
     const hasDragLock = draggerUser && draggerUser.id !== atmosphere.viewerId;
     return (
       <ReflectionCardRoot hasDragLock={hasDragLock} isCollapsed={isCollapsed}>
@@ -142,7 +139,7 @@ class ReflectionCard extends Component<Props, State> {
           onBlur={this.handleEditorBlur}
           onFocus={this.handleEditorFocus}
           placeholder="My reflection thought..."
-          readOnly={phaseType !== REFLECT}
+          readOnly={phaseType !== REFLECT || isComplete}
           setEditorState={this.setEditorState}
           teamId={teamId}
         />
@@ -164,6 +161,9 @@ export default createFragmentContainer(
       teamId
       localPhase {
         phaseType
+      }
+      localStage {
+        isComplete
       }
       phases {
         phaseType

--- a/src/universal/components/ReflectionCard/ReflectionCard.js
+++ b/src/universal/components/ReflectionCard/ReflectionCard.js
@@ -27,7 +27,6 @@ import UserDraggingHeader from 'universal/components/UserDraggingHeader';
 import ui from 'universal/styles/ui';
 import appTheme from 'universal/styles/theme/appTheme';
 import textOverflow from 'universal/styles/helpers/textOverflow';
-import findMeetingStage from 'universal/utils/meetings/findMeetingStage';
 import StyledError from 'universal/components/StyledError';
 
 export type Props = {|

--- a/src/universal/components/RetroReflectPhase/PhaseItemColumn.js
+++ b/src/universal/components/RetroReflectPhase/PhaseItemColumn.js
@@ -23,7 +23,6 @@ import reactLifecyclesCompat from 'react-lifecycles-compat';
 import ReflectionDropZone from 'universal/components/ReflectionDropZone';
 import ReflectionCard from 'universal/components/ReflectionCard/ReflectionCard';
 import AnonymousReflectionCard from 'universal/components/AnonymousReflectionCard/AnonymousReflectionCard';
-import findMeetingStage from 'universal/utils/meetings/findMeetingStage';
 
 import {LabelHeading} from 'universal/components';
 
@@ -108,11 +107,8 @@ class PhaseItemColumn extends Component<Props, State> {
   render() {
     const {meeting, retroPhaseItem} = this.props;
     const {columnReflectionGroups} = this.state;
-    const {localPhase: {phaseType}, phases} = meeting;
+    const {localPhase: {phaseType}, localStage: {isComplete}} = meeting;
     const {retroPhaseItemId, title, question} = retroPhaseItem;
-    const meetingStageRes = findMeetingStage(phases);
-    if (!meetingStageRes) return null;
-    const {phase: {phaseType: meetingPhaseType}} = meetingStageRes;
     return (
       <ColumnWrapper>
         <TypeHeader>
@@ -171,12 +167,12 @@ class PhaseItemColumn extends Component<Props, State> {
               return null;
             })}
           </ReflectionsList>
-          {phaseType === GROUP && meetingPhaseType === GROUP &&
+          {phaseType === GROUP && !isComplete &&
           <EntireDropZone>
             <ReflectionDropZone retroPhaseItem={retroPhaseItem} />
           </EntireDropZone>
           }
-          {phaseType === REFLECT && meetingPhaseType === REFLECT &&
+          {phaseType === REFLECT && !isComplete &&
           <ColumnChild>
             <ButtonBlock>
               <AddReflectionButton columnReflectionGroups={columnReflectionGroups} meeting={meeting} retroPhaseItem={retroPhaseItem} />
@@ -210,6 +206,9 @@ export default createFragmentContainer(
       meetingId: id
       localPhase {
         phaseType
+      }
+      localStage {
+        isComplete
       }
       phases {
         id

--- a/src/universal/components/RetroSidebarVoteSection.js
+++ b/src/universal/components/RetroSidebarVoteSection.js
@@ -47,9 +47,9 @@ const TeamVotesLabel = styled('div')({
 });
 
 const RetroSidebarVoteSection = (props: Props) => {
-  const {viewer: {meetingMember, team: {meetingSettings: {totalVotes = 0}, newMeeting}}} = props;
-  const {teamVotesRemaining = 0} = newMeeting || {};
-  const {myVotesRemaining = 0} = meetingMember || {};
+  const {viewer: {team: {meetingSettings: {totalVotes = 0}, newMeeting}}} = props;
+  const {teamVotesRemaining = 0, viewerMeetingMember} = newMeeting || {};
+  const {myVotesRemaining = 0} = viewerMeetingMember || {};
   const checkMarks = [...Array(totalVotes).keys()];
   return (
     <SidebarPhaseItemChild>
@@ -67,11 +67,6 @@ export default createFragmentContainer(
   RetroSidebarVoteSection,
   graphql`
     fragment RetroSidebarVoteSection_viewer on User {
-      meetingMember(teamId: $teamId) {
-        ... on RetrospectiveMeetingMember {
-          myVotesRemaining: votesRemaining
-        }
-      }
       team(teamId: $teamId) {
         meetingSettings(meetingType: $meetingType) {
           ... on RetrospectiveMeetingSettings {
@@ -81,6 +76,9 @@ export default createFragmentContainer(
         newMeeting {
           ... on RetrospectiveMeeting {
             teamVotesRemaining: votesRemaining
+            viewerMeetingMember {
+              myVotesRemaining: votesRemaining
+            }
           }
         }
       }

--- a/src/universal/modules/teamDashboard/components/TeamCallsToAction/TeamCallsToAction.js
+++ b/src/universal/modules/teamDashboard/components/TeamCallsToAction/TeamCallsToAction.js
@@ -62,7 +62,7 @@ const TeamCallToAction = (props: Props) => {
 
   return (
     <ButtonGroup>
-      {isRetroEnabled ?
+      {!isRetroEnabled ?
         <LoadableMenu
           LoadableComponent={LoadableTeamCallsToActionMenu}
           maxWidth={208}

--- a/src/universal/mutations/EndNewMeetingMutation.js
+++ b/src/universal/mutations/EndNewMeetingMutation.js
@@ -2,7 +2,6 @@ import {commitMutation} from 'react-relay';
 import {showInfo} from 'universal/modules/toast/ducks/toastDuck';
 import getMeetingPathParams from 'universal/utils/meetings/getMeetingPathParams';
 import handleMutationError from 'universal/mutations/handlers/handleMutationError';
-import getInProxy from 'universal/utils/relay/getInProxy';
 
 graphql`
   fragment EndNewMeetingMutation_team on EndNewMeetingPayload {
@@ -11,7 +10,11 @@ graphql`
       id
     }
     team {
+      id
       meetingId
+      newMeeting {
+        id
+      }
     }
   }
 `;
@@ -52,22 +55,10 @@ export const endNewMeetingTeamOnNext = (payload, context) => {
   }
 };
 
-export const endNewMeetingTeamUpdater = (payload, {store}) => {
-  const meetingId = getInProxy(payload, 'meeting', 'id');
-  const meeting = store.get(meetingId);
-  meeting.setValue(undefined, 'localPhase');
-  meeting.setValue(undefined, 'localStage');
-};
-
 const EndNewMeetingMutation = (environment, variables, context, onError, onCompleted) => {
   return commitMutation(environment, {
     mutation,
     variables,
-    updater: (store) => {
-      const payload = store.getRootField('endNewMeeting');
-      if (!payload) return;
-      endNewMeetingTeamUpdater(payload, {store});
-    },
     onCompleted: (res, errors) => {
       if (onCompleted) {
         onCompleted(res, errors);

--- a/src/universal/mutations/UpdateReflectionLocationMutation.js
+++ b/src/universal/mutations/UpdateReflectionLocationMutation.js
@@ -51,6 +51,9 @@ const mutation = graphql`
   mutation UpdateReflectionLocationMutation($reflectionGroupId: ID, $reflectionId: ID, $retroPhaseItemId: ID, $sortOrder: Float!) {
     updateReflectionLocation(
       reflectionGroupId: $reflectionGroupId, reflectionId: $reflectionId, retroPhaseItemId: $retroPhaseItemId, sortOrder: $sortOrder) {
+      error {
+        message
+      }
       ...UpdateReflectionLocationMutation_team @relay(mask: false)
     }
   }
@@ -63,6 +66,7 @@ const handleRemoveReflectionFromGroup = (reflectionId, reflectionGroupId, store)
 };
 
 const moveGroupLocation = (reflectionGroupProxy, store) => {
+  if (!reflectionGroupProxy) return;
   const reflectionGroupId = reflectionGroupProxy.getValue('id');
   const meetingId = reflectionGroupProxy.getValue('meetingId');
   handleRemoveReflectionGroups(reflectionGroupId, meetingId, store);

--- a/src/universal/subscriptions/TeamSubscription.js
+++ b/src/universal/subscriptions/TeamSubscription.js
@@ -16,7 +16,7 @@ import {navigateMeetingTeamOnNext} from 'universal/mutations/NavigateMeetingMuta
 import {promoteNewMeetingFacilitatorTeamOnNext} from 'universal/mutations/PromoteNewMeetingFacilitatorMutation';
 import {editReflectionTeamUpdater} from 'universal/mutations/EditReflectionMutation';
 import {updateReflectionLocationTeamUpdater} from 'universal/mutations/UpdateReflectionLocationMutation';
-import {endNewMeetingTeamOnNext, endNewMeetingTeamUpdater} from 'universal/mutations/EndNewMeetingMutation';
+import {endNewMeetingTeamOnNext} from 'universal/mutations/EndNewMeetingMutation';
 
 const subscription = graphql`
   subscription TeamSubscription {
@@ -110,7 +110,6 @@ const TeamSubscription = (environment, queryVariables, subParams) => {
           endMeetingTeamUpdater(payload, options);
           break;
         case 'EndNewMeetingPayload':
-          endNewMeetingTeamUpdater(payload, options);
           break;
         case 'InviteTeamMembersPayload':
           inviteTeamMembersTeamUpdater(payload, store, viewerId);

--- a/src/universal/types/schema.flow.js
+++ b/src/universal/types/schema.flow.js
@@ -1438,8 +1438,8 @@ export type RetrospectiveMeeting = {
   team: Team;
   /** The last time a meeting was updated (stage completed, finished, etc) */
   updatedAt: ?any;
-  /** The meeting member of the viewer */
-  viewerMeetingMember: ?MeetingMember;
+  /** The retrospective meeting member of the viewer */
+  viewerMeetingMember: ?RetrospectiveMeetingMember;
   /** the threshold used to achieve the autogroup. Useful for model tuning. Serves as a flag if autogroup was used. */
   autoGroupThreshold: ?number;
   /** The grouped reflections */
@@ -1449,6 +1449,26 @@ export type RetrospectiveMeeting = {
   /** The tasks created within the meeting */
   tasks: Array<Task>;
   /** The sum total of the votes remaining for the meeting members that are present in the meeting */
+  votesRemaining: number;
+}
+
+/**
+  All the meeting specifics for a user in a retro meeting
+*/
+export type RetrospectiveMeetingMember = {
+  /** A composite of userId::meetingId */
+  id: string;
+  /** true if present, false if absent, else null */
+  isCheckedIn: ?boolean;
+  meetingId: ?string;
+  meetingType: MeetingTypeEnum;
+  teamId: ?string;
+  user: ?User;
+  userId: ?string;
+  /** The last time a meeting was updated (stage completed, finished, etc) */
+  updatedAt: ?any;
+  /** The tasks assigned to members during the meeting */
+  tasks: Array<Task>;
   votesRemaining: number;
 }
 
@@ -2199,26 +2219,6 @@ export type VoteForReflectionGroupPayload = {
   meeting: ?RetrospectiveMeeting;
   reflectionGroup: ?RetroReflectionGroup;
   meetingMember: ?RetrospectiveMeetingMember;
-}
-
-/**
-  All the meeting specifics for a user in a retro meeting
-*/
-export type RetrospectiveMeetingMember = {
-  /** A composite of userId::meetingId */
-  id: string;
-  /** true if present, false if absent, else null */
-  isCheckedIn: ?boolean;
-  meetingId: ?string;
-  meetingType: MeetingTypeEnum;
-  teamId: ?string;
-  user: ?User;
-  userId: ?string;
-  /** The last time a meeting was updated (stage completed, finished, etc) */
-  updatedAt: ?any;
-  /** The tasks assigned to members during the meeting */
-  tasks: Array<Task>;
-  votesRemaining: number;
 }
 
 export type LoginPayload = {

--- a/src/universal/utils/meetings/findFirstStageInPhase.js
+++ b/src/universal/utils/meetings/findFirstStageInPhase.js
@@ -1,0 +1,17 @@
+// @flow
+
+import type {NewMeetingPhaseTypeEnum} from 'universal/types/schema.flow';
+
+const findFirstStageInPhase = (phases: $ReadOnlyArray<Object>, phaseType: NewMeetingPhaseTypeEnum) => {
+  if (!phases) return undefined;
+  for (let ii = 0; ii < phases.length; ii++) {
+    const phase = phases[ii];
+    const {stages} = phase;
+    if (phase.phaseType === phaseType) {
+      return {stage: stages[0], phase};
+    }
+  }
+  return undefined;
+};
+
+export default findFirstStageInPhase;

--- a/src/universal/utils/meetings/getIsNavigable.js
+++ b/src/universal/utils/meetings/getIsNavigable.js
@@ -1,32 +1,25 @@
-import findStageBeforeId from 'universal/utils/meetings/findStageBeforeId';
+// @flow
 
-const facilitatorCanNavigateToStage = (phases, stageId) => {
-  // i can go to the itemStage as long as it is <= meetingStage +1
-  let atMeetingStage;
+const getIsNavigable = (isViewerFacilitator: boolean, phases: $ReadOnlyArray<Object>, stageId: string) => {
+  if (!stageId) return false;
+  const facilitatorBonus = Number(isViewerFacilitator);
+  let meetingPhaseIdx;
   for (let ii = 0; ii < phases.length; ii++) {
+    // only let them go to the next phase
+    if (meetingPhaseIdx !== undefined && ii > meetingPhaseIdx + facilitatorBonus) return false;
     const phase = phases[ii];
     const {stages} = phase;
     for (let jj = 0; jj < stages.length; jj++) {
       const stage = stages[jj];
+      // if they go to the next phase, only let them go to the first stage
+      if (meetingPhaseIdx !== undefined && ii > meetingPhaseIdx && jj > 0) return false;
       if (stage.id === stageId) return true;
-      if (atMeetingStage) return false;
       if (!stage.isComplete) {
-        atMeetingStage = true;
+        meetingPhaseIdx = ii;
       }
     }
   }
   return false;
-};
-
-const getIsNavigable = (isViewerFacilitator, phases, stageId) => {
-  if (!stageId) return false;
-  if (isViewerFacilitator) {
-    return facilitatorCanNavigateToStage(phases, stageId);
-  }
-  // the first is always free
-  if (phases[0].stages[0].id === stageId) return true;
-  const {stage} = findStageBeforeId(phases, stageId);
-  return stage.isComplete;
 };
 
 export default getIsNavigable;

--- a/src/universal/utils/meetings/isForwardProgress.js
+++ b/src/universal/utils/meetings/isForwardProgress.js
@@ -1,0 +1,25 @@
+// @flow
+
+
+// import type {NewMeetingPhase} from 'universal/types/schema.flow';
+
+const isForwardProgress = (phases: $ReadOnlyArray<Object>, stageId: string, nextStageId: string) => {
+  if (!phases || !stageId || !nextStageId) return false;
+  let stageFound = false;
+  for (let ii = 0; ii < phases.length; ii++) {
+    const phase = phases[ii];
+    const {stages} = phase;
+    for (let jj = 0; jj < stages.length; jj++) {
+      const stage = stages[jj];
+      if (stageFound === true && stage.id === nextStageId) {
+        return true;
+      }
+      if (stage.id === stageId) {
+        stageFound = true;
+      }
+    }
+  }
+  return false;
+};
+
+export default isForwardProgress;


### PR DESCRIPTION
TEST

- [ ] start a meeting, write 5 reflections, go to grouping phase, then go back to reflection phase, notice you cannot edit a reflection, then back to grouping phase. group 2 of the cards together
- [ ] get to the voting phase _without refreshing_, it properly shows your votes
- [ ] go back to the grouping phase, group 2 cards, see an error message
- [ ] vote on 5 items, go to the discuss phase, any meeting participant can skip to any of the discussion topics
- [ ] go to slack, click the meeting started link, it takes you to the meeting
- [ ] finish the meeting. go to slack & see click the end meeting link. it works
- [ ] start a new meeting, get to the reflection phase. type "icanthackit", the meeting is killed & the phases all have purple bubbles