### PR TITLE
fix #1659 suppress task involvement notifications in meeting

### DIFF
--- a/src/universal/mutations/UpdateTaskMutation.js
+++ b/src/universal/mutations/UpdateTaskMutation.js
@@ -32,8 +32,8 @@ graphql`
 `;
 
 const mutation = graphql`
-  mutation UpdateTaskMutation($updatedTask: UpdateTaskInput!) {
-    updateTask(updatedTask: $updatedTask) {
+  mutation UpdateTaskMutation($updatedTask: UpdateTaskInput!, $area: AreaEnum) {
+    updateTask(updatedTask: $updatedTask, area: $area) {
       error {
         message
       }


### PR DESCRIPTION
TEST
- [ ] have a team with 2 members
- [ ] start an action meeting, both are checked in as present, create an agenda item
- [ ] go to agenda item, as user 1, mention user 2 in a new task
- [ ] user 2 does not receive a notification

