### PR TITLE
no logout on app upgrade

### DIFF
--- a/src/universal/components/SocketHealthMonitor.js
+++ b/src/universal/components/SocketHealthMonitor.js
@@ -4,14 +4,13 @@ import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
 import {connect} from 'react-redux';
 import popUpgradeAppToast from 'universal/mutations/toasts/popUpgradeAppToast';
 import {showError, showSuccess, showWarning} from 'universal/modules/toast/ducks/toastDuck';
-import {withRouter} from 'react-router-dom';
 import raven from 'raven-js';
+import {APP_VERSION_KEY} from 'universal/utils/constants';
 
 class SocketHealthMonitor extends Component {
   static propTypes = {
     atmosphere: PropTypes.object.isRequired,
-    dispatch: PropTypes.func.isRequired,
-    history: PropTypes.object.isRequired
+    dispatch: PropTypes.func.isRequired
   };
 
   componentWillMount() {
@@ -25,19 +24,26 @@ class SocketHealthMonitor extends Component {
     });
   }
   onReconnected = (payload) => {
-    const {dispatch, history} = this.props;
+    const {dispatch} = this.props;
     const {version} = payload;
-    popUpgradeAppToast(version, {dispatch, history});
-    dispatch(showSuccess({
-      autoDismiss: 5,
-      title: 'You’re back online!',
-      message: 'You were offline for a bit, but we’ve reconnected you.'
-    }));
+    const versionInStorage = window.localStorage.getItem(APP_VERSION_KEY);
+    if (version !== versionInStorage) {
+      popUpgradeAppToast({dispatch});
+    } else {
+      dispatch(showSuccess({
+        autoDismiss: 5,
+        title: 'You’re back online!',
+        message: 'You were offline for a bit, but we’ve reconnected you.'
+      }));
+    }
   };
   onConnected = (payload) => {
-    const {dispatch, history} = this.props;
+    const {dispatch} = this.props;
     const {version} = payload;
-    popUpgradeAppToast(version, {dispatch, history});
+    const versionInStorage = window.localStorage.getItem(APP_VERSION_KEY);
+    if (version !== versionInStorage) {
+      popUpgradeAppToast({dispatch});
+    }
   };
   onDisconnected = () => {
     const {atmosphere: {subscriptionClient}, dispatch} = this.props;
@@ -70,4 +76,4 @@ class SocketHealthMonitor extends Component {
   }
 }
 
-export default withRouter(connect()(withAtmosphere(SocketHealthMonitor)));
+export default connect()(withAtmosphere(SocketHealthMonitor));

--- a/src/universal/containers/Signout/signout.js
+++ b/src/universal/containers/Signout/signout.js
@@ -2,7 +2,7 @@ import {resetAtmosphere} from 'universal/components/AtmosphereProvider/Atmospher
 import {showSuccess} from 'universal/modules/toast/ducks/toastDuck';
 import SendClientSegmentEventMutation from 'universal/mutations/SendClientSegmentEventMutation';
 import {reset as resetAppState} from 'universal/redux/rootDuck';
-import {APP_TOKEN_KEY, APP_UPGRADE_PENDING_KEY, APP_UPGRADE_PENDING_RELOAD} from 'universal/utils/constants';
+import {APP_TOKEN_KEY} from 'universal/utils/constants';
 
 const signoutSuccess = {
   title: 'Tootles!',
@@ -12,16 +12,13 @@ const signoutSuccess = {
 const signout = (atmosphere, dispatch, history) => {
   window.localStorage.removeItem(APP_TOKEN_KEY);
   resetAtmosphere();
-  const reloadPendingState = window.sessionStorage.getItem(APP_UPGRADE_PENDING_KEY);
   SendClientSegmentEventMutation(atmosphere, 'User Logout');
   /* reset the app state, but preserve any pending notifications: */
   if (history) {
     history.replace('/');
   }
   dispatch(resetAppState());
-  if (reloadPendingState !== APP_UPGRADE_PENDING_RELOAD) {
-    dispatch(showSuccess(signoutSuccess));
-  }
+  dispatch(showSuccess(signoutSuccess));
 };
 
 export default signout;

--- a/src/universal/mutations/toasts/popUpgradeAppToast.js
+++ b/src/universal/mutations/toasts/popUpgradeAppToast.js
@@ -1,23 +1,17 @@
-import {APP_UPGRADE_PENDING_KEY, APP_UPGRADE_PENDING_RELOAD, APP_VERSION_KEY} from 'universal/utils/constants';
 import {showWarning} from 'universal/modules/toast/ducks/toastDuck';
 
-const popUpgradeAppToast = (versionOnServer, {dispatch, history}) => {
-  const versionInStorage = window.localStorage.getItem(APP_VERSION_KEY);
-  if (versionOnServer !== versionInStorage) {
-    dispatch(showWarning({
-      title: 'New stuff!',
-      message: 'A new version of Parabol is available',
-      autoDismiss: 0,
-      action: {
-        label: 'Log out and upgrade',
-        callback: () => {
-          history.replace('/signout');
-        }
+const popUpgradeAppToast = ({dispatch}) => {
+  dispatch(showWarning({
+    title: 'New stuff!',
+    message: 'A new version of Parabol is available',
+    autoDismiss: 0,
+    action: {
+      label: 'Refresh to upgrade',
+      callback: () => {
+        window.location.reload();
       }
-    }));
-    window.sessionStorage.setItem(APP_UPGRADE_PENDING_KEY,
-      APP_UPGRADE_PENDING_RELOAD);
-  }
+    }
+  }));
 };
 
 export default popUpgradeAppToast;

--- a/src/universal/utils/constants.js
+++ b/src/universal/utils/constants.js
@@ -6,22 +6,8 @@ import ms from 'ms';
 export const APP_CDN_USER_ASSET_SUBDIR = '/store';
 export const APP_MAX_AVATAR_FILE_SIZE = 1024 * 1024;
 export const APP_NAME = 'Action';
-export const APP_REDUX_KEY = `${APP_NAME}:redux`;
-
-/**
- * Upgrade pending states, called when the server version changes.
- * Must be a string:
- *
- *    APP_UPGRADE_PENDING_FALSE: no upgrade needed
- *   APP_UPGRADE_PENDING_RELOAD: client reload needed
- *     APP_UPGRADE_PENDING_DONE: upgrade complete
- *
- * Stored in localSession by APP_UPGRADE_PENDING_KEY.
- */
 
 export const APP_TOKEN_KEY = `${APP_NAME}:token`;
-export const APP_UPGRADE_PENDING_KEY = `${APP_NAME}:upgradePending`;
-export const APP_UPGRADE_PENDING_RELOAD = 'reload';
 export const APP_VERSION_KEY = `${APP_NAME}:version`; // in localStorage
 export const APP_WEBPACK_PUBLIC_PATH_DEFAULT = '/static/';
 


### PR DESCRIPTION
TEST
- goto team dash
- change the version in the package.json
- in components/Team/Team.js, change `"Search Team Tasks & Agenda` to `"FOO"`
- save changes
- ctrl + c in the server terminal to stop the server (cannot trust piping!)
- `yarn dev` to restart the server 
- [ ] see a toast saying you were disconnected
- [ ] see a toast saying new stuff available
- [ ] do not see a toast saying reconnected (3 toasts is just too much)
- [ ] click "Refresh to upgrade" and the page reloads & the Team filter now says "FOO"