### PR TITLE
Updating group and topic labels (ready for review)

### DIFF
--- a/src/universal/components/ReflectionGroup/ReflectionGroupTitleEditor.js
+++ b/src/universal/components/ReflectionGroup/ReflectionGroupTitleEditor.js
@@ -17,6 +17,7 @@ import type {ReflectionGroupTitleEditor_reflectionGroup as ReflectionGroup} from
 import type {ReflectionGroupTitleEditor_meeting as Meeting} from './__generated__/ReflectionGroupTitleEditor_meeting.graphql';
 import reactLifecyclesCompat from 'react-lifecycles-compat';
 import StyledFontAwesome from 'universal/components/StyledFontAwesome';
+import {RETRO_TOPIC_LABEL} from 'universal/utils/constants';
 
 const {Component} = React;
 
@@ -164,7 +165,7 @@ class ReflectionGroupTitleEditor extends Component<Props> {
             <NameInput
               onBlur={this.onSubmit}
               onChange={this.onChange}
-              placeholder="Theme"
+              placeholder={RETRO_TOPIC_LABEL}
               readOnly={readOnly}
               innerRef={this.inputRef}
               size={20}

--- a/src/universal/components/RetroGroupPhase.js
+++ b/src/universal/components/RetroGroupPhase.js
@@ -15,6 +15,8 @@ import MeetingPhaseWrapper from 'universal/components/MeetingPhaseWrapper';
 import type {MutationProps} from 'universal/utils/relay/withMutationProps';
 import withMutationProps from 'universal/utils/relay/withMutationProps';
 import StyledError from 'universal/components/StyledError';
+import {VOTE} from 'universal/utils/constants';
+import {phaseLabelLookup} from 'universal/utils/meetings/lookups';
 
 type Props = {
   atmosphere: Object,
@@ -30,6 +32,7 @@ const RetroGroupPhase = (props: Props) => {
   const {facilitatorUserId} = newMeeting || {};
   const phaseItems = meetingSettings.phaseItems || [];
   const isFacilitating = facilitatorUserId === viewerId;
+  const nextPhaseLabel = phaseLabelLookup[VOTE];
   return (
     <React.Fragment>
       <ScrollableBlock>
@@ -50,7 +53,7 @@ const RetroGroupPhase = (props: Props) => {
           iconLarge
           iconPalette="warm"
           iconPlacement="right"
-          label={'Done! Let’s Vote'}
+          label={`Done! Let’s ${nextPhaseLabel}`}
           onClick={gotoNext}
         />
       </MeetingControlBar>

--- a/src/universal/components/RetroReflectPhase/RetroReflectPhase.js
+++ b/src/universal/components/RetroReflectPhase/RetroReflectPhase.js
@@ -10,7 +10,8 @@ import PhaseItemColumn from 'universal/components/RetroReflectPhase/PhaseItemCol
 import MeetingControlBar from 'universal/modules/meeting/components/MeetingControlBar/MeetingControlBar';
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere';
 import {Button} from 'universal/components';
-import {REFLECT} from 'universal/utils/constants';
+import {REFLECT, GROUP} from 'universal/utils/constants';
+import {phaseLabelLookup} from 'universal/utils/meetings/lookups';
 import ScrollableBlock from 'universal/components/ScrollableBlock';
 import MeetingPhaseWrapper from 'universal/components/MeetingPhaseWrapper';
 
@@ -26,6 +27,7 @@ const RetroReflectPhase = (props: Props) => {
   const {facilitatorUserId, localPhase: {phaseType}, reflectionGroups} = newMeeting || {};
   const phaseItems = meetingSettings.phaseItems || [];
   const isFacilitating = facilitatorUserId === viewerId;
+  const nextPhaseLabel = phaseLabelLookup[GROUP];
   return (
     <React.Fragment>
       <ScrollableBlock>
@@ -47,7 +49,7 @@ const RetroReflectPhase = (props: Props) => {
           iconLarge
           iconPalette="warm"
           iconPlacement="right"
-          label={'Done! Let’s Theme'}
+          label={`Done! Let’s ${nextPhaseLabel}`}
           onClick={gotoNext}
         />
       </MeetingControlBar>

--- a/src/universal/components/RetroSidebarDiscussSection.js
+++ b/src/universal/components/RetroSidebarDiscussSection.js
@@ -9,6 +9,8 @@ import MeetingSidebarLabelBlock from 'universal/components/MeetingSidebarLabelBl
 import MeetingSubnavItem from 'universal/components/MeetingSubnavItem';
 import {LabelHeading} from 'universal/components';
 import getIsNavigable from 'universal/utils/meetings/getIsNavigable';
+import {RETRO_TOPIC_LABEL, RETRO_VOTED_LABEL} from 'universal/utils/constants';
+import plural from 'universal/utils/plural';
 
 type Props = {|
   gotoStageId: (stageId: string) => void,
@@ -40,7 +42,7 @@ const RetroSidebarDiscussSection = (props: Props) => {
   return (
     <SidebarPhaseItemChild>
       <MeetingSidebarLabelBlock>
-        <LabelHeading>{'Upvoted Topics'}</LabelHeading>
+        <LabelHeading>{plural(stages.length, `${RETRO_VOTED_LABEL} ${RETRO_TOPIC_LABEL}`)}</LabelHeading>
       </MeetingSidebarLabelBlock>
       {stages.map((stage, idx) => {
         const {reflectionGroup} = stage;

--- a/src/universal/components/RetroVotePhase.js
+++ b/src/universal/components/RetroVotePhase.js
@@ -7,6 +7,8 @@ import MeetingControlBar from 'universal/modules/meeting/components/MeetingContr
 import {Button} from 'universal/components';
 import ScrollableBlock from 'universal/components/ScrollableBlock';
 import MeetingPhaseWrapper from 'universal/components/MeetingPhaseWrapper';
+import {DISCUSS} from 'universal/utils/constants';
+import {phaseLabelLookup} from 'universal/utils/meetings/lookups';
 
 type Props = {|
   atmosphere: Object,
@@ -21,6 +23,7 @@ const RetroVotePhase = (props: Props) => {
   const {facilitatorUserId, votesRemaining} = newMeeting || {};
   const {phaseItems = [], totalVotes} = meetingSettings;
   const isFacilitating = facilitatorUserId === viewerId;
+  const nextPhaseLabel = phaseLabelLookup[DISCUSS];
   return (
     <React.Fragment>
       <ScrollableBlock>
@@ -41,7 +44,7 @@ const RetroVotePhase = (props: Props) => {
           iconLarge
           iconPalette="warm"
           iconPlacement="right"
-          label={'Done! Let’s Discuss'}
+          label={`Done! Let’s ${nextPhaseLabel}`}
           onClick={gotoNext}
         />
       </MeetingControlBar>

--- a/src/universal/modules/email/components/QuickStats/RetroQuickStats.js
+++ b/src/universal/modules/email/components/QuickStats/RetroQuickStats.js
@@ -3,6 +3,7 @@ import React from 'react';
 import EmptySpace from '../EmptySpace/EmptySpace';
 import plural from 'universal/utils/plural';
 import styles from './quickStatsStyles';
+import {RETRO_TOPIC_LABEL, RETRO_VOTED_LABEL} from 'universal/utils/constants';
 
 const {
   cellStyles,
@@ -38,7 +39,7 @@ const RetroQuickStats = (props: Props) => {
             <td style={cellStyles}>
               <div style={statStyles}>
                 <div style={statValue}>{upvotedTopicCount}</div>
-                <div style={statLabel}>{plural(upvotedTopicCount, 'Upvoted Topic')}</div>
+                <div style={statLabel}>{plural(upvotedTopicCount, `${RETRO_VOTED_LABEL} ${RETRO_TOPIC_LABEL}`)}</div>
               </div>
             </td>
             <td style={cellStyles}>
@@ -55,7 +56,7 @@ const RetroQuickStats = (props: Props) => {
                     <span>{meetingMembersPresentCount}/{meetingMembersCount}</span>
                   }
                 </div>
-                <div style={statLabel}>Present</div>
+                <div style={statLabel}>{'Present'}</div>
               </div>
             </td>
           </tr>

--- a/src/universal/modules/email/components/RetroDiscussionTopics/RetroDiscussionTopics.js
+++ b/src/universal/modules/email/components/RetroDiscussionTopics/RetroDiscussionTopics.js
@@ -3,6 +3,8 @@ import React from 'react';
 import EmptySpace from '../../components/EmptySpace/EmptySpace';
 import ui from 'universal/styles/ui';
 import RetroDiscussionTopic from 'universal/modules/email/components/RetroDiscussionTopics/RetroDiscussionTopic';
+import plural from 'universal/utils/plural';
+import {RETRO_TOPIC_LABEL, RETRO_VOTED_LABEL} from 'universal/utils/constants';
 
 const fontFamily = ui.emailFontFamily;
 
@@ -25,7 +27,7 @@ const RetroDiscussionTopics = (props) => {
         <tr>
           <td style={sectionHeading}>
             <EmptySpace height={16} />
-            {'Upvoted Reflections'}
+            {plural(topics.length, `${RETRO_VOTED_LABEL} ${RETRO_TOPIC_LABEL}`)}
             <EmptySpace height={16} />
           </td>
         </tr>

--- a/src/universal/utils/constants.js
+++ b/src/universal/utils/constants.js
@@ -29,6 +29,8 @@ export const APP_WEBPACK_PUBLIC_PATH_DEFAULT = '/static/';
 export const MEETING_NAME = 'Action Meeting';
 export const MEETING_SUMMARY_LABEL = 'Summary';
 export const AGENDA_ITEM_LABEL = 'Agenda Topic';
+export const RETRO_TOPIC_LABEL = 'Topic';
+export const RETRO_VOTED_LABEL = 'Upvoted';
 
 /* Phases */
 export const LOBBY = 'lobby';

--- a/src/universal/utils/meetings/lookups.js
+++ b/src/universal/utils/meetings/lookups.js
@@ -23,7 +23,7 @@ export const phaseTypeToPhaseGroup = {
 export const phaseLabelLookup = {
   [CHECKIN]: 'Social Check-In',
   [REFLECT]: 'Reflect',
-  [GROUP]: 'Theme',
+  [GROUP]: 'Group',
   [VOTE]: 'Vote',
   [DISCUSS]: 'Discuss',
   [UPDATES]: 'Solo Updates',
@@ -34,7 +34,7 @@ export const phaseLabelLookup = {
 
 export const phaseDescriptionLookup = {
   [REFLECT]: 'Add anonymous reflections for each prompt',
-  [GROUP]: 'Drag cards to group by common themes',
+  [GROUP]: 'Drag cards to group by common topics',
   [VOTE]: 'Vote on the themes you want to discuss',
   [DISCUSS]: 'Create takeaway task cards to capture next steps'
 };
@@ -52,7 +52,7 @@ export const meetingTypeToLabel = {
 export const phaseTypeToSlug = {
   [CHECKIN]: 'checkin',
   [REFLECT]: 'reflect',
-  [GROUP]: 'theme',
+  [GROUP]: 'group',
   [VOTE]: 'vote',
   [DISCUSS]: 'discuss'
 };

--- a/stories/MeetingComponents.stories.js
+++ b/stories/MeetingComponents.stories.js
@@ -65,14 +65,14 @@ storiesOf('Meeting Components', module)
       />
     </RetroBackground>
   ))
-  .add('Retro Theme Heading', () => (
+  .add('Retro Group Heading', () => (
     <RetroBackground>
       <StoryContainer
         render={() => (
           <div>
-            <LabelHeading>{'Theme'}</LabelHeading>
-            <MeetingPhaseHeading>{'Group by Theme'}</MeetingPhaseHeading>
-            <MeetingCopy margin="0">{'Drag cards to group by common themes'}</MeetingCopy>
+            <LabelHeading>{'Group'}</LabelHeading>
+            <MeetingPhaseHeading>{'Group'}</MeetingPhaseHeading>
+            <MeetingCopy margin="0">{'Drag cards to group by common topics'}</MeetingCopy>
           </div>
         )}
       />


### PR DESCRIPTION
### Test
- [ ] Retro navigation, URL, and phase view now use “Group” when it’s a label or “group” when it’s a slug
- [ ] Reflection card group title placeholder is “Topic”
- [ ] Retro sidebar nav says “Upvoted Topic” or “Upvoted Topics” depending on length
- [ ] Retro summary section says “Upvoted Topic” or “Upvoted Topics” depending on length