### PR TITLE
Fix retro email summary votes [BASE: false-no-ws]

### DIFF
--- a/src/server/graphql/mutations/helpers/endMeeting/sendNewMeetingSummary.js
+++ b/src/server/graphql/mutations/helpers/endMeeting/sendNewMeetingSummary.js
@@ -24,14 +24,15 @@ const getRetroMeeting = (meetingId) => {
       reflectionGroups: r.table('RetroReflectionGroup')
         .getAll(meetingId, {index: 'meetingId'})
         .filter({isActive: true})
-        .filter((group) => group('voterIds').count().ge(1))
-        .orderBy(r.desc('voterIds'))
         .merge((reflectionGroup) => ({
           reflections: r.table('RetroReflection')
             .getAll(reflectionGroup('id'), {index: 'reflectionGroupId'})
             .filter({isActive: true})
-            .coerceTo('array')
+            .coerceTo('array'),
+          voteCount: reflectionGroup('voterIds').count().default(0)
         }))
+        .filter((group) => group('voteCount').ge(1))
+        .orderBy(r.desc('voteCount'))
         .coerceTo('array')
     }));
 };


### PR DESCRIPTION
before this gets too crazy we should just figure out how to SSR the summary route so we don't have to construct megaqueries... but until then,

TEST
- start a retro, add 3 reflections, don't group them, give them all your votes, end the meeting
- [ ] the email summary you receive looks like the web summary
