### PR TITLE
Refine auto group

### DIFF
--- a/src/server/graphql/mutations/helpers/addEntitiesToReflections.js
+++ b/src/server/graphql/mutations/helpers/addEntitiesToReflections.js
@@ -33,10 +33,10 @@ const addEntitiesToReflections = async (meetingId) => {
   // run a distance matrix on the lemma
   // sanitize reflection responses, nulling out anything without a full response tree
   const sanitizedReflectionResponses = reflectionResponses.map(sanitizeAnalyzedEntitiesResponse);
-  const responsesWithLemma = sanitizedReflectionResponses.map((response, idx) => addLemmaToEntities(response, reflectionSyntax[idx]))
+  const responsesWithLemma = sanitizedReflectionResponses.map((response, idx) => addLemmaToEntities(response, reflectionSyntax[idx]));
   const nextReflections = reflections.map((reflection, idx) => ({
     id: reflection.id,
-    entities: sanitizedReflectionResponses[idx]
+    entities: responsesWithLemma[idx]
   }));
 
   return r(nextReflections).forEach((reflection) => {

--- a/src/server/graphql/mutations/helpers/addEntitiesToReflections.js
+++ b/src/server/graphql/mutations/helpers/addEntitiesToReflections.js
@@ -3,6 +3,9 @@ import getRethink from 'server/database/rethinkDriver';
 import extractTextFromDraftString from 'universal/utils/draftjs/extractTextFromDraftString';
 import promiseAllPartial from 'universal/utils/promiseAllPartial';
 import sanitizeAnalyzedEntitiesResponse from 'server/graphql/mutations/helpers/autoGroup/sanitizeAnalyzedEntititesResponse';
+import promiseAllObj from 'universal/utils/promiseAllObj';
+import getSyntaxFromText from 'server/graphql/mutations/helpers/autoGroup/getSyntaxFromText';
+import addLemmaToEntities from 'server/graphql/mutations/helpers/autoGroup/addLemmaToEntities';
 
 const addEntitiesToReflections = async (meetingId) => {
   const r = getRethink();
@@ -19,11 +22,18 @@ const addEntitiesToReflections = async (meetingId) => {
   const contentTexts = reflections.map((reflection) => extractTextFromDraftString(reflection.content));
 
   // intelligently extract the entities from the body of the text
-  const reflectionResponses = await promiseAllPartial(contentTexts.map(getEntitiesFromText));
+  const {reflectionResponses, reflectionSyntax} = await promiseAllObj({
+    reflectionResponses: promiseAllPartial(contentTexts.map(getEntitiesFromText)),
+    reflectionSyntax: promiseAllPartial(contentTexts.map(getSyntaxFromText))
+  });
 
+  // for each entity, look in the tokens array to first the first word of the entity
+  // for each word in the entity, make sure that the next token points to it, else continue, return entity starting index
+  // take the lemma of the last word and recompute the entity based on that lemma
+  // run a distance matrix on the lemma
   // sanitize reflection responses, nulling out anything without a full response tree
   const sanitizedReflectionResponses = reflectionResponses.map(sanitizeAnalyzedEntitiesResponse);
-
+  const responsesWithLemma = sanitizedReflectionResponses.map((response, idx) => addLemmaToEntities(response, reflectionSyntax[idx]))
   const nextReflections = reflections.map((reflection, idx) => ({
     id: reflection.id,
     entities: sanitizedReflectionResponses[idx]

--- a/src/server/graphql/mutations/helpers/autoGroup/addLemmaToEntities.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/addLemmaToEntities.js
@@ -1,0 +1,36 @@
+const addLemmaToEntity = (entityName, tokens) => {
+  const namePieces = entityName.toLowerCase().split(' ');
+  const [firstPiece] = namePieces;
+  for (let jj = 0; jj < tokens.length; jj++) {
+    const token = tokens[jj];
+    if (token.text.content === firstPiece) {
+      let startIdxFound = true;
+      // make sure the rest of the pieces match
+      for (let kk = 1; kk < namePieces.length; kk++) {
+        const nextPiece = namePieces[kk];
+        const nextToken = tokens[jj + kk];
+        if (nextPiece !== nextToken) {
+          startIdxFound = false;
+          break;
+        }
+      }
+      if (!startIdxFound) continue;
+
+    }
+  }
+}
+
+const addLemmaToEntities = (entities, syntax) => {
+  if (!entities || !syntax) return null;
+  const [firstSyntax] = syntax;
+  if (!firstSyntax) return null;
+  const {tokens} = firstSyntax;
+  if (!Array.isArray(tokens)) return null;
+  const validEntities = [];
+  return entities.map((entity) => ({
+    ...entity,
+    lemma: addLemmaToEntity(entity.name, tokens)
+  }));
+};
+
+export default addLemmaToEntities;

--- a/src/server/graphql/mutations/helpers/autoGroup/addLemmaToEntities.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/addLemmaToEntities.js
@@ -1,32 +1,50 @@
-const addLemmaToEntity = (entityName, tokens) => {
-  const namePieces = entityName.toLowerCase().split(' ');
+const getTokenIndices = (entityName, tokens) => {
+  const indices = [];
+  // assumes already lowercased
+  const namePieces = entityName.split(' ');
   const [firstPiece] = namePieces;
   for (let jj = 0; jj < tokens.length; jj++) {
     const token = tokens[jj];
-    if (token.text.content === firstPiece) {
+    if (token.text.content.toLowerCase() === firstPiece) {
       let startIdxFound = true;
       // make sure the rest of the pieces match
       for (let kk = 1; kk < namePieces.length; kk++) {
         const nextPiece = namePieces[kk];
         const nextToken = tokens[jj + kk];
-        if (nextPiece !== nextToken) {
+        if (!nextToken || nextPiece !== nextToken.text.content.toLowerCase()) {
           startIdxFound = false;
           break;
         }
       }
-      if (!startIdxFound) continue;
-
+      if (startIdxFound) {
+        indices.push({
+          start: jj,
+          end: jj + namePieces.length - 1
+        });
+      }
     }
   }
-}
+  return indices;
+};
+
+export const addLemmaToEntity = (entityName, tokens) => {
+  const tokenIndices = getTokenIndices(entityName, tokens);
+  if (tokenIndices.length === 0) return entityName;
+  // we only care about the first match since the lemma will be the same for all
+  const [firstTokenIdx] = tokenIndices;
+  const {end} = firstTokenIdx;
+  const {lemma: partialLemma} = tokens[end];
+  const namePieces = entityName.split(' ');
+  namePieces[namePieces.length - 1] = partialLemma;
+  return namePieces.join(' ').toLowerCase();
+};
 
 const addLemmaToEntities = (entities, syntax) => {
-  if (!entities || !syntax) return null;
+  if (!entities || !syntax) return entities;
   const [firstSyntax] = syntax;
-  if (!firstSyntax) return null;
+  if (!firstSyntax) return entities;
   const {tokens} = firstSyntax;
-  if (!Array.isArray(tokens)) return null;
-  const validEntities = [];
+  if (!Array.isArray(tokens)) return entities;
   return entities.map((entity) => ({
     ...entity,
     lemma: addLemmaToEntity(entity.name, tokens)

--- a/src/server/graphql/mutations/helpers/autoGroup/computeDistanceMatrix.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/computeDistanceMatrix.js
@@ -4,11 +4,11 @@
  * see if it exists for this reflection in particular.
  * if it does, grab the salience, else, set it to 0
  */
-const computeDistanceMatrix = (reflectionEntities, entityNameArr) => {
+const computeDistanceMatrix = (reflectionEntities, uniqueLemmaArr) => {
   return reflectionEntities.map((entities) => {
-    if (!entities) return new Array(entityNameArr.length).fill(0);
-    return entityNameArr.map((name) => {
-      const entity = entities.find((ent) => ent.name === name);
+    if (!entities) return new Array(uniqueLemmaArr.length).fill(0);
+    return uniqueLemmaArr.map((lemma) => {
+      const entity = entities.find((ent) => ent.lemma === lemma);
       return entity ? entity.salience : 0;
     });
   });

--- a/src/server/graphql/mutations/helpers/autoGroup/getAllLemmasFromReflections.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/getAllLemmasFromReflections.js
@@ -5,6 +5,7 @@ const getAllLemmasFromReflections = (reflectionEntities = []) => {
   const lemmaSet = new Set();
   for (let jj = 0; jj < reflectionEntities.length; jj++) {
     const entities = reflectionEntities[jj];
+    if (!Array.isArray(entities)) continue;
     for (let ii = 0; ii < entities.length; ii++) {
       const entity = entities[ii];
       const {lemma} = entity;

--- a/src/server/graphql/mutations/helpers/autoGroup/getAllLemmasFromReflections.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/getAllLemmasFromReflections.js
@@ -1,17 +1,17 @@
 /*
  * Make a list of all the entities mentioned across all the reflections
  */
-const getEntityNameArrFromResponses = (reflectionEntities = []) => {
-  const entitySet = new Set();
+const getAllLemmasFromReflections = (reflectionEntities = []) => {
+  const lemmaSet = new Set();
   for (let jj = 0; jj < reflectionEntities.length; jj++) {
     const entities = reflectionEntities[jj];
     for (let ii = 0; ii < entities.length; ii++) {
       const entity = entities[ii];
-      const {name} = entity;
-      entitySet.add(name);
+      const {lemma} = entity;
+      lemmaSet.add(lemma);
     }
   }
-  return Array.from(entitySet);
+  return Array.from(lemmaSet);
 };
 
-export default getEntityNameArrFromResponses;
+export default getAllLemmasFromReflections;

--- a/src/server/graphql/mutations/helpers/autoGroup/getSyntaxFromText.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/getSyntaxFromText.js
@@ -1,0 +1,29 @@
+import sendSentryEvent from 'server/utils/sendSentryEvent';
+import language from '@google-cloud/language/src/index';
+
+const getEntitiesFromText = async (contextText) => {
+  let client;
+  // google writes this so horribly wrong that we can't actually catch an error from here, but I write it like this in hopes they change
+  try {
+    client = new language.LanguageServiceClient();
+  } catch (e) {
+    sendSentryEvent(undefined, undefined, e);
+    return null;
+  }
+  const document = {
+    content: contextText,
+    type: 'PLAIN_TEXT'
+  };
+  try {
+    return client.analyzeSyntax({document});
+  } catch (e) {
+    const breadcrumb = {
+      message: e.message,
+      category: 'Google cloud language API fail'
+    };
+    sendSentryEvent(undefined, breadcrumb);
+    return null;
+  }
+};
+
+export default getEntitiesFromText;

--- a/src/server/graphql/mutations/helpers/autoGroup/getTitleFromComputedGroup.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/getTitleFromComputedGroup.js
@@ -8,8 +8,22 @@ const SALIENT_THRESHOLD = 0.60;
 const MIN_ENTITIES = 2;
 const MAX_CHARS = 30;
 
-const getTitleFromComputedGroup = (entityNameArr, group) => {
-  const sumArr = new Array(entityNameArr.length).fill(0);
+const getNameFromLemma = (lemma, reflectionEntities) => {
+  const names = new Set();
+  reflectionEntities.forEach((entities) => {
+    entities.forEach((entity) => {
+      if (entity.lemma === lemma) {
+        names.add(entity.name);
+      }
+    });
+  });
+  names.delete(lemma);
+  if (names.size !== 1) return lemma;
+  return Array.from(names)[0];
+};
+
+const getTitleFromComputedGroup = (uniqueLemmaArr, group, reflectionEntities) => {
+  const sumArr = new Array(uniqueLemmaArr.length).fill(0);
   group.forEach((reflectionDistanceArr) => {
     for (let jj = 0; jj < reflectionDistanceArr.length; jj++) {
       sumArr[jj] += reflectionDistanceArr[jj];
@@ -26,7 +40,8 @@ const getTitleFromComputedGroup = (entityNameArr, group) => {
   const titleArr = [];
   for (let ii = 0; ii < arrWithIdx.length; ii++) {
     const [totalSalience, idx] = arrWithIdx[ii];
-    const name = entityNameArr[idx];
+    const lemma = uniqueLemmaArr[idx];
+    const name = getNameFromLemma(lemma, reflectionEntities);
     const capName = name[0].toUpperCase() + name.slice(1);
     // if we've used 2 words & adding this word would make it look long & ugly, abort
     if (titleArr.length > MIN_ENTITIES && titleArr.join(' ').length + capName.length > MAX_CHARS) {

--- a/src/server/graphql/mutations/helpers/autoGroup/groupReflections.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/groupReflections.js
@@ -1,7 +1,7 @@
 import getRethink from 'server/database/rethinkDriver';
 import * as shortid from 'shortid';
 import mode from 'universal/utils/mode';
-import getEntityNameArrFromResponses from 'server/graphql/mutations/helpers/autoGroup/getEntityNameArrFromResponses';
+import getAllLemmasFromReflections from 'server/graphql/mutations/helpers/autoGroup/getAllLemmasFromReflections';
 import computeDistanceMatrix from 'server/graphql/mutations/helpers/autoGroup/computeDistanceMatrix';
 import getGroupMatrix from 'server/graphql/mutations/helpers/autoGroup/getGroupMatrix';
 import getTitleFromComputedGroup from 'server/graphql/mutations/helpers/autoGroup/getTitleFromComputedGroup';
@@ -21,12 +21,10 @@ const groupReflections = async (meetingId, groupingThreshold) => {
   const allReflectionEntities = reflections.map(({entities}) => entities);
   const oldReflectionGroupIds = reflections.map(({reflectionGroupId}) => reflectionGroupId);
   // create a unique array of all entity names mentioned in the meeting's reflect phase
-  const entityNameArr = getEntityNameArrFromResponses(allReflectionEntities);
-
+  const uniqueLemmaArr = getAllLemmasFromReflections(allReflectionEntities);
   // create a distance vector for each reflection
-  const distanceMatrix = computeDistanceMatrix(allReflectionEntities, entityNameArr);
+  const distanceMatrix = computeDistanceMatrix(allReflectionEntities, uniqueLemmaArr);
   const {groups: groupedArrays, thresh, nextThresh} = getGroupMatrix(distanceMatrix, groupingThreshold);
-
   // replace the arrays with reflections
   const updatedReflections = [];
   const newGroups = groupedArrays.map((group, sortOrder) => {
@@ -36,7 +34,8 @@ const groupReflections = async (meetingId, groupingThreshold) => {
       const idx = distanceMatrix.indexOf(reflectionDistanceArr);
       return reflections[idx];
     });
-    const smartTitle = getTitleFromComputedGroup(entityNameArr, group);
+    const groupedReflectionEntities = groupedReflections.map(({entities}) => entities).filter(Boolean);
+    const smartTitle = getTitleFromComputedGroup(uniqueLemmaArr, group, groupedReflectionEntities);
 
     // put all the reflections in the column where most of them are
     const getField = ({retroPhaseItemId}) => retroPhaseItemId;

--- a/src/server/graphql/mutations/helpers/autoGroup/sanitizeAnalyzedEntititesResponse.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/sanitizeAnalyzedEntititesResponse.js
@@ -4,14 +4,19 @@ const sanitizeAnalyzedEntitiesResponse = (response) => {
   if (!firstResponse) return null;
   const {entities} = firstResponse;
   if (!Array.isArray(entities)) return null;
-  const validEntities = [];
+  const validEntities = {};
   for (let ii = 0; ii < entities.length; ii++) {
     const entity = entities[ii];
     const {name, salience} = entity;
     if (!name || !salience) continue;
-    validEntities.push(entity);
+    const normalizedEntityName = name.toLowerCase();
+    const cumlSalience = validEntities[normalizedEntityName] || 0;
+    validEntities[normalizedEntityName] = cumlSalience + salience;
   }
-  return validEntities;
+  return Object.keys(validEntities).map((name) => ({
+    name,
+    salience: validEntities[name]
+  }));
 };
 
 export default sanitizeAnalyzedEntitiesResponse;

--- a/src/server/graphql/mutations/helpers/autoGroup/sortGroupedReflections.js
+++ b/src/server/graphql/mutations/helpers/autoGroup/sortGroupedReflections.js
@@ -13,8 +13,7 @@ const sortGroupedReflections = (groupedReflections, retroPhaseItemIdMode, reflec
   return groupedReflections.map((reflection, idx) => ({
     ...reflection,
     sortOrder: firstReflection.sortOrder + idx * 0.01,
-    reflectionGroupId,
-    retroPhaseItemId: retroPhaseItemIdMode
+    reflectionGroupId
   }));
 };
 

--- a/src/server/graphql/mutations/helpers/makeRetroGroupTitle.js
+++ b/src/server/graphql/mutations/helpers/makeRetroGroupTitle.js
@@ -2,18 +2,18 @@
  * Takes a guess at what the cards are talking about.
  * If that fails, just gives them a generic name
  */
-import getEntityNameArrFromResponses from 'server/graphql/mutations/helpers/autoGroup/getEntityNameArrFromResponses';
+import getAllLemmasFromReflections from 'server/graphql/mutations/helpers/autoGroup/getAllLemmasFromReflections';
 import computeDistanceMatrix from 'server/graphql/mutations/helpers/autoGroup/computeDistanceMatrix';
 import getTitleFromComputedGroup from 'server/graphql/mutations/helpers/autoGroup/getTitleFromComputedGroup';
 import extractTextFromDraftString from 'universal/utils/draftjs/extractTextFromDraftString';
 
 const makeRetroGroupTitle = (meetingId, reflections) => {
   const allReflectionEntities = reflections.map(({entities}) => entities).filter(Boolean);
-  const entityNameArr = getEntityNameArrFromResponses(allReflectionEntities);
+  const uniqueLemmaArr = getAllLemmasFromReflections(allReflectionEntities);
 
   // create a distance vector for each reflection
-  const distanceMatrix = computeDistanceMatrix(allReflectionEntities, entityNameArr);
-  const smartTitle = getTitleFromComputedGroup(entityNameArr, distanceMatrix);
+  const distanceMatrix = computeDistanceMatrix(allReflectionEntities, uniqueLemmaArr);
+  const smartTitle = getTitleFromComputedGroup(uniqueLemmaArr, distanceMatrix, allReflectionEntities);
   if (smartTitle) {
     // need to filter out the current group if we want to check for dupes. but a dupe is good, it makes it obvious they should be merged
     return {smartTitle, title: smartTitle};

--- a/src/server/graphql/types/GoogleAnalyzedEntity.js
+++ b/src/server/graphql/types/GoogleAnalyzedEntity.js
@@ -3,6 +3,10 @@ import {GraphQLFloat, GraphQLNonNull, GraphQLObjectType, GraphQLString} from 'gr
 const GoogleAnalyzedEntity = new GraphQLObjectType({
   name: 'GoogleAnalyzedEntity',
   fields: () => ({
+    lemma: {
+      type: GraphQLString,
+      description: 'The lemma (dictionary entry) of the entity name. Fancy way of saying the singular form of the name, if plural. Only present if different'
+    },
     name: {
       type: new GraphQLNonNull(GraphQLString),
       description: 'The name of the entity. Usually 1 or 2 words. Always a noun, sometimes a proper noun.'

--- a/src/server/graphql/types/GoogleAnalyzedEntity.js
+++ b/src/server/graphql/types/GoogleAnalyzedEntity.js
@@ -4,8 +4,8 @@ const GoogleAnalyzedEntity = new GraphQLObjectType({
   name: 'GoogleAnalyzedEntity',
   fields: () => ({
     lemma: {
-      type: GraphQLString,
-      description: 'The lemma (dictionary entry) of the entity name. Fancy way of saying the singular form of the name, if plural. Only present if different'
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The lemma (dictionary entry) of the entity name. Fancy way of saying the singular form of the name, if plural.'
     },
     name: {
       type: new GraphQLNonNull(GraphQLString),

--- a/src/universal/components/NewMeetingCheckIn.js
+++ b/src/universal/components/NewMeetingCheckIn.js
@@ -19,6 +19,7 @@ import NewMeetingCheckInPrompt from 'universal/modules/meeting/components/Meetin
 import findStageAfterId from 'universal/utils/meetings/findStageAfterId';
 import {CHECKIN} from 'universal/utils/constants';
 import withHotkey from 'react-hotkey-hoc';
+import {phaseLabelLookup} from 'universal/utils/meetings/lookups';
 
 const {Component} = React;
 
@@ -104,6 +105,7 @@ class NewMeetingCheckIn extends Component<Props> {
             checkInPressFactory={this.checkinPressFactory}
             currentMemberName={teamMember.preferredName}
             nextMemberName={nextMemberName}
+            nextPhaseName={phaseLabelLookup[nextPhase.phaseType]}
           />
         </MeetingControlBar>
         }

--- a/src/universal/modules/meeting/components/CheckInControls/CheckInControls.js
+++ b/src/universal/modules/meeting/components/CheckInControls/CheckInControls.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 import withHotkey from 'react-hotkey-hoc';
-import actionMeeting from 'universal/modules/meeting/helpers/actionMeeting';
 import Button from 'universal/components/Button/Button';
 import BounceBlock from 'universal/components/BounceBlock/BounceBlock';
 
@@ -16,12 +15,12 @@ const CheckInControls = (props) => {
     checkInPressFactory,
     currentMemberName,
     localPhaseItem,
-    nextMemberName
+    nextMemberName,
+    nextPhaseName
   } = props;
 
   const handleOnClickPresent = checkInPressFactory(true);
   const handleOnClickAbsent = checkInPressFactory(false);
-  const nextPhaseName = actionMeeting.updates.name;
 
   bindHotkey('h', handleOnClickPresent);
   bindHotkey('n', handleOnClickAbsent);
@@ -79,7 +78,8 @@ CheckInControls.propTypes = {
   checkInPressFactory: PropTypes.func.isRequired,
   currentMemberName: PropTypes.string,
   localPhaseItem: PropTypes.number,
-  nextMemberName: PropTypes.string
+  nextMemberName: PropTypes.string,
+  nextPhaseName: PropTypes.string
 };
 
 export default withHotkey(CheckInControls);

--- a/src/universal/modules/meeting/components/MeetingCheckIn/MeetingCheckIn.js
+++ b/src/universal/modules/meeting/components/MeetingCheckIn/MeetingCheckIn.js
@@ -77,6 +77,7 @@ const MeetingCheckin = (props) => {
             currentMemberName={currentMember.preferredName}
             localPhaseItem={localPhaseItem}
             nextMemberName={nextMember && nextMember.preferredName}
+            nextPhaseName={actionMeeting.updates.name}
           />
         </MeetingControlBar>
       }

--- a/src/universal/types/schema.flow.js
+++ b/src/universal/types/schema.flow.js
@@ -1388,7 +1388,7 @@ export type RetrospectiveMeeting = {
   viewerMeetingMember: ?RetrospectiveMeetingMember;
   /** the threshold used to achieve the autogroup. Useful for model tuning. Serves as a flag if autogroup was used. */
   autoGroupThreshold: ?number;
-  /** the next smallest threshold to guarantee at least 1 more grouping will be achieved */
+  /** the next smallest distance threshold to guarantee at least 1 more grouping will be achieved */
   nextAutoGroupThreshold: ?number;
   /** The grouped reflections */
   reflectionGroups: Array<RetroReflectionGroup>;
@@ -1549,6 +1549,8 @@ export type DraggerCoords = {
 }
 
 export type GoogleAnalyzedEntity = {
+  /** The lemma (dictionary entry) of the entity name. Fancy way of saying the singular form of the name, if plural. */
+  lemma: string;
   /** The name of the entity. Usually 1 or 2 words. Always a noun, sometimes a proper noun. */
   name: string;
   /** The salience of the entity in the provided text. The salience of all entities always sums to 1 */


### PR DESCRIPTION
This improves grouping by supporting case insensitivity and grouping plurals & singulars.
Fixes #2063

TEST

- [ ] write a reflection talking about a child
- [ ] write a reflections talking about children
- [ ] write a reflection that includes "Cake" with a capital C
- [ ] write a reflections that includes "cakes" all lowercase & plural
- [ ] try the autogroup, it should group correctly
- [ ] drag them out of their groups & group manually. the titles should look good
