### PR TITLE
extend meeting members for team members that joined after the meeting…

### DIFF
--- a/src/server/graphql/mutations/helpers/addTeamMemberToNewMeeting.js
+++ b/src/server/graphql/mutations/helpers/addTeamMemberToNewMeeting.js
@@ -2,6 +2,7 @@ import {CHECKIN} from 'universal/utils/constants';
 import getRethink from 'server/database/rethinkDriver';
 import {makeCheckInStage} from 'server/graphql/mutations/helpers/makeCheckinStages';
 import createMeetingMember from 'server/graphql/mutations/helpers/createMeetingMember';
+import extendMeetingMembersForType from 'server/graphql/mutations/helpers/extendMeetingMembersForType';
 
 /*
  * NewMeetings have a predefined set of stages, we need to add the new team member manually
@@ -23,6 +24,7 @@ const addTeamMemberToNewMeeting = async (teamMember, teamId, dataLoader) => {
   const newStage = makeCheckInStage(teamMember, meetingId, false);
   stages.push(newStage);
   const meetingMember = createMeetingMember(meetingId, meetingType)(teamMember);
+  const [extendedMeetingMember] = extendMeetingMembersForType([meetingMember], dataLoader);
   await r({
     meeting: r.table('NewMeeting')
       .get(meetingId)
@@ -30,7 +32,7 @@ const addTeamMemberToNewMeeting = async (teamMember, teamId, dataLoader) => {
         phases,
         updatedAt: now
       }),
-    member: r.table('MeetingMember').insert(meetingMember)
+    member: r.table('MeetingMember').insert(extendedMeetingMember)
   });
   return true;
 };

--- a/src/server/graphql/mutations/helpers/extendMeetingMembersForType.js
+++ b/src/server/graphql/mutations/helpers/extendMeetingMembersForType.js
@@ -1,6 +1,6 @@
 import {RETROSPECTIVE} from 'universal/utils/constants';
 
-const extendNewMeetingForType = async (meetingMembers, dataLoader) => {
+const extendMeetingMembersForType = async (meetingMembers, dataLoader) => {
   const {meetingType, teamId} = meetingMembers[0];
   if (meetingType === RETROSPECTIVE) {
     const allSettings = await dataLoader.get('meetingSettingsByTeamId').load(teamId);
@@ -14,4 +14,4 @@ const extendNewMeetingForType = async (meetingMembers, dataLoader) => {
   return meetingMembers;
 };
 
-export default extendNewMeetingForType;
+export default extendMeetingMembersForType;


### PR DESCRIPTION
good bug to find early-ish! yay for hitting it before GA!

TEST

- create a new team, invite someone to it
- start a retro meeting
- in browser 2, accept the invite and join the meeting
- go to the vote phase
- [ ] in browser 2, they have 5 votes remaining (fixes #2104)
