### PR TITLE
fix #2053 multiple subscriptions bug

### DIFF
--- a/src/universal/Atmosphere.js
+++ b/src/universal/Atmosphere.js
@@ -24,7 +24,10 @@ export default class Atmosphere extends Environment {
       const {subscription, variables = {}} = config;
       const {name} = subscription();
       const subKey = JSON.stringify({name, variables});
-      requestSubscription(this, {onError: defaultErrorHandler, ...config});
+      const isRequested = Boolean(this.querySubscriptions.find((qs) => qs.subKey === subKey));
+      if (!isRequested) {
+        requestSubscription(this, {onError: defaultErrorHandler, ...config});
+      }
       return {
         subKey,
         queryKey,


### PR DESCRIPTION
TEST
- open up debugger to websocket frames, navigate to team dash, hit refresh, notice a list of sent subscription requests
- [ ] go to a meeting route, notice there are no duplicate subscriptions created (fix #2053)