### PR TITLE
fix #2034 upgrade Card.js

### DIFF
--- a/src/universal/modules/email/components/Card/Card.js
+++ b/src/universal/modules/email/components/Card/Card.js
@@ -15,28 +15,13 @@ class Card extends Component {
     super(props);
     const {content} = props;
     const contentState = truncateCard(content);
-    this.state = {
-      editorState: EditorState.createWithContent(contentState, editorDecorators(this.getEditorState))
-    };
+    this.editorState = EditorState.createWithContent(contentState, editorDecorators(this.getEditorState));
   }
 
-  componentWillReceiveProps(nextProps) {
-    const {content: oldContent} = this.props;
-    const {content} = nextProps;
-    if (content !== oldContent) {
-      const contentState = truncateCard(content);
-      this.setState({
-        editorState: EditorState.createWithContent(contentState, editorDecorators(this.getEditorState))
-      });
-      this.setEditorState(content);
-    }
-  }
-
-  getEditorState = () => this.state.editorState;
+  getEditorState = () => this.editorState;
 
   render() {
     const {status, tags} = this.props;
-    const {editorState} = this.state;
     const isPrivate = isTaskPrivate(tags);
     const backgroundColor = isPrivate ? ui.privateCardBgColor : '#FFFFFF';
 
@@ -78,7 +63,7 @@ class Card extends Component {
                 <EmptySpace height={8} />
                 <div style={statusStyle} />
                 <EmptySpace height={8} />
-                <Editor readOnly editorState={editorState} />
+                <Editor readOnly editorState={this.editorState} />
               </div>
             </td>
           </tr>


### PR DESCRIPTION
fix #2034 

TEST
- [ ] run a retro, create a few task cards in the discuss phase, goto the summary, click around on all the cards, hit refresh, open the console, nothing wrong pops up.

Honestly, not too sure how to reproduce the problem, but I've seen it crop up from time to time both locally & on sentry.