### PR TITLE
fix #2100 retro interrupting chicken

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "jsx": "react",
     "target": "ES6",
     "module": "commonjs",
     "allowSyntheticDefaultImports": true,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "relay": "npm run update-schema && relay-compiler --src ./src --schema build/schema.json --client-schema src/client/clientSchema.graphql --watch",
     "update-schema": "node ./src/server/utils/updateSchema.babel.js && yarn flowgen",
     "postversion": "git push --follow-tags",
-    "flowgen": "gql2flow -e -o ./src/universal/types/schema.flow.js ./build/schema.json",
+    "flowgen": "gql2flow -e -o ./src/universal/types/schema.flow.js ./build/schema.json && prettier --write 'src/universal/types/schema.flow.js'",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/src/universal/components/AnalyticsIdentifierRoot.js
+++ b/src/universal/components/AnalyticsIdentifierRoot.js
@@ -21,12 +21,15 @@ type Props = {|
 
 const AnalyticsIdentifierRoot = (props: Props) => {
   const {atmosphere, location} = props
+  const {authToken} = atmosphere
+  if (!authToken) return null
   return (
     <QueryRenderer
       environment={atmosphere}
       query={query}
       variables={{}}
       render={({props: renderProps}) => {
+        console.log('anal')
         return (
           <AnalyticsIdentifier
             location={location}

--- a/src/universal/components/AnalyticsIdentifierRoot.js
+++ b/src/universal/components/AnalyticsIdentifierRoot.js
@@ -29,7 +29,6 @@ const AnalyticsIdentifierRoot = (props: Props) => {
       query={query}
       variables={{}}
       render={({props: renderProps}) => {
-        console.log('anal')
         return (
           <AnalyticsIdentifier
             location={location}

--- a/src/universal/components/NewMeetingWithLocalState.js
+++ b/src/universal/components/NewMeetingWithLocalState.js
@@ -13,6 +13,8 @@ import NewMeeting from 'universal/components/NewMeeting'
 import fromStageIdToUrl from 'universal/utils/meetings/fromStageIdToUrl'
 import updateLocalStage from 'universal/utils/relay/updateLocalStage'
 import findStageById from 'universal/utils/meetings/findStageById'
+import isInterruptingChickenPhase from 'universal/utils/isInterruptingChickenPhase'
+import isViewerTyping from 'universal/utils/isViewerTyping'
 
 /*
  * Creates a 2-way sync between the URL and the local state
@@ -74,6 +76,12 @@ class NewMeetingWithLocalState extends Component<Props, State> {
       if (!newMeeting && teamId) {
         // goto lobby
         history.push(`/${meetingSlug}/${teamId}`)
+        return
+      }
+      const {
+        localPhase: {phaseType}
+      } = oldMeeting
+      if (isInterruptingChickenPhase(phaseType) && isViewerTyping()) {
         return
       }
       const {phases} = newMeeting

--- a/src/universal/components/NewMeetingWithLocalState.js
+++ b/src/universal/components/NewMeetingWithLocalState.js
@@ -5,8 +5,6 @@ import {withRouter} from 'react-router-dom'
 import NewMeeting from 'universal/components/NewMeeting'
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere'
 import findKeyByValue from 'universal/utils/findKeyByValue'
-import isInterruptingChickenPhase from 'universal/utils/isInterruptingChickenPhase'
-import isViewerTyping from 'universal/utils/isViewerTyping'
 import findStageById from 'universal/utils/meetings/findStageById'
 import fromStageIdToUrl from 'universal/utils/meetings/fromStageIdToUrl'
 import {meetingTypeToSlug, phaseTypeToSlug} from 'universal/utils/meetings/lookups'
@@ -76,10 +74,6 @@ class NewMeetingWithLocalState extends Component<Props, State> {
       if (!newMeeting && teamId) {
         // goto lobby
         history.push(`/${meetingSlug}/${teamId}`)
-        return
-      }
-      const oldPhaseType = oldMeeting && oldMeeting.localPhase && oldMeeting.localPhase.phaseType
-      if (oldPhaseType && isInterruptingChickenPhase(oldPhaseType) && isViewerTyping()) {
         return
       }
       const {phases} = newMeeting

--- a/src/universal/components/NewMeetingWithLocalState.js
+++ b/src/universal/components/NewMeetingWithLocalState.js
@@ -1,20 +1,20 @@
 // @flow
 import React, {Component} from 'react'
+import {createFragmentContainer} from 'react-relay'
+import {withRouter} from 'react-router-dom'
+import NewMeeting from 'universal/components/NewMeeting'
+import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere'
+import findKeyByValue from 'universal/utils/findKeyByValue'
+import isInterruptingChickenPhase from 'universal/utils/isInterruptingChickenPhase'
+import isViewerTyping from 'universal/utils/isViewerTyping'
+import findStageById from 'universal/utils/meetings/findStageById'
+import fromStageIdToUrl from 'universal/utils/meetings/fromStageIdToUrl'
+import {meetingTypeToSlug, phaseTypeToSlug} from 'universal/utils/meetings/lookups'
+import updateLocalStage from 'universal/utils/relay/updateLocalStage'
+import {withLocationMeetingState_viewer as Viewer} from './__generated__/NewMeetingWithLocalState_viewer.graphql'
 
 import type {Match, RouterHistory} from 'react-router-dom'
 import type {MeetingTypeEnum} from 'universal/types/schema.flow'
-import {withRouter} from 'react-router-dom'
-import {createFragmentContainer} from 'react-relay'
-import findKeyByValue from 'universal/utils/findKeyByValue'
-import {meetingTypeToSlug, phaseTypeToSlug} from 'universal/utils/meetings/lookups'
-import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere'
-import {withLocationMeetingState_viewer as Viewer} from './__generated__/NewMeetingWithLocalState_viewer.graphql'
-import NewMeeting from 'universal/components/NewMeeting'
-import fromStageIdToUrl from 'universal/utils/meetings/fromStageIdToUrl'
-import updateLocalStage from 'universal/utils/relay/updateLocalStage'
-import findStageById from 'universal/utils/meetings/findStageById'
-import isInterruptingChickenPhase from 'universal/utils/isInterruptingChickenPhase'
-import isViewerTyping from 'universal/utils/isViewerTyping'
 
 /*
  * Creates a 2-way sync between the URL and the local state
@@ -78,10 +78,8 @@ class NewMeetingWithLocalState extends Component<Props, State> {
         history.push(`/${meetingSlug}/${teamId}`)
         return
       }
-      const {
-        localPhase: {phaseType}
-      } = oldMeeting
-      if (isInterruptingChickenPhase(phaseType) && isViewerTyping()) {
+      const oldPhaseType = oldMeeting && oldMeeting.localPhase && oldMeeting.localPhase.phaseType
+      if (oldPhaseType && isInterruptingChickenPhase(oldPhaseType) && isViewerTyping()) {
         return
       }
       const {phases} = newMeeting

--- a/src/universal/mutations/NavigateMeetingMutation.js
+++ b/src/universal/mutations/NavigateMeetingMutation.js
@@ -5,6 +5,8 @@ import {DISCUSS, VOTE} from 'universal/utils/constants'
 import clientTempId from 'universal/utils/relay/clientTempId'
 import createProxyRecord from 'universal/utils/relay/createProxyRecord'
 import handleRemoveReflectionGroups from 'universal/mutations/handlers/handleRemoveReflectionGroups'
+import isViewerTyping from 'universal/utils/isViewerTyping'
+import isInterruptingChickenPhase from 'universal/utils/isInterruptingChickenPhase'
 
 graphql`
   fragment NavigateMeetingMutation_team on NavigateMeetingPayload {
@@ -88,7 +90,10 @@ export const navigateMeetingTeamOnNext = (payload, context) => {
     const meetingProxy = store.get(meetingId)
     const viewerStageId = getInProxy(meetingProxy, 'localStage', 'id')
     if (viewerStageId === oldFacilitatorStageId) {
-      setLocalStageAndPhase(store, meetingId, facilitatorStageId)
+      const viewerPhaseType = getInProxy(meetingProxy, 'localPhase', 'phaseType')
+      if (!isInterruptingChickenPhase(viewerPhaseType) || !isViewerTyping()) {
+        setLocalStageAndPhase(store, meetingId, facilitatorStageId)
+      }
     }
   })
 }

--- a/src/universal/utils/isInterruptingChickenPhase.js
+++ b/src/universal/utils/isInterruptingChickenPhase.js
@@ -1,0 +1,13 @@
+/*
+ * An interrupting chicken is when the facilitator moves forward while another client is still typing.
+ * This causes the user to progress as well, causing them to lose their progress on what they were typing.
+ */
+import {AGENDA_ITEMS, DISCUSS} from 'universal/utils/constants'
+
+const interruptingChickenPhases = new Set([AGENDA_ITEMS, DISCUSS])
+
+const isInterruptingChickenPhase = (phaseType) => {
+  return interruptingChickenPhases.has(phaseType)
+}
+
+export default isInterruptingChickenPhase

--- a/src/universal/utils/isViewerTyping.js
+++ b/src/universal/utils/isViewerTyping.js
@@ -1,0 +1,5 @@
+const isViewerTyping = () => {
+  return document.activeElement.contentEditable === 'true'
+}
+
+export default isViewerTyping


### PR DESCRIPTION
TEST

- progress to the discussion phase of a retro meeting
- on 1 device, the non-facilitator start typing a task in the discussion phase
- on another device, the facilitator progresses the meeting
- [ ] the non-facilitator stays on the page and does not get interrupted

EXTRA (for devs)
- [ ] run `yarn flowgen` the schema.flow.js file is not changed so you no longer commit that file with no changes @ackernaut 