### PR TITLE
2174 approve on promote [BASE: update-cc-modal]

### DIFF
--- a/src/server/graphql/mutations/helpers/addDefaultGroupTitles.js
+++ b/src/server/graphql/mutations/helpers/addDefaultGroupTitles.js
@@ -33,7 +33,7 @@ const addDefaultGroupTitles = async (meeting) => {
   })
   await promiseAllPartial(singleGroupReflections.map(getTitleFromReflection))
   const reflectionGroupIds = singleGroupReflections.map(({reflectionGroupId}) => reflectionGroupId)
-  return {reflectionGroupIds}
+  return {meetingId, reflectionGroupIds}
 }
 
 export default addDefaultGroupTitles

--- a/src/server/graphql/mutations/setOrgUserRole.js
+++ b/src/server/graphql/mutations/setOrgUserRole.js
@@ -8,11 +8,37 @@ import {
   BILLING_LEADER,
   billingLeaderTypes,
   ORGANIZATION,
-  PROMOTE_TO_BILLING_LEADER
+  PROMOTE_TO_BILLING_LEADER,
+  REQUEST_NEW_USER
 } from 'universal/utils/constants'
 import {sendOrgLeadAccessError} from 'server/utils/authorizationErrors'
 import sendAuthRaven from 'server/utils/sendAuthRaven'
 import {sendSegmentIdentify} from 'server/utils/sendSegmentEvent'
+import approveToOrg from 'server/graphql/mutations/approveToOrg'
+
+const approveToOrgForUserId = async (orgId, userId, authToken, dataLoader) => {
+  const r = getRethink()
+  const outstandingNotifications = await r
+    .table('Notification')
+    .getAll(orgId, {index: 'orgId'})
+    .filter({
+      type: REQUEST_NEW_USER,
+      inviterUserId: userId
+    })
+    .default([])
+  return Promise.all(
+    outstandingNotifications.map((notification) => {
+      // a quick & dirty way to accomplish all the approvals.
+      // the person that promoted someone to billing leader is the same person that approves the invitees
+      // the updates are sent via socket, not mutation response
+      return approveToOrg.resolve(
+        {},
+        {email: notification.inviteeEmail, orgId},
+        {authToken, dataLoader}
+      )
+    })
+  )
+}
 
 export default {
   type: SetOrgUserRolePayload,
@@ -121,6 +147,7 @@ export default {
         orgId,
         userIds: [userId]
       }
+      await approveToOrgForUserId(orgId, userId, authToken, dataLoader)
       const {existingNotificationIds} = await r({
         insert: r.table('Notification').insert(promotionNotification),
         existingNotificationIds: r


### PR DESCRIPTION
fixes #2174
- User A creates Org1, Team1, invites User B
- User B joins Team 1, invites User C (does not exist yet)
- [ ] User C is pending approval
- User A promotes User B to billing leader in the org.
- [ ]  Upon promotion, User C is sent an invite
- [ ] User B gets a notification that they are a billing leader
- [ ] User B gets a notification that User C was invited

also fixes the bug mentioned here: https://github.com/ParabolInc/action/pull/2245#issuecomment-403149684

- [ ] follow repro steps in above link. cannot reproduce 