### PR TITLE
Staging dragging fix

### DIFF
--- a/src/server/graphql/mutations/startDraggingReflection.js
+++ b/src/server/graphql/mutations/startDraggingReflection.js
@@ -52,6 +52,7 @@ export default {
 
     // RESOLUTION
     const data = {
+      teamId,
       meetingId,
       reflectionId,
       dragContext: {

--- a/src/server/graphql/types/StartDraggingReflectionPayload.js
+++ b/src/server/graphql/types/StartDraggingReflectionPayload.js
@@ -29,6 +29,9 @@ const StartDraggingReflectionPayload = new GraphQLObjectType({
     },
     reflectionId: {
       type: GraphQLID
+    },
+    teamId: {
+      type: GraphQLID
     }
   })
 })

--- a/src/universal/components/PhaseItemMasonry.js
+++ b/src/universal/components/PhaseItemMasonry.js
@@ -142,7 +142,15 @@ class PhaseItemMasonry extends React.Component<Props> {
           y: modalTop + top + headerHeight + MODAL_PADDING
         })
       } else {
-        const {top, left} = el.getBoundingClientRect()
+        /*
+         * There is a bug in react's vdom where the setRef doesn't get called under certain conditions
+         * To reproduce, have 3 cards. A, B, C. A is to the left of B,C which are in a group.
+         * Drag B onto A and you have B,A then C all alone.
+         * However, the reference to the new B will not be created until after the drop.
+         * To mitigate this, we add attach the reflectionId to the DOM node itself so we can find it
+         */
+        const correctEl = document.contains(el) ? el : document.getElementById(itemId)
+        const {top, left} = correctEl.getBoundingClientRect()
         setClosingTransform(atmosphere, itemId, {x: left, y: top})
       }
     } else {

--- a/src/universal/components/ReflectionGroup/ReflectionGroup.js
+++ b/src/universal/components/ReflectionGroup/ReflectionGroup.js
@@ -199,30 +199,17 @@ class ReflectionGroup extends Component<Props> {
     const {setItemRef, meeting, reflectionGroup} = this.props
     const {reflections} = reflectionGroup
     const {isViewerDragInProgress} = meeting
-    if (isModal) {
-      return (
-        <DraggableReflectionCard
-          closeGroupModal={this.closeGroupModal}
-          idx={idx}
-          isDraggable={isDraggable}
-          isModal
-          key={reflection.id}
-          meeting={meeting}
-          reflection={reflection}
-          setItemRef={setItemRef}
-          isViewerDragInProgress={isViewerDragInProgress}
-        />
-      )
-    }
     return (
       <DraggableReflectionCard
+        closeGroupodal={isModal ? this.closeGroupModal : undefined}
         key={reflection.id}
+        idx={reflections.length - idx - 1}
+        isDraggable={isDraggable}
+        isModal={isModal}
         meeting={meeting}
         reflection={reflection}
         setItemRef={setItemRef}
-        isDraggable={isDraggable}
         isSingleCardGroup={reflections.length === 1}
-        idx={reflections.length - idx - 1}
         isViewerDragInProgress={isViewerDragInProgress}
       />
     )

--- a/src/universal/mutations/UpdateDragLocationMutation.js
+++ b/src/universal/mutations/UpdateDragLocationMutation.js
@@ -26,6 +26,8 @@ const mutation = graphql`
 `
 
 export const updateDragLocationTeamUpdater = (payload, {atmosphere, store}) => {
+  // getMasonry is false if they are not in the meeting
+  if (!atmosphere.getMasonry) return
   const sourceId = getInProxy(payload, 'sourceId')
   if (!sourceId) return
   const {

--- a/src/universal/types/schema.flow.js
+++ b/src/universal/types/schema.flow.js
@@ -2238,7 +2238,8 @@ export type StartDraggingReflectionPayload = {
   meeting: ?NewMeeting,
   meetingId: ?string,
   reflection: ?RetroReflection,
-  reflectionId: ?string
+  reflectionId: ?string,
+  teamId: ?string
 }
 
 export type StartMeetingPayload = {


### PR DESCRIPTION
TEST

Since this touches the draggable reflection logic, a general test of all dragging is needed. For example, multiple clients dragging in & out of modals.

- [ ] Follow tests in #2292, there are no regressions (will need to add `await sleep(3000)` to `endDraggingReflection.js` on the server just above the `publish` line)
- Have 3 cards, A is alone. B & C are grouped together. A is on the left: `|A|  |B,C|`
- [ ] drag card B to A and drop. it drops as expected
- [ ] open group |B,A| in the modal, you can see the cards
- [ ] in tab 2, drop card C on the group, it's correct in both tabs
- [ ] in tab 2, remove card C from the group, it work
- [ ] in tab 1, remove card B from the group from the modal

TEST 2
- [ ] follow reproduction test in the last comment of #2259, it works as expected (fixes #2259)
 