### PR TITLE
Adding Retro 101 links to help dialogs (WIP)

### DIFF
--- a/src/universal/components/NewMeeting.js
+++ b/src/universal/components/NewMeeting.js
@@ -371,7 +371,10 @@ class NewMeeting extends Component<Props> {
           <RejoinFacilitatorButton onClickHandler={() => this.gotoStageId(facilitatorStageId)} />
         )}
         <MeetingHelpBlock isFacilitating={isFacilitating} localPhaseType={localPhaseType}>
-          <MeetingHelpDialog phase={localPhaseType || retroLobbyHelpContent} />
+          <MeetingHelpDialog
+            meetingType={meetingType}
+            phase={localPhaseType || retroLobbyHelpContent}
+          />
         </MeetingHelpBlock>
       </MeetingContainer>
     )

--- a/src/universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialog.js
+++ b/src/universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialog.js
@@ -12,6 +12,7 @@ import RaisedButton from 'universal/components/RaisedButton'
 import IconLabel from 'universal/components/IconLabel'
 
 type Props = {
+  meetingType: string,
   phase: string
 }
 
@@ -31,7 +32,7 @@ const targetAnchor = {
   horizontal: 'right'
 }
 
-const MeetingHelpDialog = ({phase}: Props) => {
+const MeetingHelpDialog = ({meetingType, phase}: Props) => {
   const iconButtonToggle = (
     <StyledButton palette='white' depth={2}>
       <IconLabel icon='question' />
@@ -44,7 +45,7 @@ const MeetingHelpDialog = ({phase}: Props) => {
       maxWidth={280}
       maxHeight={320}
       originAnchor={originAnchor}
-      queryVars={{phase}}
+      queryVars={{meetingType, phase}}
       targetAnchor={targetAnchor}
       toggle={iconButtonToggle}
     />

--- a/src/universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialogMenu.js
+++ b/src/universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialogMenu.js
@@ -5,10 +5,12 @@ import FontAwesome from 'react-fontawesome'
 import ui from 'universal/styles/ui'
 import appTheme from 'universal/styles/theme/appTheme'
 import {phaseLabelLookup} from 'universal/utils/meetings/lookups'
-import phaseHelpLookup from 'universal/utils/meetings/helpLookups'
+import {actionPhaseHelpLookup, retroPhaseHelpLookup} from 'universal/utils/meetings/helpLookups'
+import {ACTION} from 'universal/utils/constants'
 
 type Props = {
   closePortal: () => void,
+  meetingType: string,
   phase: string
 }
 
@@ -46,8 +48,9 @@ const DialogClose = styled(FontAwesome)({
 })
 
 const MeetingHelpDialogMenu = (props: Props) => {
-  const {closePortal, phase} = props
+  const {closePortal, meetingType, phase} = props
   const phaseLabel = phaseLabelLookup[phase]
+  const phaseHelpLookup = meetingType === ACTION ? actionPhaseHelpLookup : retroPhaseHelpLookup
 
   return (
     <DialogContent>

--- a/src/universal/modules/meeting/components/MeetingMain/MeetingMain.js
+++ b/src/universal/modules/meeting/components/MeetingMain/MeetingMain.js
@@ -5,6 +5,7 @@ import ErrorBoundary from 'universal/components/ErrorBoundary'
 import withStyles from 'universal/styles/withStyles'
 import {meetingChromeBoxShadowInset} from 'universal/styles/meeting'
 import MeetingHelpDialog from 'universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialog'
+import {ACTION} from 'universal/utils/constants'
 
 const MeetingMain = (props) => {
   const {children, hasBoxShadow, hasHelpFor, isFacilitating, styles} = props
@@ -16,7 +17,7 @@ const MeetingMain = (props) => {
       <div className={rootStyles}>
         {hasHelpFor && (
           <div className={helpStyles}>
-            <MeetingHelpDialog phase={hasHelpFor} />
+            <MeetingHelpDialog meetingType={ACTION} phase={hasHelpFor} />
           </div>
         )}
         <div className={innerBlockStyles}>{children}</div>

--- a/src/universal/utils/meetings/helpLookups.js
+++ b/src/universal/utils/meetings/helpLookups.js
@@ -22,29 +22,35 @@ const makeLink = (href, copy) => (
 )
 
 const teamAgendaHelpLink = makeLink(
-  'https://www.parabol.co/getting-started-guide#team-agenda',
+  'https://www.parabol.co/getting-started-guide/action-meetings-101#team-agenda',
   'Learn More'
 )
 
 const actionGettingStartedLink = makeLink(
-  'https://www.parabol.co/getting-started-guide',
+  'https://www.parabol.co/getting-started-guide/action-meetings-101',
   'Getting Started Guide'
 )
-// TODO: Add Learn More links, etc. for Retro Guide when it is created
+
 const retroGettingStartedLink = makeLink(
-  'https://www.parabol.co/getting-started-guide',
+  'https://www.parabol.co/getting-started-guide/retrospective-meetings-101',
   'Getting Started Guide'
 )
 
-// TODO: Refactor to handle Retro type
-const meetingLabel = 'an Action Meeting' || 'a Retro Meeting'
-const meetingHelpLink = actionGettingStartedLink || retroGettingStartedLink
+const retroGettingStartedContent = (
+  <p>
+    {'See our '}
+    {retroGettingStartedLink}
+    {' for running a Retrospective Meeting.'}
+  </p>
+)
+const checkInFacilitatorBarTip =
+  'Facilitator: allow each teammate a moment to answer today’s prompt, then mark them as Here or Not Here.'
 
-const lobbyHelpContent = (
+const actionLobbyHelpContent = (
   <div>
     <p>
-      {`To learn more about how to run ${meetingLabel}, see our `}
-      {meetingHelpLink}
+      {'To learn more about how to run an Action Meeting, see our '}
+      {actionGettingStartedLink}
       {'.'}
     </p>
   </div>
@@ -54,6 +60,7 @@ const retroLobbyHelpContentFree = (
   <div>
     <p>{'The person who presses “Start Meeting” will be today’s Facilitator.'}</p>
     <p>{'Everyone’s display automatically follows the Facilitator.'}</p>
+    {retroGettingStartedContent}
   </div>
 )
 
@@ -67,10 +74,11 @@ const retroLobbyHelpContentPaid = (
         'In 30 minutes you can discover underlying tensions, create next steps, and have a summary delivered to your inbox.'
       }
     </p>
+    {retroGettingStartedContent}
   </div>
 )
 
-const checkInHelpContent = (
+const checkInHelpContent = (link) => (
   <div>
     <p>
       {
@@ -78,8 +86,17 @@ const checkInHelpContent = (
       }
     </p>
     <p>{'Avoid cross-talk so that everybody can have uninterrupted airtime.'}</p>
-    <p>{makeLink('https://www.parabol.co/getting-started-guide#social-check-in', 'Learn More')}</p>
+    <p>{link}</p>
   </div>
+)
+
+const actionCheckInLink = makeLink(
+  'https://www.parabol.co/getting-started-guide/action-meetings-101#social-check-in',
+  'Learn More'
+)
+const retroCheckInLink = makeLink(
+  'https://www.parabol.co/getting-started-guide/retrospective-meetings-101#social-check-in',
+  'Learn More'
 )
 
 const reflectHelpContent = (
@@ -178,42 +195,14 @@ const lastCallHelpContent = (
   </div>
 )
 
-const phaseHelpLookup = {
+export const actionPhaseHelpLookup = {
   [LOBBY]: {
     facilitatorBarTip: null,
-    helpDialog: lobbyHelpContent
-  },
-  [RETRO_LOBBY_FREE]: {
-    facilitatorBarTip: null,
-    helpDialog: retroLobbyHelpContentFree
-  },
-  [RETRO_LOBBY_PAID]: {
-    facilitatorBarTip: null,
-    helpDialog: retroLobbyHelpContentPaid
+    helpDialog: actionLobbyHelpContent
   },
   [CHECKIN]: {
-    facilitatorBarTip:
-      'Facilitator: allow each teammate a moment to answer today’s prompt, then mark them as Here or Not Here.',
-    helpDialog: checkInHelpContent
-  },
-  [REFLECT]: {
-    facilitatorBarTip:
-      'Facilitator: depending on preference, your team can focus on 1 prompt at a time, or both.',
-    helpDialog: reflectHelpContent
-  },
-  [GROUP]: {
-    facilitatorBarTip:
-      'Facilitator: have teammates ask clarifying questions as they group reflections.',
-    helpDialog: groupHelpContent
-  },
-  [VOTE]: {
-    facilitatorBarTip: 'Facilitator: only 1 vote is required to move forward.',
-    helpDialog: voteHelpContent
-  },
-  [DISCUSS]: {
-    facilitatorBarTip: `Facilitator: encourage your team to break tasks down to their smallest components,
-                        perhaps owned by multiple teammates.`,
-    helpDialog: discussHelpContent
+    facilitatorBarTip: checkInFacilitatorBarTip,
+    helpDialog: checkInHelpContent(actionCheckInLink)
   },
   [UPDATES]: {
     facilitatorBarTip:
@@ -236,4 +225,36 @@ const phaseHelpLookup = {
   }
 }
 
-export default phaseHelpLookup
+export const retroPhaseHelpLookup = {
+  [RETRO_LOBBY_FREE]: {
+    facilitatorBarTip: null,
+    helpDialog: retroLobbyHelpContentFree
+  },
+  [RETRO_LOBBY_PAID]: {
+    facilitatorBarTip: null,
+    helpDialog: retroLobbyHelpContentPaid
+  },
+  [CHECKIN]: {
+    facilitatorBarTip: checkInFacilitatorBarTip,
+    helpDialog: checkInHelpContent(retroCheckInLink)
+  },
+  [REFLECT]: {
+    facilitatorBarTip:
+      'Facilitator: depending on preference, your team can focus on 1 prompt at a time, or both.',
+    helpDialog: reflectHelpContent
+  },
+  [GROUP]: {
+    facilitatorBarTip:
+      'Facilitator: have teammates ask clarifying questions as they group reflections.',
+    helpDialog: groupHelpContent
+  },
+  [VOTE]: {
+    facilitatorBarTip: 'Facilitator: only 1 vote is required to move forward.',
+    helpDialog: voteHelpContent
+  },
+  [DISCUSS]: {
+    facilitatorBarTip: `Facilitator: encourage your team to break tasks down to their smallest components,
+                        perhaps owned by multiple teammates.`,
+    helpDialog: discussHelpContent
+  }
+}

--- a/stories/Portals.stories.js
+++ b/stories/Portals.stories.js
@@ -9,12 +9,12 @@ import {storiesOf} from '@storybook/react'
 
 import MeetingControlBar from 'universal/modules/meeting/components/MeetingControlBar/MeetingControlBar'
 import MeetingHelpDialog from 'universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialog'
-import phaseHelpLookup from 'universal/utils/meetings/helpLookups'
+import {retroPhaseHelpLookup} from 'universal/utils/meetings/helpLookups'
 
 import RetroBackground from './components/RetroBackground'
 import StoryContainer from './components/StoryContainer'
 
-const EXAMPLE_PHASE = 'firstcall'
+const EXAMPLE_PHASE = 'group'
 
 storiesOf('Loadable Help Dialog', module).add('toggle the help dialog', () => (
   <RetroBackground>
@@ -26,9 +26,11 @@ storiesOf('Loadable Help Dialog', module).add('toggle the help dialog', () => (
           <div
             style={{display: 'flex', justifyContent: 'flex-end', padding: '0 1.25rem 1.25rem 0'}}
           >
-            <MeetingHelpDialog phase={EXAMPLE_PHASE} />
+            <MeetingHelpDialog meetingType='retrospective' phase={EXAMPLE_PHASE} />
           </div>
-          <MeetingControlBar>{phaseHelpLookup[EXAMPLE_PHASE].facilitatorBarTip}</MeetingControlBar>
+          <MeetingControlBar>
+            {retroPhaseHelpLookup[EXAMPLE_PHASE].facilitatorBarTip}
+          </MeetingControlBar>
         </div>
       )}
     />

--- a/yarn.lock
+++ b/yarn.lock
@@ -10793,12 +10793,6 @@ react-split-pane@^0.1.82:
     react-lifecycles-compat "^3.0.4"
     react-style-proptype "^3.0.0"
 
-react-storybooks-relay-container@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-storybooks-relay-container/-/react-storybooks-relay-container-1.1.2.tgz#bb5f1718eb0590e900a12494717930cd945fa530"
-  dependencies:
-    prop-types "^15.5.10"
-
 react-style-proptype@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.2.1.tgz#7cfeb9b87ec7ab9dcbde9715170ed10c11fb86aa"
@@ -13020,9 +13014,9 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
-uws@10.148.0:
-  version "10.148.0"
-  resolved "https://registry.yarnpkg.com/uws/-/uws-10.148.0.tgz#3fcd35f083ca515e091cd33b2d78f0f51a666215"
+uws@10.148.1:
+  version "10.148.1"
+  resolved "https://registry.yarnpkg.com/uws/-/uws-10.148.1.tgz#fd1a79cf6118a388e0a1bed8a1397030d2c4fd2c"
 
 v8-compile-cache@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This addresses #2293 

- [x] updates `helpLookups.js` exporting objects for both Action and Retro meetings
- [x] adds Retro 101 links to phase help for Retros
- [x] updates link URLs

### Test
- [ ] Open the help dialog box and test the link in each phase of an Action meeting including the Lobby
- [ ] Open the help dialog box and test the link in each phase of a Retro meeting including both the free and paid versions of the Lobby