### PR TITLE
mark card as editing when a menu is open

### DIFF
--- a/src/universal/components/LoadableMenu.js
+++ b/src/universal/components/LoadableMenu.js
@@ -40,6 +40,8 @@ const LoadableMenu = (props: Props) => {
     coords,
     isClosing,
     isOpen,
+    onClose,
+    onOpen,
     maxHeight,
     maxWidth,
     setModalRef,
@@ -47,12 +49,16 @@ const LoadableMenu = (props: Props) => {
     queryVars,
     terminatePortal
   } = props
+  const handleClose = () => {
+    closePortal()
+    onClose()
+  }
   return (
-    <Modal clickToClose escToClose onClose={closePortal} isOpen={isOpen}>
+    <Modal clickToClose escToClose onClose={handleClose} isOpen={isOpen} onOpen={onOpen}>
       <AnimatedFade appear duration={100} slide={32} in={!isClosing} onExited={terminatePortal}>
         <MenuBlock style={{...coords, maxWidth}} innerRef={setModalRef}>
           <MenuContents style={{maxHeight}}>
-            <LoadableComponent {...queryVars} closePortal={closePortal} />
+            <LoadableComponent {...queryVars} closePortal={handleClose} />
           </MenuContents>
         </MenuBlock>
       </AnimatedFade>

--- a/src/universal/components/Modal.js
+++ b/src/universal/components/Modal.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types'
 class Modal extends Component {
   static propTypes = {
     onClose: PropTypes.func,
+    onOpen: PropTypes.func,
     clickToClose: PropTypes.bool,
     escToClose: PropTypes.bool,
     children: PropTypes.element.isRequired,
@@ -42,7 +43,7 @@ class Modal extends Component {
     this.setState({
       isOpen: true
     })
-    const {clickToClose, escToClose} = this.props
+    const {clickToClose, escToClose, onOpen} = this.props
     if (clickToClose) {
       document.addEventListener('mousedown', this.handleDocumentClick)
       document.addEventListener('touchstart', this.handleDocumentClick)
@@ -51,6 +52,7 @@ class Modal extends Component {
       document.addEventListener('keydown', this.handleKeydown)
     }
     document.body.appendChild(this.el)
+    onOpen && onOpen()
   }
 
   teardown () {

--- a/src/universal/decorators/withToggledPortal.js
+++ b/src/universal/decorators/withToggledPortal.js
@@ -55,10 +55,7 @@ const withToggledPortal = (ComposedComponent) => {
         const node = findDOMNode(this.toggleRef)
         node.focus()
       }
-      const {onClose} = this.props
-      if (onClose) {
-        onClose()
-      }
+      // no need to call onClose here, since it's taken care of in the parent
     }
 
     terminatePortal = () => {

--- a/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
+++ b/src/universal/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.js
@@ -94,8 +94,10 @@ class OutcomeCardContainer extends Component {
 
   toggleMenuState = () => {
     if (this._mounted) {
+      const method = this.state.cardHasMenuOpen ? 'remove' : 'add'
       this.setState({
-        cardHasMenuOpen: !this.state.cardHasMenuOpen
+        cardHasMenuOpen: !this.state.cardHasMenuOpen,
+        activeEditingComponents: this.state.activeEditingComponents[method]('menu')
       })
     }
   }


### PR DESCRIPTION
This is useful in meetings when you want to see if someone is still working on a card.
fixes #2130
TEST

-  [ ] click any menu on a task card (avatar, github octocat, status, due date) & the header changes to "editing". close the menu & it's no longer editing
