### PR TITLE
engine.io transport (experimental! DO NOT MERGE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,8 @@
     "draft-js-export-markdown": "^0.3.0",
     "email-addresses": "^3.0.1",
     "emotion": "^9.0.1",
+    "engine.io": "^3.2.0",
+    "engine.io-client": "^3.2.1",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.0",
     "es6-promisify": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "string-score": "^1.0.1",
     "string-similarity": "^1.2.0",
     "stripe": "^4.24.0",
-    "subscriptions-transport-ws": "https://github.com/mattkrick/subscriptions-transport-ws/tarball/8eaa45976cbb01b03b3bf004c5595b571482f349",
+    "subscriptions-transport-engineio": "https://github.com/jordanh/subscriptions-transport-engineio/tarball/cfa3866b610d3f0a0726c8695c30c54a43376c04",
     "tayden-clusterfck": "^0.7.0",
     "tinycolor2": "^1.4.1",
     "tlds": "^1.192.0",

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -38,6 +38,7 @@ const INTRANET_JWT_SECRET = process.env.INTRANET_JWT_SECRET || ''
 const app = express()
 const httpServer = http.createServer(app)
 const eioServer = engine.attach(httpServer, {
+  // transports: ['polling', 'websocket'],
   transports: ['polling'],
   wsEngine: 'uws'
 })

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -38,8 +38,8 @@ const INTRANET_JWT_SECRET = process.env.INTRANET_JWT_SECRET || ''
 const app = express()
 const httpServer = http.createServer(app)
 const eioServer = engine.attach(httpServer, {
-  // transports: ['polling', 'websocket'],
-  transports: ['polling'],
+  transports: ['polling', 'websocket'],
+  // transports: ['polling'],
   wsEngine: 'uws'
 })
 httpServer.listen(PORT)

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -9,7 +9,7 @@ import Raven from 'raven'
 import createSSR from './createSSR'
 import emailSSR from './emailSSR'
 import {clientSecret as secretKey} from './utils/auth0Helpers'
-import connectionHandler from './socketHandlers/wssConnectionHandler'
+import connectionHandler from './socketHandlers/eioConnectionHandler'
 import httpGraphQLHandler, {intranetHttpGraphQLHandler} from './graphql/httpGraphQLHandler'
 import stripeWebhookHandler from './billing/stripeWebhookHandler'
 import getDotenv from '../universal/utils/dotenv'
@@ -36,11 +36,12 @@ const {PORT = 3000} = process.env
 const INTRANET_JWT_SECRET = process.env.INTRANET_JWT_SECRET || ''
 
 const app = express()
-const server = http.createServer(app).listen(PORT)
-const eioServer = engine.attach(server, {
+const httpServer = http.createServer(app)
+const eioServer = engine.attach(httpServer, {
   transports: ['polling'],
   wsEngine: 'uws'
 })
+httpServer.listen(PORT)
 
 // This houses a per-mutation dataloader. When GraphQL is its own microservice, we can move this there.
 const sharedDataLoader = new SharedDataLoader({

--- a/src/server/socketHandlers/eioConnectionHandler.js
+++ b/src/server/socketHandlers/eioConnectionHandler.js
@@ -1,4 +1,3 @@
-import shortid from 'shortid'
 import keepAlive from 'server/socketHelpers/keepAlive'
 import handleDisconnect from 'server/socketHandlers/handleDisconnect'
 import handleMessage from 'server/socketHandlers/handleMessage'
@@ -8,14 +7,13 @@ import {clientSecret as auth0ClientSecret} from 'server/utils/auth0Helpers'
 import {verify} from 'jsonwebtoken'
 import {GQL_CONNECTION_ERROR, WS_KEEP_ALIVE} from 'universal/utils/constants'
 import handleConnect from 'server/socketHandlers/handleConnect'
-import {GRAPHQL_WS} from 'subscriptions-transport-ws'
 
 class ConnectionContext {
   constructor (socket, authToken, sharedDataLoader, rateLimiter) {
     this.authToken = authToken
     this.availableResubs = []
     this.cancelKeepAlive = null
-    this.id = shortid.generate()
+    this.id = socket.id
     this.isAlive = true
     this.rateLimiter = rateLimiter
     this.socket = socket
@@ -26,15 +24,17 @@ class ConnectionContext {
 
 export default function connectionHandler (sharedDataLoader, rateLimiter) {
   return async function socketConnectionHandler (socket) {
-    const req = socket.upgradeReq
-    const {headers} = req
-    const protocol = headers['sec-websocket-protocol']
-    if (protocol !== GRAPHQL_WS) {
-      sendMessage(socket, GQL_CONNECTION_ERROR, {
-        errors: [{message: 'Invalid protocol'}]
-      })
-      return
-    }
+    const req = socket.request
+    // we don't need websockets, we're we're going...
+    //
+    // const {headers} = req
+    // const protocol = headers['sec-websocket-protocol']
+    // if (protocol !== GRAPHQL_WS) {
+    //   sendMessage(socket, GQL_CONNECTION_ERROR, {
+    //     errors: [{message: 'Invalid protocol'}]
+    //   })
+    //   return
+    // }
     const {query} = url.parse(req.url, true)
     let authToken
     try {

--- a/src/server/socketHandlers/eioConnectionHandler.js
+++ b/src/server/socketHandlers/eioConnectionHandler.js
@@ -25,7 +25,7 @@ class ConnectionContext {
 export default function connectionHandler (sharedDataLoader, rateLimiter) {
   return async function socketConnectionHandler (socket) {
     const req = socket.request
-    // we don't need websockets, we're we're going...
+    // we don't need websockets, not where we're going...
     //
     // const {headers} = req
     // const protocol = headers['sec-websocket-protocol']

--- a/src/universal/Atmosphere.js
+++ b/src/universal/Atmosphere.js
@@ -7,6 +7,7 @@ import NewAuthTokenSubscription from 'universal/subscriptions/NewAuthTokenSubscr
 import EventEmitter from 'eventemitter3'
 import handlerProvider from 'universal/utils/relay/handlerProvider'
 import {SubscriptionClient} from 'subscriptions-transport-ws/dist/index'
+import eioClient from 'engine.io-client'
 
 const defaultErrorHandler = (err) => {
   console.error('Captured error:', err)
@@ -94,7 +95,7 @@ export default class Atmosphere extends Environment {
     }
     const wsProtocol = window.location.protocol.replace('http', 'ws')
     const url = `${wsProtocol}//${window.location.host}/?token=${this.authToken}`
-    const subscriptionClient = new SubscriptionClient(url, {reconnect: true})
+    const subscriptionClient = new SubscriptionClient(url, {reconnect: true}, eioClient)
 
     const {text: query, name: operationName} = NewAuthTokenSubscription().subscription()
     subscriptionClient.operations[NEW_AUTH_TOKEN] = {

--- a/src/universal/Atmosphere.js
+++ b/src/universal/Atmosphere.js
@@ -6,7 +6,7 @@ import {APP_TOKEN_KEY, GQL_START, NEW_AUTH_TOKEN} from 'universal/utils/constant
 import NewAuthTokenSubscription from 'universal/subscriptions/NewAuthTokenSubscription'
 import EventEmitter from 'eventemitter3'
 import handlerProvider from 'universal/utils/relay/handlerProvider'
-import {SubscriptionClient} from 'subscriptions-transport-ws/dist/index'
+import {SubscriptionClient} from 'subscriptions-transport-engineio/dist/index'
 import eioClient from 'engine.io-client'
 
 const defaultErrorHandler = (err) => {
@@ -59,7 +59,6 @@ export default class Atmosphere extends Environment {
     this.querySubscriptions = []
     this.subscriptions = {}
     this.eventEmitter = new EventEmitter()
-    console.log('new Atmosphere')
   }
 
   socketSubscribe = async (operation, variables, cacheConfig, observer) => {
@@ -96,9 +95,6 @@ export default class Atmosphere extends Environment {
     }
     const wsProtocol = window.location.protocol.replace('http', 'ws')
     const url = `${wsProtocol}//${window.location.host}/?token=${this.authToken}`
-    eioClient.CLOSED = 'closed'
-    eioClient.CONNECTING = 'connecting'
-    eioClient.OPEN = 'open'
     const subscriptionClient = new SubscriptionClient(url, {reconnect: true}, eioClient)
 
     const {text: query, name: operationName} = NewAuthTokenSubscription().subscription()
@@ -117,13 +113,11 @@ export default class Atmosphere extends Environment {
 
   fetchWS = async (operation, variables) => {
     return new Promise((resolve, reject) => {
-      console.log('Atmosphere: fetchWS')
       const opId = this.subscriptionClient.generateOperationId()
       const payload = {
         query: operation.text,
         variables
       }
-      console.log('Atmosphere: fetchWS got optIt')
       this.subscriptionClient.operations[opId] = {
         options: payload,
         handler: (errors, result) => {
@@ -138,13 +132,11 @@ export default class Atmosphere extends Environment {
           }
         }
       }
-      console.log('Atmosphere: fetchWS got about to sendMessage')
       this.subscriptionClient.sendMessage(opId, GQL_START, payload)
     })
   }
 
   setNet = (name) => {
-    console.log(`setNet(${name})`)
     this._network = this.networks[name]
   }
 

--- a/src/universal/Atmosphere.js
+++ b/src/universal/Atmosphere.js
@@ -59,6 +59,7 @@ export default class Atmosphere extends Environment {
     this.querySubscriptions = []
     this.subscriptions = {}
     this.eventEmitter = new EventEmitter()
+    console.log('new Atmosphere')
   }
 
   socketSubscribe = async (operation, variables, cacheConfig, observer) => {
@@ -95,6 +96,9 @@ export default class Atmosphere extends Environment {
     }
     const wsProtocol = window.location.protocol.replace('http', 'ws')
     const url = `${wsProtocol}//${window.location.host}/?token=${this.authToken}`
+    eioClient.CLOSED = 'closed'
+    eioClient.CONNECTING = 'connecting'
+    eioClient.OPEN = 'open'
     const subscriptionClient = new SubscriptionClient(url, {reconnect: true}, eioClient)
 
     const {text: query, name: operationName} = NewAuthTokenSubscription().subscription()
@@ -113,11 +117,13 @@ export default class Atmosphere extends Environment {
 
   fetchWS = async (operation, variables) => {
     return new Promise((resolve, reject) => {
+      console.log('Atmosphere: fetchWS')
       const opId = this.subscriptionClient.generateOperationId()
       const payload = {
         query: operation.text,
         variables
       }
+      console.log('Atmosphere: fetchWS got optIt')
       this.subscriptionClient.operations[opId] = {
         options: payload,
         handler: (errors, result) => {
@@ -132,11 +138,13 @@ export default class Atmosphere extends Environment {
           }
         }
       }
+      console.log('Atmosphere: fetchWS got about to sendMessage')
       this.subscriptionClient.sendMessage(opId, GQL_START, payload)
     })
   }
 
   setNet = (name) => {
+    console.log(`setNet(${name})`)
     this._network = this.networks[name]
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,6 +900,10 @@ addressparser@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/addressparser/-/addressparser-1.0.1.tgz#47afbe1a2a9262191db6838e4fd1d39b40821746"
 
+after@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
+
 agent-base@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.1.1.tgz#d6de10d5af6132d5bd692427d46fc538539094c7"
@@ -1197,6 +1201,10 @@ array.prototype.flatmap@^1.2.1:
     define-properties "^1.1.2"
     es-abstract "^1.10.0"
     function-bind "^1.1.1"
+
+arraybuffer.slice@~0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
 
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
@@ -2486,9 +2494,17 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base64-arraybuffer@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
+
 base64-js@^1.0.2, base64-js@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+
+base64id@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6"
 
 base@^0.11.1:
   version "0.11.2"
@@ -2516,6 +2532,12 @@ bcryptjs@^2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
 
+better-assert@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
+  dependencies:
+    callsite "1.0.0"
+
 bfj-node4@^5.2.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/bfj-node4/-/bfj-node4-5.3.1.tgz#e23d8b27057f1d0214fc561142ad9db998f26830"
@@ -2535,6 +2557,10 @@ binary-extensions@^1.0.0:
 binaryextensions@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
+
+blob@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
 
 "bluebird@>= 3.0.1", bluebird@^3.3.4, bluebird@^3.5.1:
   version "3.5.1"
@@ -2869,6 +2895,10 @@ caller-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
   dependencies:
     callsites "^0.2.0"
+
+callsite@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
 
 callsites@^0.2.0:
   version "0.2.0"
@@ -3445,9 +3475,13 @@ compare-versions@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.2.1.tgz#a49eb7689d4caaf0b6db5220173fd279614000f7"
 
-component-emitter@^1.2.0, component-emitter@^1.2.1:
+component-emitter@1.2.1, component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
+component-inherit@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
 
 component-type@^1.2.1:
   version "1.2.1"
@@ -3997,7 +4031,7 @@ debug@2.6.7:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@^3.1.0:
+debug@3.1.0, debug@^3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -4537,6 +4571,43 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   dependencies:
     once "^1.4.0"
+
+engine.io-client@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.2.1.tgz#6f54c0475de487158a1a7c77d10178708b6add36"
+  dependencies:
+    component-emitter "1.2.1"
+    component-inherit "0.0.3"
+    debug "~3.1.0"
+    engine.io-parser "~2.1.1"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    ws "~3.3.1"
+    xmlhttprequest-ssl "~1.5.4"
+    yeast "0.1.2"
+
+engine.io-parser@~2.1.0, engine.io-parser@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.1.2.tgz#4c0f4cff79aaeecbbdcfdea66a823c6085409196"
+  dependencies:
+    after "0.8.2"
+    arraybuffer.slice "~0.0.7"
+    base64-arraybuffer "0.1.5"
+    blob "0.0.4"
+    has-binary2 "~1.0.2"
+
+engine.io@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.2.0.tgz#54332506f42f2edc71690d2f2a42349359f3bf7d"
+  dependencies:
+    accepts "~1.3.4"
+    base64id "1.0.0"
+    cookie "0.3.1"
+    debug "~3.1.0"
+    engine.io-parser "~2.1.0"
+    ws "~3.3.1"
 
 enhanced-resolve@^4.0.0:
   version "4.0.0"
@@ -6108,9 +6179,19 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-binary2@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-binary2/-/has-binary2-1.0.3.tgz#7776ac627f3ea77250cfc332dab7ddf5e4f5d11d"
+  dependencies:
+    isarray "2.0.1"
+
 has-color@~0.1.0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
+
+has-cors@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
 
 has-flag@^1.0.0:
   version "1.0.0"
@@ -7120,6 +7201,10 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isarray@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
 
 isbinaryfile@^3.0.2:
   version "3.0.2"
@@ -9490,6 +9575,18 @@ parse5@^3.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
   dependencies:
     "@types/node" "*"
+
+parseqs@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
+  dependencies:
+    better-assert "~1.0.0"
+
+parseuri@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a"
+  dependencies:
+    better-assert "~1.0.0"
 
 parseurl@~1.3.2:
   version "1.3.2"
@@ -13515,7 +13612,7 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^3.0.0:
+ws@^3.0.0, ws@~3.3.1:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
   dependencies:
@@ -13592,6 +13689,10 @@ xmlbuilder@^4.1.0:
 xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+
+xmlhttprequest-ssl@~1.5.4:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
 
 xregexp@2.0.0:
   version "2.0.0"
@@ -13754,6 +13855,10 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yeast@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
 yeoman-environment@^2.0.5, yeoman-environment@^2.1.1:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12422,9 +12422,9 @@ stylis@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
 
-"subscriptions-transport-ws@https://github.com/mattkrick/subscriptions-transport-ws/tarball/8eaa45976cbb01b03b3bf004c5595b571482f349":
-  version "0.9.5"
-  resolved "https://github.com/mattkrick/subscriptions-transport-ws/tarball/8eaa45976cbb01b03b3bf004c5595b571482f349#220d1dc20c9885aa35926c80e48f504bd9bca376"
+"subscriptions-transport-engineio@https://github.com/jordanh/subscriptions-transport-engineio/tarball/cfa3866b610d3f0a0726c8695c30c54a43376c04":
+  version "0.10.0"
+  resolved "https://github.com/jordanh/subscriptions-transport-engineio/tarball/cfa3866b610d3f0a0726c8695c30c54a43376c04#dde98333f43a3783dbbb9adb19bb3c3f8b39ef26"
   dependencies:
     backo2 "^1.0.2"
     eventemitter3 "^2.0.3"


### PR DESCRIPTION
I had some time on Sunday to play around. It'd been too long since I had really got my hands dirty with anything. Plus, it bugged me that we had tried to onboard with an excited corporate client and got stymied by their lousy firewall.

Here's a branch that uses [engine.io](https://github.com/socketio/engine.io) as the underlying transport. It provides a polled transport that is upgraded to websockets if the path supports it. I _think_ everything works but presence, but I didn't test it too hard.

I don't think presence works yet. But, I haven't looked into it too hard.

## Tests

### GraphQL subscriptions, websocket upgrade enabled

Start the app, load app

- [ ] app is served
- [ ] can login

Load `/me`, open second tab

- [ ] `/me` loads
- [ ] can create card
- [ ] when card is dragged between columns, events propagate to other browser

Start retro meeting, enter reflections and proceed to group phase. With two tabs open:

- [ ] drag events propagate as expected

### GraphQL subscriptions, polling only

Edit `server.js` and initialized engine.io transport as:

```
const eioServer = engine.attach(httpServer, {
  // transports: ['polling', 'websocket'],
  transports: ['polling'],
  wsEngine: 'uws'
})
```

Start the app, load app

- [ ] app is served
- [ ] can login

Load `/me`, open second tab

- [ ] `/me` loads
- [ ] can create card
- [ ] when card is dragged between columns, events propagate to other browser
- [ ] when network tab is opened, polled HTTP requests are observed

Start retro meeting, enter reflections and proceed to group phase. With two tabs open:

- [ ] drag events propagate as expected

### Presence

- [ ] Presence works as expected