### PR TITLE
hide private cards in meeting summary fixes #2286

### DIFF
--- a/src/server/graphql/mutations/helpers/endMeeting/sendNewMeetingSummary.js
+++ b/src/server/graphql/mutations/helpers/endMeeting/sendNewMeetingSummary.js
@@ -20,6 +20,11 @@ const getRetroMeeting = (meetingId) => {
               userId: meetingMember('userId'),
               meetingId
             })
+            .filter((task) =>
+              task('tags')
+                .contains('private')
+                .not()
+            )
             .coerceTo('array')
         }))
         .coerceTo('array'),

--- a/src/server/graphql/types/RetrospectiveMeetingMember.js
+++ b/src/server/graphql/types/RetrospectiveMeetingMember.js
@@ -15,7 +15,10 @@ const RetrospectiveMeetingMember = new GraphQLObjectType({
         const meeting = await dataLoader.get('newMeetings').load(meetingId)
         const {teamId} = meeting
         const teamTasks = await dataLoader.get('tasksByTeamId').load(teamId)
-        return teamTasks.filter((task) => task.meetingId === meetingId && task.userId === userId)
+        return teamTasks.filter(
+          (task) =>
+            task.meetingId === meetingId && task.userId === userId && !task.tags.includes('private')
+        )
       }
     },
     votesRemaining: {


### PR DESCRIPTION
TEST

- run a retro, add a public & a private task card, complete the meeting, 
- [ ] only the public card shows up in the browser 
- [ ] & in the email