### PR TITLE
remove the double duck flash

### DIFF
--- a/src/universal/modules/newTeam/containers/NewTeamForm/NewTeamRoot.js
+++ b/src/universal/modules/newTeam/containers/NewTeamForm/NewTeamRoot.js
@@ -1,12 +1,11 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {TransitionGroup} from 'react-transition-group'
-import AnimatedFade from 'universal/components/AnimatedFade'
 import ErrorComponent from 'universal/components/ErrorComponent/ErrorComponent'
-import LoadingComponent from 'universal/components/LoadingComponent/LoadingComponent'
 import QueryRenderer from 'universal/components/QueryRenderer/QueryRenderer'
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere'
 import NewTeam from 'universal/modules/newTeam/NewTeam'
+import RelayTransitionGroup from 'universal/components/RelayTransitionGroup'
+import LoadingView from 'universal/components/LoadingView/LoadingView'
 
 const query = graphql`
   query NewTeamRootQuery {
@@ -26,24 +25,14 @@ const NewTeamRoot = ({
     <QueryRenderer
       environment={atmosphere}
       query={query}
-      render={({error, props: renderProps}) => {
-        return (
-          <TransitionGroup appear component={React.Fragment}>
-            {error && <ErrorComponent height={'14rem'} error={error} />}
-            {renderProps && (
-              <AnimatedFade key='1'>
-                <NewTeam defaultOrgId={defaultOrgId} viewer={renderProps.viewer} />
-              </AnimatedFade>
-            )}
-            {!renderProps &&
-              !error && (
-                <AnimatedFade key='2' unmountOnExit exit={false}>
-                  <LoadingComponent height={'5rem'} />
-                </AnimatedFade>
-              )}
-          </TransitionGroup>
-        )
-      }}
+      render={(readyState) => (
+        <RelayTransitionGroup
+          readyState={readyState}
+          error={<ErrorComponent height={'14rem'} />}
+          loading={<LoadingView minHeight='50vh' />}
+          ready={<NewTeam defaultOrgId={defaultOrgId} />}
+        />
+      )}
     />
   )
 }

--- a/src/universal/modules/teamDashboard/components/Team/Team.js
+++ b/src/universal/modules/teamDashboard/components/Team/Team.js
@@ -3,7 +3,6 @@ import React, {Component} from 'react'
 import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
 import {withRouter} from 'react-router-dom'
 import DashboardAvatars from 'universal/components/DashboardAvatars/DashboardAvatars'
-import LoadingView from 'universal/components/LoadingView/LoadingView'
 import EditTeamName from 'universal/modules/teamDashboard/components/EditTeamName/EditTeamName'
 import TeamCallsToAction from 'universal/modules/teamDashboard/components/TeamCallsToAction/TeamCallsToAction'
 import UnpaidTeamModalRoot from 'universal/modules/teamDashboard/containers/UnpaidTeamModal/UnpaidTeamModalRoot'
@@ -79,7 +78,7 @@ class Team extends Component {
 
   render () {
     const {children, hasMeetingAlert, isSettings, team} = this.props
-    if (!team) return <LoadingView />
+    if (!team) return null
     const {teamId, teamName, isPaid, meetingId, newMeeting} = team
     const hasActiveMeeting = Boolean(meetingId)
     const hasOverlay = hasActiveMeeting || !isPaid

--- a/src/universal/modules/teamDashboard/containers/TeamArchive/TeamArchiveRoot.js
+++ b/src/universal/modules/teamDashboard/containers/TeamArchive/TeamArchiveRoot.js
@@ -1,12 +1,11 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {TransitionGroup} from 'react-transition-group'
-import AnimatedFade from 'universal/components/AnimatedFade'
 import ErrorComponent from 'universal/components/ErrorComponent/ErrorComponent'
-import LoadingComponent from 'universal/components/LoadingComponent/LoadingComponent'
 import QueryRenderer from 'universal/components/QueryRenderer/QueryRenderer'
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere'
 import TeamArchive from 'universal/modules/teamDashboard/components/TeamArchive/TeamArchive'
+import RelayTransitionGroup from 'universal/components/RelayTransitionGroup'
+import LoadingView from 'universal/components/LoadingView/LoadingView'
 
 const query = graphql`
   query TeamArchiveRootQuery($teamId: ID!, $first: Int!, $after: DateTime) {
@@ -26,30 +25,14 @@ const TeamArchiveRoot = ({atmosphere, match, team}) => {
       environment={atmosphere}
       query={query}
       variables={{teamId, first: 40}}
-      render={({error, props: renderProps}) => {
-        return (
-          <TransitionGroup appear component={React.Fragment}>
-            {error && <ErrorComponent height={'14rem'} error={error} />}
-            {renderProps &&
-              team && (
-                <AnimatedFade key='1'>
-                  <TeamArchive
-                    teamId={teamId}
-                    team={team}
-                    userId={userId}
-                    viewer={renderProps.viewer}
-                  />
-                </AnimatedFade>
-              )}
-            {!renderProps &&
-              !error && (
-                <AnimatedFade key='2' unmountOnExit exit={false}>
-                  <LoadingComponent height={'5rem'} />
-                </AnimatedFade>
-              )}
-          </TransitionGroup>
-        )
-      }}
+      render={(readyState) => (
+        <RelayTransitionGroup
+          readyState={readyState}
+          error={<ErrorComponent height={'14rem'} />}
+          loading={<LoadingView minHeight='50vh' />}
+          ready={<TeamArchive teamId={teamId} team={team} userId={userId} />}
+        />
+      )}
     />
   )
 }

--- a/src/universal/modules/userDashboard/components/UserDashRoot.js
+++ b/src/universal/modules/userDashboard/components/UserDashRoot.js
@@ -1,13 +1,12 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {TransitionGroup} from 'react-transition-group'
-import AnimatedFade from 'universal/components/AnimatedFade'
 import ErrorComponent from 'universal/components/ErrorComponent/ErrorComponent'
-import LoadingView from 'universal/components/LoadingView/LoadingView'
 import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere'
 import UserDashMain from 'universal/modules/userDashboard/components/UserDashMain/UserDashMain'
 import {cacheConfig} from 'universal/utils/constants'
 import QueryRenderer from 'universal/components/QueryRenderer/QueryRenderer'
+import RelayTransitionGroup from 'universal/components/RelayTransitionGroup'
+import LoadingView from 'universal/components/LoadingView/LoadingView'
 
 const query = graphql`
   query UserDashRootQuery {
@@ -25,24 +24,14 @@ const UserDashRoot = ({atmosphere}) => {
       cacheConfig={cacheConfig}
       environment={atmosphere}
       query={query}
-      render={({error, props: renderProps}) => {
-        return (
-          <TransitionGroup appear component={React.Fragment}>
-            {error && <ErrorComponent height={'14rem'} error={error} />}
-            {renderProps && (
-              <AnimatedFade key='1'>
-                <UserDashMain viewer={renderProps.viewer} />
-              </AnimatedFade>
-            )}
-            {!renderProps &&
-              !error && (
-                <AnimatedFade key='2' unmountOnExit exit={false}>
-                  <LoadingView />
-                </AnimatedFade>
-              )}
-          </TransitionGroup>
-        )
-      }}
+      render={(readyState) => (
+        <RelayTransitionGroup
+          readyState={readyState}
+          error={<ErrorComponent height={'14rem'} />}
+          loading={<LoadingView minHeight='50vh' />}
+          ready={<UserDashMain />}
+        />
+      )}
     />
   )
 }


### PR DESCRIPTION
on any route that starts with /team you could see 2 sets of ducks. now you only see 1.

still not perfect, but this'll all change when react 17 comes out, so it's not worth the investment for now