### PR TITLE
CDN fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
     "relay-compiler": "1.7.0-rc.1",
     "relay-compiler-language-typescript": "file:./relay-compiler-language-typescript-v1.1.0.tgz",
+    "script-ext-html-webpack-plugin": "^2.0.1",
     "selenium-webdriver": "^3.6.0",
     "snazzy": "^7.1.1",
     "standard": "^11.0.1",

--- a/src/client/cdnFallback.js
+++ b/src/client/cdnFallback.js
@@ -1,0 +1,11 @@
+/*eslint-disable*/
+const original = __webpack_chunk_load__
+__webpack_chunk_load__ = (id) => {
+  const tryCDN = () => {
+    return original(id).catch(() => {
+      __webpack_public_path__ = '/static/'
+      return tryCDN()
+    })
+  }
+  return tryCDN()
+}

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -1,3 +1,4 @@
+import './cdnFallback'
 import React from 'react'
 import {render} from 'react-dom'
 import makeStore from './makeStore'

--- a/src/server/template.html
+++ b/src/server/template.html
@@ -7,5 +7,12 @@
 </head>
 <body>
     <div id="root"></div>
+    <script>
+      function fallback(el) {
+        const url = document.createElement('script')
+        url.src = window.location.origin + '/static' + el.src.slice(el.src.lastIndexOf('/'))
+        document.body.append(url)
+      }
+    </script>
 </body>
 </html>

--- a/webpack/webpack.prod.config.js
+++ b/webpack/webpack.prod.config.js
@@ -18,6 +18,7 @@ const presetReact = require('@babel/preset-react')
 const pluginObjectRestSpread = require('@babel/plugin-proposal-object-rest-spread')
 const pluginClassProps = require('@babel/plugin-proposal-class-properties')
 const pluginRelay = require('babel-plugin-relay')
+const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 
 const publicPath = getWebpackPublicPath.default()
 getDotenv.default()
@@ -98,6 +99,13 @@ module.exports = {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: 'src/server/template.html'
+    }),
+    new ScriptExtHtmlWebpackPlugin({
+      custom: {
+        test: /\.js$/,
+        attribute: 'onerror',
+        value: 'fallback(this)'
+      }
     }),
     new CleanWebpackPlugin([path.join(__dirname, '../build/*.*')], {
       root: path.join(__dirname, '..'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -12643,6 +12643,12 @@ scoped-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
 
+script-ext-html-webpack-plugin@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/script-ext-html-webpack-plugin/-/script-ext-html-webpack-plugin-2.0.1.tgz#90ac3d77f1892ad9054c3752f0e4673607f6d9a3"
+  dependencies:
+    debug "^3.1.0"
+
 secure-compare@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"


### PR DESCRIPTION
this supports clients that block our CDN.
here's how it works:

- the HTML template includes a fallback script that grabs the failed resource name & prefixes it with our static address
- every script in our generated HTML calls the fallback when it encounters an error

for scripts that are loaded after the initial bundle:
- we add a `catch` clause to the chunk loader. when a chunk fails, we try it again without the CDN.

TEST
- [ ] in webpack.prod.config, set `publicPath: '/staticFOO/` 
- [ ] `yarn bs` & load the dashboard
- [ ] you'll see each resource is requested twice. once from `/staticFOO` and again from `/static`