### PR TITLE
auto-invalidate dll

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start:tunnel": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d '\"') && ultrahook -k $ULTRAHOOK_API_KEY dev 3000",
     "start:memwatch": "NODE_ENV=production MEMWATCH=true node --expose-gc --inspect --trace-warnings ./src/server/server.babel.js",
     "quickstart": "npm run db:migrate && npm run bs",
-    "dev": "if [ ! -f \"dll/vendors.json\" ] ; then npm run build:dll ; fi ; node ./src/server/server.babel.js",
+    "dev": "node ./webpack/buildDll.js && node ./src/server/server.babel.js",
     "bs": "npm run build && npm start",
     "build": "npm run build:relay && npm run build:client",
     "build:client": "webpack --config ./webpack/webpack.prod.config.js",

--- a/webpack/buildDll.js
+++ b/webpack/buildDll.js
@@ -1,8 +1,8 @@
 /* cwd needs to be project root */
-const childProcess = require('child_process')
 const fs = require('fs')
 const webpack = require('webpack')
 const config = require('./webpack.config.dll.js')
+const crypto = require('crypto')
 
 let cacheHash
 try {
@@ -11,13 +11,18 @@ try {
   cacheHash = ''
 }
 
-const hash = childProcess.execSync('md5sum yarn.lock')
-if (hash.toString() !== cacheHash) {
+const lockfile = fs.readFileSync('yarn.lock', 'utf8')
+
+const hash = crypto
+  .createHash('md5')
+  .update(lockfile)
+  .digest('hex')
+if (hash !== cacheHash) {
   webpack(config, () => {
     console.log('DLL created')
   })
   if (!fs.existsSync('dll')) {
     fs.mkdirSync('dll')
   }
-  childProcess.exec('md5sum yarn.lock > dll/yarn.md5')
+  fs.writeFileSync('dll/yarn.md5', hash)
 }

--- a/webpack/buildDll.js
+++ b/webpack/buildDll.js
@@ -1,0 +1,23 @@
+/* cwd needs to be project root */
+const childProcess = require('child_process')
+const fs = require('fs')
+const webpack = require('webpack')
+const config = require('./webpack.config.dll.js')
+
+let cacheHash
+try {
+  cacheHash = fs.readFileSync('dll/yarn.md5', 'utf8')
+} catch (e) {
+  cacheHash = ''
+}
+
+const hash = childProcess.execSync('md5sum yarn.lock')
+if (hash.toString() !== cacheHash) {
+  webpack(config, () => {
+    console.log('DLL created')
+  })
+  if (!fs.existsSync('dll')) {
+    fs.mkdirSync('dll')
+  }
+  childProcess.exec('md5sum yarn.lock > dll/yarn.md5')
+}

--- a/webpack/webpack.config.dll.js
+++ b/webpack/webpack.config.dll.js
@@ -53,7 +53,7 @@ module.exports = {
   },
   output: {
     filename: '[name].dll.js',
-    path: path.join(__dirname, '../build'),
+    path: path.join(__dirname, '../dll'),
     library: '[name]'
   },
   plugins: [


### PR DESCRIPTION
fix #2213

written in node because the shell script was getting ugly & md5sum doesn't exist on macOS.

TEST
- [ ] `yarn dev` creates a DLL when the `dll` folder or `dll/yarn.md5` does not exist OR deps change