### PR TITLE
Fixes #2372 prompt footer in summary

### DIFF
--- a/src/server/graphql/mutations/createReflection.js
+++ b/src/server/graphql/mutations/createReflection.js
@@ -74,6 +74,7 @@ export default {
       content: normalizedContent,
       isActive: true,
       meetingId,
+      phaseItem,
       reflectionGroupId,
       retroPhaseItemId,
       sortOrder: 0,

--- a/src/universal/modules/email/components/RetroDiscussionTopics/RetroDiscussionTopic.js
+++ b/src/universal/modules/email/components/RetroDiscussionTopics/RetroDiscussionTopic.js
@@ -58,6 +58,13 @@ const reflectionCard = {
   padding: 0
 }
 
+const reflectionCardFooter = {
+  color: ui.palette.midGray,
+  fontFamily,
+  fontSize: '11px',
+  padding: '0 .5rem .5rem'
+}
+
 type Reflection = {
   id: string,
   content: string
@@ -101,10 +108,11 @@ const RetroDiscussionTopic = (props: Props) => {
                 {rows.map((row, idx) => (
                   // eslint-disable-next-line
                   <tr key={idx}>
-                    {row.map(({id, content}) => (
+                    {row.map(({id, content, phaseItem: {question}}) => (
                       <td key={id} style={cardCell}>
                         <div style={reflectionCard}>
                           <ReflectionEditorWrapperForEmail content={content} />
+                          <div style={reflectionCardFooter}>{question}</div>
                         </div>
                       </td>
                     ))}

--- a/src/universal/modules/summary/components/NewMeetingSummary.tsx
+++ b/src/universal/modules/summary/components/NewMeetingSummary.tsx
@@ -77,6 +77,9 @@ export default createFragmentContainer(
               id
               content
               sortOrder
+              phaseItem {
+                question
+              }
             }
           }
         }

--- a/src/universal/mutations/EndNewMeetingMutation.js
+++ b/src/universal/mutations/EndNewMeetingMutation.js
@@ -35,7 +35,7 @@ export const popEndNewMeetingToast = (dispatch) => {
     showInfo({
       autoDismiss: 10,
       title: 'It’s dead!',
-      message: `You killed the meeting. 
+      message: `You killed the meeting.
     Just like your goldfish.`,
       action: {label: 'Good.'}
     })


### PR DESCRIPTION
#### Test
- [ ] Run a retro locally with at least 1 voted topic. See the prompt question in the footer of the reflections in the summary view (browser, email).