### PR TITLE
add better resize detection & return handling

### DIFF
--- a/src/universal/components/ReflectionCard/ReflectionCard.tsx
+++ b/src/universal/components/ReflectionCard/ReflectionCard.tsx
@@ -143,7 +143,7 @@ class ReflectionCard extends Component<Props, State> {
 
   handleReturn = (e) => {
     if (e.shiftKey) return 'not-handled'
-    this.handleEditorBlur()
+    this.editorRef.blur()
     return 'handled'
   }
 

--- a/src/universal/components/RetroReflectPhase/ChildrenCache.tsx
+++ b/src/universal/components/RetroReflectPhase/ChildrenCache.tsx
@@ -75,7 +75,7 @@ class ChildrenCache {
     return result
   }
 
-  private updateChildren () {
+  updateChildren () {
     let childrenToAnimate = 0
     const {children, height, width} = this.getGridTuples()
     children.forEach((last, idx) => {

--- a/src/universal/components/RetroReflectPhase/ExpandedReflectionStack.tsx
+++ b/src/universal/components/RetroReflectPhase/ExpandedReflectionStack.tsx
@@ -1,6 +1,7 @@
 import {PhaseItemColumn_meeting} from '__generated__/PhaseItemColumn_meeting.graphql'
 import React, {Component} from 'react'
 import styled from 'react-emotion'
+import ResizeObserver from 'resize-observer-polyfill'
 import Modal from 'universal/components/Modal'
 import ReflectionCard from 'universal/components/ReflectionCard/ReflectionCard'
 import FLIPGrid from 'universal/components/RetroReflectPhase/FLIPGrid'
@@ -34,14 +35,29 @@ class ExpandedReflectionStack extends Component<Props, State> {
   state = {
     isClosing: false
   }
+  resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      this.handleResize(entry.target.id)
+    }
+  })
+
   gridRef = React.createRef<FLIPGrid>()
   getModalFirst = () => getBBox(this.props.stackRef.current)
   getParentBBox = () => getBBox(this.props.phaseRef.current)
   getChildrenFirst = () => getBBox(this.props.firstReflectionRef.current)
 
-  checkForResize = (key) => () => {
+  componentDidMount () {
+    window.addEventListener('resize', this.handleWindowResize)
+  }
+
+  handleWindowResize = () => {
     if (!this.gridRef.current) return
-    this.gridRef.current.checkForResize(key)
+    this.gridRef.current.handleWindowResize()
+  }
+
+  handleResize = (id) => {
+    if (!this.gridRef.current) return
+    this.gridRef.current.checkForResize(id)
   }
 
   handleClose = () => {
@@ -59,6 +75,14 @@ class ExpandedReflectionStack extends Component<Props, State> {
 
   componentWillUnmount () {
     this.props.collapse()
+    window.removeEventListener('resize', this.handleWindowResize)
+    this.resizeObserver.disconnect()
+  }
+
+  setItemRef = (c) => {
+    if (c) {
+      this.resizeObserver.observe(c)
+    }
   }
 
   render () {
@@ -83,12 +107,16 @@ class ExpandedReflectionStack extends Component<Props, State> {
             >
               {reflectionStack.map((reflection, idx) => {
                 return (
-                  <ModalReflectionWrapper key={reflection.id} style={{zIndex: idx + 1}}>
+                  <ModalReflectionWrapper
+                    key={reflection.id}
+                    style={{zIndex: idx + 1}}
+                    innerRef={this.setItemRef}
+                    id={reflection.id}
+                  >
                     <ReflectionCard
                       meetingId={meetingId}
                       reflection={reflection}
                       phaseItemId={phaseItemId}
-                      handleChange={this.checkForResize(reflection.id)}
                     />
                   </ModalReflectionWrapper>
                 )

--- a/src/universal/components/RetroReflectPhase/FLIPGrid.tsx
+++ b/src/universal/components/RetroReflectPhase/FLIPGrid.tsx
@@ -1,7 +1,7 @@
 import React, {cloneElement, Component, ComponentElement} from 'react'
 import {findDOMNode} from 'react-dom'
-import ChildrenCache from 'universal/components/RetroReflectPhase/ChildrenCache'
 import {BBox} from 'types/animations'
+import ChildrenCache from 'universal/components/RetroReflectPhase/ChildrenCache'
 import ParentCache from 'universal/components/RetroReflectPhase/ParentCache'
 import {
   CARD_PADDING,
@@ -81,6 +81,11 @@ class FLIPGrid extends Component<Props, State> {
     this.parentCache.setCoords(this.parentCache.el, dims, maxBBox)
     this.props.setBBox(this.parentCache.bbox)
     this.updateChildren()
+  }
+
+  handleWindowResize = () => {
+    const dims = this.childrenCache.updateChildren()
+    this.handleGridChange(dims)
   }
 
   checkForResize (key: string) {


### PR DESCRIPTION
TEST - reflect phase modal
- pressing shift+enter resizes the layout
- resizes the window works
- press enter to blur the card & submit
- tab submits (#2385 says it didn't, but in my tests it does, so maybe i'm missing something)