### PR TITLE
Button elevation, card buttons

### DIFF
--- a/src/universal/components/BaseButton.js
+++ b/src/universal/components/BaseButton.js
@@ -11,7 +11,8 @@ const isValidElevation = (elevation) => elevation >= 0 && elevation <= 24
 const getPressedElevation = (elevation1, elevation2) => {
   const offset = Math.floor(Math.abs(elevation1 - elevation2) / 2)
   const hovered = Math.max(elevation1, elevation2)
-  return hovered ? hovered - offset : 0
+  const pressedElevation = hovered ? hovered - offset : 0
+  return elevation[pressedElevation]
 }
 
 const getBoxShadow = (disabled, pressedDown, desiredElevation, otherElevation) => {
@@ -35,7 +36,7 @@ const ButtonRoot = styled(PlainButton)(
       userSelect: 'none',
       whiteSpace: 'nowrap',
       ':hover,:focus,:active': {
-        boxShadow: getBoxShadow(disabled, pressedDown, elevationHovered.elevationResting),
+        boxShadow: getBoxShadow(disabled, pressedDown, elevationHovered, elevationResting),
         outline: pressedDown && 0
       }
     }

--- a/src/universal/components/BaseButton.js
+++ b/src/universal/components/BaseButton.js
@@ -6,15 +6,28 @@ import PlainButton from 'universal/components/PlainButton/PlainButton'
 import withInnerRef from 'universal/decorators/withInnerRef'
 import elevation from 'universal/styles/elevation'
 
+const isValidElevation = (elevation) => elevation >= 0 && elevation <= 24
+
+const getPressedElevation = (elevation1, elevation2) => {
+  const offset = Math.floor(Math.abs(elevation1 - elevation2) / 2)
+  const hovered = Math.max(elevation1, elevation2)
+  return hovered ? hovered - offset : 0
+}
+
+const getBoxShadow = (disabled, pressedDown, desiredElevation, otherElevation) => {
+  if (disabled || !isValidElevation(desiredElevation)) return undefined
+  if (pressedDown) return getPressedElevation(desiredElevation, otherElevation)
+  return elevation[desiredElevation]
+}
+
 const ButtonRoot = styled(PlainButton)(
   ({disabled, elevationResting, elevationHovered, pressedDown, size}) => {
-    const hasDepth = elevationResting && elevationHovered
     return {
       // size is easy to override, it adds: fontSize, lineHeight, padding
       ...ui.buttonSizeStyles[size],
       alignItems: 'center',
       border: '.0625rem solid transparent',
-      boxShadow: !disabled && hasDepth ? elevation[elevationResting] : undefined,
+      boxShadow: getBoxShadow(disabled, pressedDown, elevationResting, elevationHovered),
       display: 'flex',
       justifyContent: 'center',
       textAlign: 'center',
@@ -22,18 +35,7 @@ const ButtonRoot = styled(PlainButton)(
       userSelect: 'none',
       whiteSpace: 'nowrap',
       ':hover,:focus,:active': {
-        boxShadow: !disabled && hasDepth ? elevation[elevationHovered] : undefined,
-        outline: pressedDown && 0
-      }
-    }
-  },
-  ({disabled, elevationHovered, elevationResting, pressedDown}) => {
-    const pressedDownElevation = elevationHovered - (elevationHovered - elevationResting) / 2
-    const boxShadow = !disabled && pressedDown ? elevation[pressedDownElevation] : undefined
-    return {
-      boxShadow,
-      ':hover,:focus,:active': {
-        boxShadow,
+        boxShadow: getBoxShadow(disabled, pressedDown, elevationHovered.elevationResting),
         outline: pressedDown && 0
       }
     }
@@ -111,9 +113,6 @@ class BaseButton extends Component {
 
     const {pressedDown} = this.state
     const hasDisabledStyles = disabled || waiting
-
-    console.log(`elevationHovered: ${elevationHovered}`)
-    console.log(`elevationResting: ${elevationResting}`)
 
     // spread props to allow for html attributes like type when needed
     return (

--- a/src/universal/components/CardButton.js
+++ b/src/universal/components/CardButton.js
@@ -3,7 +3,7 @@ import ui from 'universal/styles/ui'
 import BaseButton from 'universal/components/BaseButton'
 
 const CardButton = styled(BaseButton)({
-  borderRadius: ui.borderRadiusSmall,
+  borderRadius: '4em',
   color: ui.palette.dark,
   height: ui.cardButtonHeight,
   lineHeight: ui.cardContentLineHeight,
@@ -12,7 +12,7 @@ const CardButton = styled(BaseButton)({
   outline: 0,
   padding: 0,
   ':hover, :focus': {
-    borderColor: ui.cardButtonBorderColor,
+    backgroundColor: ui.palette.gray,
     opacity: 1
   }
 })

--- a/src/universal/components/CreateAccountPage/CreateAccountEmailPasswordForm.js
+++ b/src/universal/components/CreateAccountPage/CreateAccountEmailPasswordForm.js
@@ -57,7 +57,7 @@ const SignInEmailPasswordForm = (props: Props) => {
           disabled={submitting}
         />
       </Block>
-      <PrimaryButton size='large' depth={1} disabled={!valid} waiting={submitting}>
+      <PrimaryButton size='large' disabled={!valid} waiting={submitting}>
         {CREATE_ACCOUNT_BUTTON_LABEL}
       </PrimaryButton>
     </Form>

--- a/src/universal/components/DueDateToggle.js
+++ b/src/universal/components/DueDateToggle.js
@@ -11,14 +11,15 @@ import CardButton from 'universal/components/CardButton'
 import ms from 'ms'
 import tinycolor from 'tinycolor2'
 
-const lighten = (color, amount) =>
+const darken = (color, amount) =>
   tinycolor(color)
-    .lighten(amount)
+    .darken(amount)
     .toString()
 
 const Toggle = styled(CardButton)(
   {
     alignItems: 'center',
+    borderRadius: '4em',
     display: 'flex',
     justifyContent: 'center',
     opacity: 0
@@ -26,7 +27,7 @@ const Toggle = styled(CardButton)(
   ({cardIsActive}) => ({
     opacity: cardIsActive && 0.5,
     ':hover, :focus': {
-      borderColor: ui.cardButtonBorderColor,
+      backgroundColor: ui.palette.gray,
       opacity: cardIsActive && 1
     }
   }),
@@ -40,7 +41,8 @@ const Toggle = styled(CardButton)(
       opacity: 1,
       padding: '0 .1875rem',
       ':hover,:focus': {
-        borderColor: lighten(ui.dueDateColor, 30)
+        backgroundColor: darken(ui.dueDateBg, 6),
+        color: darken(ui.dueDateColor, 6)
       }
     },
   ({isDueSoon}) =>
@@ -48,7 +50,8 @@ const Toggle = styled(CardButton)(
       backgroundColor: ui.dueDateSoonBg,
       color: ui.dueDateSoonColor,
       ':hover,:focus': {
-        borderColor: lighten(ui.dueDateSoonColor, 20)
+        backgroundColor: darken(ui.dueDateSoonBg, 9),
+        color: darken(ui.dueDateSoonColor, 9)
       }
     },
   ({isPastDue}) =>
@@ -56,7 +59,8 @@ const Toggle = styled(CardButton)(
       backgroundColor: ui.dueDatePastBg,
       color: ui.dueDatePastColor,
       ':hover,:focus': {
-        borderColor: lighten(ui.dueDatePastColor, 20)
+        backgroundColor: darken(ui.dueDatePastBg, 9),
+        color: darken(ui.dueDatePastColor, 9)
       }
     }
 )

--- a/src/universal/components/FloatingActionButton.js
+++ b/src/universal/components/FloatingActionButton.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import RaisedButton from 'universal/components/RaisedButton'
+
+const FloatingActionButton = (props) => (
+  <RaisedButton {...props} className={props.className} elevationHovered={12} elevationResting={6}>
+    {props.children}
+  </RaisedButton>
+)
+
+export default FloatingActionButton

--- a/src/universal/components/MeetingHelp/HelpMenuToggle.js
+++ b/src/universal/components/MeetingHelp/HelpMenuToggle.js
@@ -1,10 +1,10 @@
 import IconLabel from 'universal/components/IconLabel'
 import React from 'react'
 import styled from 'react-emotion'
-import RaisedButton from 'universal/components/RaisedButton'
+import FloatingActionButton from 'universal/components/FloatingActionButton'
 import {meetingHelpWithBottomBar} from 'universal/styles/meeting'
 
-const StyledButton = styled(RaisedButton)(({floatAboveBottomBar}) => ({
+const StyledButton = styled(FloatingActionButton)(({floatAboveBottomBar}) => ({
   bottom: floatAboveBottomBar ? meetingHelpWithBottomBar : '1.25rem',
   paddingLeft: 0,
   paddingRight: 0,
@@ -15,7 +15,7 @@ const StyledButton = styled(RaisedButton)(({floatAboveBottomBar}) => ({
 }))
 
 const HelpMenuToggle = (props) => (
-  <StyledButton palette='white' depth={2} {...props}>
+  <StyledButton palette='white' {...props}>
     <IconLabel icon='question' />
   </StyledButton>
 )

--- a/src/universal/components/NewMeetingLobby.tsx
+++ b/src/universal/components/NewMeetingLobby.tsx
@@ -187,7 +187,6 @@ class NewMeetingLobby extends React.Component<Props> {
             {(isPro || retroMeetingsRemaining > 0) && (
               <StyledButton
                 aria-label={buttonLabel}
-                depth={1}
                 disabled={!canStartMeeting}
                 onClick={onStartMeetingClick}
                 size='large'
@@ -202,7 +201,7 @@ class NewMeetingLobby extends React.Component<Props> {
                   LoadableComponent={UpgradeModalRootLoadable}
                   queryVars={{orgId}}
                   toggle={
-                    <StyledButton aria-label='Get Access Now' size='large' depth={1}>
+                    <StyledButton aria-label='Get Access Now' size='large'>
                       {'Get Access Now'}
                     </StyledButton>
                   }

--- a/src/universal/components/PrimaryButton.js
+++ b/src/universal/components/PrimaryButton.js
@@ -1,8 +1,9 @@
+import React from 'react'
 import styled from 'react-emotion'
 import ui from 'universal/styles/ui'
 import BaseButton from 'universal/components/BaseButton'
 
-const PrimaryButton = styled(BaseButton)((props) => {
+const StyledBaseButton = styled(BaseButton)((props) => {
   const {disabled, waiting} = props
   const visuallyDisabled = disabled || waiting
   return {
@@ -18,5 +19,19 @@ const PrimaryButton = styled(BaseButton)((props) => {
     }
   }
 })
+
+const PrimaryButton = (props) => {
+  const {children, className, elevationHovered, elevationResting} = props
+  return (
+    <StyledBaseButton
+      {...props}
+      className={className}
+      elevationHovered={elevationHovered || 8}
+      elevationResting={elevationResting || 2}
+    >
+      {children}
+    </StyledBaseButton>
+  )
+}
 
 export default PrimaryButton

--- a/src/universal/components/PrimaryFloatingActionButton.js
+++ b/src/universal/components/PrimaryFloatingActionButton.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import PrimaryButton from 'universal/components/PrimaryButton'
+
+const PrimaryFloatingActionButton = (props) => (
+  <PrimaryButton {...props} className={props.className} elevationHovered={12} elevationResting={6}>
+    {props.children}
+  </PrimaryButton>
+)
+
+export default PrimaryFloatingActionButton

--- a/src/universal/components/RaisedButton.js
+++ b/src/universal/components/RaisedButton.js
@@ -1,8 +1,9 @@
+import React from 'react'
 import styled from 'react-emotion'
 import ui from 'universal/styles/ui'
 import BaseButton from 'universal/components/BaseButton'
 
-const RaisedButton = styled(BaseButton)(({palette = 'gray'}) => {
+const StyledBaseButton = styled(BaseButton)(({palette = 'gray'}) => {
   const backgroundColor = ui.palette[palette]
   const color = ui.buttonLightThemes.includes(palette) ? ui.palette.dark : ui.palette.white
   return {
@@ -13,5 +14,19 @@ const RaisedButton = styled(BaseButton)(({palette = 'gray'}) => {
     outline: 0
   }
 })
+
+const RaisedButton = (props) => {
+  const {children, className, elevationHovered, elevationResting} = props
+  return (
+    <StyledBaseButton
+      {...props}
+      className={className}
+      elevationHovered={elevationHovered || 8}
+      elevationResting={elevationResting || 2}
+    >
+      {children}
+    </StyledBaseButton>
+  )
+}
 
 export default RaisedButton

--- a/src/universal/components/ResetPasswordPage/ResetPasswordForm.js
+++ b/src/universal/components/ResetPasswordPage/ResetPasswordForm.js
@@ -47,7 +47,7 @@ const PasswordResetForm = (props: Props) => {
           disabled={submitting}
         />
       </Block>
-      <PrimaryButton size='large' depth={1} disabled={!valid} waiting={submitting}>
+      <PrimaryButton size='large' disabled={!valid} waiting={submitting}>
         {'Submit'}
       </PrimaryButton>
     </Form>

--- a/src/universal/components/SignInPage/SignInEmailPasswordForm.js
+++ b/src/universal/components/SignInPage/SignInEmailPasswordForm.js
@@ -71,7 +71,7 @@ const SignInEmailPasswordForm = (props: Props) => {
           disabled={submitting}
         />
       </Block>
-      <PrimaryButton size='large' depth={1} disabled={!valid} waiting={submitting}>
+      <PrimaryButton size='large' disabled={!valid} waiting={submitting}>
         {SIGNIN_LABEL}
       </PrimaryButton>
       <ForgotPasswordLink to='/reset-password'>{'Forgot your password?'}</ForgotPasswordLink>

--- a/src/universal/components/UpgradeSuccess.js
+++ b/src/universal/components/UpgradeSuccess.js
@@ -112,7 +112,7 @@ class UpgradeSuccess extends React.Component<Props, State> {
           <b>{PRO_LABEL}</b>
           {' tier.'}
         </ModalCopy>
-        <ModalButton size='large' depth={1} onClick={handleClose}>
+        <ModalButton size='large' onClick={handleClose}>
           {'Let’s Get Back to Business'}
         </ModalButton>
         <Confetti active={active} config={confettiConfig} />

--- a/src/universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialog.js
+++ b/src/universal/modules/meeting/components/MeetingHelpDialog/MeetingHelpDialog.js
@@ -8,14 +8,14 @@ import React from 'react'
 import styled from 'react-emotion'
 import LoadableMeetingHelpDialogMenu from 'universal/modules/meeting/components/MeetingHelpDialog/LoadableMeetingHelpDialogMenu'
 import LoadableMenu from 'universal/components/LoadableMenu'
-import RaisedButton from 'universal/components/RaisedButton'
+import FloatingActionButton from 'universal/components/FloatingActionButton'
 import IconLabel from 'universal/components/IconLabel'
 
 type Props = {
   phase: string
 }
 
-const StyledButton = styled(RaisedButton)({
+const StyledButton = styled(FloatingActionButton)({
   paddingLeft: 0,
   paddingRight: 0,
   width: '2rem'
@@ -33,7 +33,7 @@ const targetAnchor = {
 
 const MeetingHelpDialog = ({phase}: Props) => {
   const iconButtonToggle = (
-    <StyledButton palette='white' depth={2}>
+    <StyledButton palette='white'>
       <IconLabel icon='question' />
     </StyledButton>
   )

--- a/src/universal/modules/meeting/components/RejoinFacilitatorButton/RejoinFacilitatorButton.js
+++ b/src/universal/modules/meeting/components/RejoinFacilitatorButton/RejoinFacilitatorButton.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import ui from 'universal/styles/ui'
-import RaisedButton from 'universal/components/RaisedButton'
+import FloatingActionButton from 'universal/components/FloatingActionButton'
 import IconLabel from 'universal/components/IconLabel'
 import styled from 'react-emotion'
 
-const RejoinButton = styled(RaisedButton)({
+const RejoinButton = styled(FloatingActionButton)({
   bottom: '1.25rem',
   position: 'fixed',
   right: '4.5rem',
@@ -15,7 +15,7 @@ const RejoinButton = styled(RaisedButton)({
 const RejoinFacilitatorButton = (props) => {
   const {onClickHandler} = props
   return (
-    <RejoinButton depth={2} onClick={onClickHandler} palette='warm'>
+    <RejoinButton onClick={onClickHandler} palette='warm'>
       <IconLabel icon='user' label='Rejoin Facilitator' />
     </RejoinButton>
   )

--- a/src/universal/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/src/universal/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -330,7 +330,7 @@ class NewTeamForm extends Component<Props, State> {
               onBlur={this.handleBlur}
             />
 
-            <StyledButton size='large' depth={1} waiting={submitting}>
+            <StyledButton size='large' waiting={submitting}>
               {isNewOrg ? 'Create Team & Org' : 'Create Team'}
             </StyledButton>
           </FormInner>

--- a/src/universal/modules/teamDashboard/components/TeamArchiveSqueeze/TeamArchiveSqueeze.js
+++ b/src/universal/modules/teamDashboard/components/TeamArchiveSqueeze/TeamArchiveSqueeze.js
@@ -102,7 +102,7 @@ class TeamArchiveSqueeze extends Component {
     }
     return (
       <ArchiveSqueezeOuter>
-        <Panel bgTheme='light' depth={0}>
+        <Panel bgTheme='light'>
           <ArchiveSqueezeInner>
             <ArchiveSqueezeContent>
               <ArchiveSqueezeHeading>
@@ -126,7 +126,7 @@ class TeamArchiveSqueeze extends Component {
             </ArchiveSqueezeContent>
             <ArchiveSqueezeButtonBlock>
               {isBillingLeader ? (
-                <PrimaryButton size='medium' depth={1} onClick={handleUpgrade}>
+                <PrimaryButton size='medium' onClick={handleUpgrade}>
                   {`Upgrade to the ${PRO_LABEL} Plan`}
                 </PrimaryButton>
               ) : (

--- a/src/universal/modules/userDashboard/components/CreditCardModal/UpgradeCreditCardForm.tsx
+++ b/src/universal/modules/userDashboard/components/CreditCardModal/UpgradeCreditCardForm.tsx
@@ -335,7 +335,7 @@ class UpgradeCreditCardForm extends React.Component<Props, State> {
             </CardDetails>
           </CardInputs>
           <ButtonGroup>
-            <UpdateButton size='medium' depth={1} onClick={this.handleSubmit} waiting={submitting}>
+            <UpdateButton size='medium' onClick={this.handleSubmit} waiting={submitting}>
               {actionLabel}
             </UpdateButton>
           </ButtonGroup>

--- a/src/universal/modules/userDashboard/components/OrgPlanSqueeze/OrgPlanSqueeze.js
+++ b/src/universal/modules/userDashboard/components/OrgPlanSqueeze/OrgPlanSqueeze.js
@@ -131,9 +131,7 @@ const OrgPlanSqueeze = (props: Props) => {
     }
   } = props
   const toggle = (
-    <StyledPrimaryButton size='medium' depth={2}>
-      {'Upgrade to the Pro Plan'}
-    </StyledPrimaryButton>
+    <StyledPrimaryButton size='medium'>{'Upgrade to the Pro Plan'}</StyledPrimaryButton>
   )
   const openUrl = (url) => () => window.open(url, '_blank')
   const hasManyBillingLeaders = billingLeaders.length !== 1

--- a/src/universal/styles/ui.js
+++ b/src/universal/styles/ui.js
@@ -252,7 +252,7 @@ const ui = {
   cardBorderColor: appTheme.palette.mid30l,
   cardBorderRadius: borderRadiusMedium,
   cardButtonHeight: '1.5rem',
-  cardButtonBorderColor: appTheme.palette.mid50l,
+  cardButtonBorderColor: appTheme.palette.mid30l,
   cardContentFontSize: '.875rem',
   cardContentLineHeight: '1.25rem',
   cardPaddingBase: '.9375rem',

--- a/src/universal/types/graphql.d.ts
+++ b/src/universal/types/graphql.d.ts
@@ -22,93 +22,7 @@ declare namespace GQL {
 
   interface IQuery {
     __typename: 'Query'
-    suCountTiersForUser: IUserTiersCount | null
-    suUserCount: number | null
-    suProOrgInfo: Array<ISuProOrgInfo> | null
-    suOrgCount: number | null
     viewer: IUser | null
-  }
-
-  interface ISuCountTiersForUserOnQueryArguments {
-    /**
-     * the user for which you want the count of tier membership
-     */
-    userId: string
-  }
-
-  interface ISuUserCountOnQueryArguments {
-    /**
-     * filter out users who's email matches this regular expression
-     * @default ""
-     */
-    ignoreEmailRegex?: string | null
-
-    /**
-     * should organizations without active users be included?
-     * @default false
-     */
-    includeInactive?: boolean | null
-
-    /**
-     * @default "pro"
-     */
-    tier?: OrgTierEnum | null
-  }
-
-  interface ISuProOrgInfoOnQueryArguments {
-    /**
-     * should organizations without active users be included?
-     * @default false
-     */
-    includeInactive?: boolean | null
-  }
-
-  interface ISuOrgCountOnQueryArguments {
-    /**
-     * filter out users who's email matches this regular expression
-     * @default ""
-     */
-    ignoreEmailRegex?: string | null
-
-    /**
-     * should organizations without active users be included?
-     * @default false
-     */
-    includeInactive?: boolean | null
-
-    /**
-     * the minimum number of users within the org to count it
-     * @default 2
-     */
-    minOrgSize?: number | null
-
-    /**
-     * @default "pro"
-     */
-    tier?: OrgTierEnum | null
-  }
-
-  /**
-   * A count of the number of account tiers a user belongs to.
-   */
-  interface IUserTiersCount {
-    __typename: 'UserTiersCount'
-
-    /**
-     * The number of personal orgs the user is active upon
-     */
-    tierPersonalCount: number | null
-
-    /**
-     * The number of pro orgs the user is active upon
-     */
-    tierProCount: number | null
-
-    /**
-     * The number of pro orgs the user holds the role of Billing Leader
-     */
-    tierProBillingLeaderCount: number | null
-    user: IUser | null
   }
 
   /**
@@ -2587,29 +2501,6 @@ declare namespace GQL {
      * *The team that cares about these annoucements
      */
     teamId: string
-  }
-
-  /**
-   * The tier of the Organization
-   */
-  const enum OrgTierEnum {
-    personal = 'personal',
-    pro = 'pro',
-    enterprise = 'enterprise'
-  }
-
-  interface ISuProOrgInfo {
-    __typename: 'SuProOrgInfo'
-
-    /**
-     * The PRO organization
-     */
-    organization: IOrganization | null
-
-    /**
-     * The id of the Organization
-     */
-    organizationId: string
   }
 
   interface IMutation {


### PR DESCRIPTION
- Fixes #2332 (Button API updated to handle elevation)
- Fixes #2258 (Card buttons updated to be flat)

#### Notes
- Buttons are flat unless an explicit `elevationHovered` and elevationResting` are passed as props
- The value for `elevationHovered` is using the default Material for pressed
- The pressed value is half of the distance between `evelationHovered` and `elevationResting` so that when pressing the button looks like it drops a little on the z axis
- Raised and primary buttons were updated to a consistent elevation
- Floating action buttons and primary floating action buttons were added
- Cards are using flat buttons