### PR TITLE
fix the last page of invoices listed under org

### DIFF
--- a/src/server/graphql/queries/invoices.js
+++ b/src/server/graphql/queries/invoices.js
@@ -43,23 +43,26 @@ export default {
         .table('Invoice')
         .between([orgId, r.minval], [orgId, dbAfter], {
           index: 'orgIdStartAt',
-          leftBound: 'open'
+          leftBound: 'open',
+          rightBound: 'closed'
         })
         .filter((invoice) =>
           invoice('status')
             .ne(UPCOMING)
             .and(invoice('total').ne(0))
         )
-        .orderBy(r.desc('startAt'))
+        // it's possible that stripe gives the same startAt to 2 invoices (the first $5 charge & the next)
+        // break ties based on when created. In the future, we might want to consider using the created_at provided by stripe instead of our own
+        .orderBy(r.desc('startAt'), r.desc('createdAt'))
         .limit(first + 1),
       upcomingInvoice: after
         ? Promise.resolve(undefined)
         : makeUpcomingInvoice(orgId, stripeId, stripeSubscriptionId)
     })
-
+    const paginatedInvoices = after ? tooManyInvoices.slice(1) : tooManyInvoices
     const allInvoices = upcomingInvoice
-      ? [upcomingInvoice].concat(tooManyInvoices)
-      : tooManyInvoices
+      ? [upcomingInvoice].concat(paginatedInvoices)
+      : paginatedInvoices
     const nodes = allInvoices.slice(0, first)
     const edges = nodes.map((node) => ({
       cursor: node.startAt,
@@ -71,7 +74,7 @@ export default {
       pageInfo: {
         startCursor: firstEdge && firstEdge.cursor,
         endCursor: firstEdge && edges[edges.length - 1].cursor,
-        hasNextPage: allInvoices.length > nodes.length
+        hasNextPage: tooManyInvoices.length + (upcomingInvoice ? 1 : 0) > first
       }
     }
   }


### PR DESCRIPTION
there were a couple problems with the paginated list of invoices.
first, stripe can sometimes create 2 invoices (first month + following month) at the exact same timestamp, so we needed another sort to ensure that the sort order is deterministic.
second, we weren't accounting for the upcoming invoice for `hasNextPage`.

TEST
- [ ] an org with <= 3 invoices (including the upcoming) does not show the "load more" button
- [ ] an org with > 3 invoices has a load more button & when clicked, more load below
