### PR TITLE
Fix 1956

### DIFF
--- a/src/server/graphql/mutations/helpers/removeTeamMember.js
+++ b/src/server/graphql/mutations/helpers/removeTeamMember.js
@@ -11,14 +11,12 @@ const removeTeamMember = async (teamMemberId, options, dataLoader) => {
   const r = getRethink()
   const now = new Date()
   const {userId, teamId} = fromTeamMemberId(teamMemberId)
-  console.log('member', teamMemberId)
   // see if they were a leader, make a new guy leader so later we can reassign tasks
   const activeTeamMembers = await r.table('TeamMember').getAll(teamId, {index: 'teamId'})
   const teamMember = activeTeamMembers.find((t) => t.id === teamMemberId)
   const {isLead, isNotRemoved} = teamMember
   // if the guy being removed is the leader & not the last, pick a new one. else, use him
   const teamLeader = activeTeamMembers.find((t) => t.isLead === !isLead) || teamMember
-  console.log('teamLeader', teamLeader)
   if (!isNotRemoved) {
     throw new Error('Team member already removed')
   }

--- a/src/server/graphql/mutations/helpers/removeTeamMember.js
+++ b/src/server/graphql/mutations/helpers/removeTeamMember.js
@@ -11,13 +11,14 @@ const removeTeamMember = async (teamMemberId, options, dataLoader) => {
   const r = getRethink()
   const now = new Date()
   const {userId, teamId} = fromTeamMemberId(teamMemberId)
-
+  console.log('member', teamMemberId)
   // see if they were a leader, make a new guy leader so later we can reassign tasks
   const activeTeamMembers = await r.table('TeamMember').getAll(teamId, {index: 'teamId'})
   const teamMember = activeTeamMembers.find((t) => t.id === teamMemberId)
   const {isLead, isNotRemoved} = teamMember
-  // if the guy being removed is the leader, pick a new one. else, use him
-  const teamLeader = activeTeamMembers.find((t) => t.isLead === !isLead)
+  // if the guy being removed is the leader & not the last, pick a new one. else, use him
+  const teamLeader = activeTeamMembers.find((t) => t.isLead === !isLead) || teamMember
+  console.log('teamLeader', teamLeader)
   if (!isNotRemoved) {
     throw new Error('Team member already removed')
   }


### PR DESCRIPTION
fix #1956 (can remove user who is the leader of their own team)

such a small, targeted change, merging to prod (but treating this as a PR to keep a record)