### PR TITLE
create downgrade mutation

### DIFF
--- a/src/server/graphql/mutations/downgradeToPersonal.ts
+++ b/src/server/graphql/mutations/downgradeToPersonal.ts
@@ -36,7 +36,12 @@ export default {
 
     // RESOLUTION
     // if they downgrade & are re-upgrading, they'll already have a stripeId
-    const subscription = await stripe.subscriptions.del(stripeSubscriptionId)
+    try {
+      await stripe.subscriptions.del(stripeSubscriptionId)
+    } catch (e) {
+      console.log(e)
+    }
+
     const {teamIds} = await r({
       org: r
         .table('Organization')
@@ -44,7 +49,7 @@ export default {
         .update({
           creditCard: {},
           tier: PERSONAL,
-          periodEnd: subscription.current_period_end,
+          periodEnd: now,
           stripeSubscriptionId: null,
           updatedAt: now
         }),

--- a/src/server/graphql/mutations/downgradeToPersonal.ts
+++ b/src/server/graphql/mutations/downgradeToPersonal.ts
@@ -1,0 +1,78 @@
+import {GraphQLID, GraphQLNonNull} from 'graphql'
+import stripe from 'server/billing/stripe'
+import getRethink from 'server/database/rethinkDriver'
+import DowngradeToPersonalPayload from 'server/graphql/types/DowngradeToPersonalPayload'
+import {sendAlreadyPersonalTierError} from 'server/utils/alreadyMutatedErrors'
+import {getUserId, getUserOrgDoc, isOrgBillingLeader} from 'server/utils/authorization'
+import {sendOrgLeadAccessError} from 'server/utils/authorizationErrors'
+import publish from 'server/utils/publish'
+import sendSegmentEvent, {sendSegmentIdentify} from 'server/utils/sendSegmentEvent'
+import {ORGANIZATION, PERSONAL, TEAM} from 'universal/utils/constants'
+
+export default {
+  type: DowngradeToPersonalPayload,
+  description: 'Downgrade a paid account to the personal service',
+  args: {
+    orgId: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'the org requesting the upgrade'
+    }
+  },
+  async resolve (_source, {orgId}, {authToken, dataLoader, socketId: mutatorId}) {
+    const r = getRethink()
+    const now = new Date()
+    const operationId = dataLoader.share()
+    const subOptions = {mutatorId, operationId}
+
+    // AUTH
+    const userId = getUserId(authToken)
+    const userOrgDoc = await getUserOrgDoc(userId, orgId)
+    if (!isOrgBillingLeader(userOrgDoc)) return sendOrgLeadAccessError(authToken, userOrgDoc)
+
+    // VALIDATION
+    const {stripeSubscriptionId, tier} = await r.table('Organization').get(orgId)
+
+    if (tier === PERSONAL) return sendAlreadyPersonalTierError(authToken, orgId)
+
+    // RESOLUTION
+    // if they downgrade & are re-upgrading, they'll already have a stripeId
+    const subscription = await stripe.subscriptions.del(stripeSubscriptionId)
+    const {teamIds} = await r({
+      org: r
+        .table('Organization')
+        .get(orgId)
+        .update({
+          creditCard: {},
+          tier: PERSONAL,
+          periodEnd: subscription.current_period_end,
+          stripeSubscriptionId: null,
+          updatedAt: now
+        }),
+      teamIds: r
+        .table('Team')
+        .getAll(orgId, {index: 'orgId'})
+        .update(
+          {
+            tier: PERSONAL,
+            isPaid: true,
+            updatedAt: now
+          },
+          {returnChanges: true}
+        )('changes')('new_val')('id')
+        .default([])
+    })
+    sendSegmentEvent('Downgrade to personal', userId, {orgId})
+    const data = {orgId, teamIds}
+    publish(ORGANIZATION, orgId, DowngradeToPersonalPayload, data, subOptions)
+
+    teamIds.forEach((teamId) => {
+      // I can't readily think of a clever way to use the data obj and filter in the resolver so I'll reduce here.
+      // This is probably a smelly piece of code telling me I should be sending this per-userId or per-org
+      const teamData = {orgId, teamIds: [teamId]}
+      publish(TEAM, teamId, DowngradeToPersonalPayload, teamData, subOptions)
+    })
+    // the count of this users tier stats just changed, update:
+    await sendSegmentIdentify(userId)
+    return data
+  }
+}

--- a/src/server/graphql/rootMutation.js
+++ b/src/server/graphql/rootMutation.js
@@ -16,6 +16,7 @@ import createGitHubIssue from 'server/graphql/mutations/createGitHubIssue'
 import createTask from 'server/graphql/mutations/createTask'
 import deleteTask from 'server/graphql/mutations/deleteTask'
 import disconnectSocket from 'server/graphql/mutations/disconnectSocket'
+import downgradeToPersonal from 'server/graphql/mutations/downgradeToPersonal'
 import editTask from 'server/graphql/mutations/editTask'
 import endMeeting from 'server/graphql/mutations/endMeeting'
 import githubAddAssignee from 'server/graphql/mutations/githubAddAssignee'
@@ -122,6 +123,7 @@ export default new GraphQLObjectType({
     createUserPicturePutUrl,
     deleteTask,
     disconnectSocket,
+    downgradeToPersonal,
     dragDiscussionTopic,
     endDraggingReflection,
     editReflection,

--- a/src/server/graphql/types/DowngradeToPersonalPayload.ts
+++ b/src/server/graphql/types/DowngradeToPersonalPayload.ts
@@ -1,0 +1,26 @@
+import {GraphQLObjectType, GraphQLList} from 'graphql'
+import {resolveOrganization, resolveTeams} from 'server/graphql/resolvers'
+import Organization from 'server/graphql/types/Organization'
+import Team from 'server/graphql/types/Team'
+import StandardMutationError from 'server/graphql/types/StandardMutationError'
+
+const DowngradeToPersonalPayload = new GraphQLObjectType({
+  name: 'DowngradeToPersonalPayload',
+  fields: () => ({
+    error: {
+      type: StandardMutationError
+    },
+    organization: {
+      type: Organization,
+      description: 'The new Personal Org',
+      resolve: resolveOrganization
+    },
+    teams: {
+      type: new GraphQLList(Team),
+      description: 'The updated teams under the org',
+      resolve: resolveTeams
+    }
+  })
+})
+
+export default DowngradeToPersonalPayload

--- a/src/server/graphql/types/OrganizationSubscriptionPayload.js
+++ b/src/server/graphql/types/OrganizationSubscriptionPayload.js
@@ -7,10 +7,12 @@ import UpdateOrgPayload from 'server/graphql/types/UpdateOrgPayload'
 import UpgradeToProPayload from 'server/graphql/types/UpgradeToProPayload'
 import RemoveOrgUserPayload from 'server/graphql/types/RemoveOrgUserPayload'
 import UpdateCreditCardPayload from 'server/graphql/types/UpdateCreditCardPayload'
+import DowngradeToPersonalPayload from 'server/graphql/types/DowngradeToPersonalPayload'
 
 const types = [
   AddOrgPayload,
   ApproveToOrgPayload,
+  DowngradeToPersonalPayload,
   RemoveOrgUserPayload,
   SetOrgUserRoleAddedPayload,
   SetOrgUserRoleRemovedPayload,

--- a/src/server/graphql/types/TeamSubscriptionPayload.js
+++ b/src/server/graphql/types/TeamSubscriptionPayload.js
@@ -41,6 +41,7 @@ import RemoveReflectTemplatePayload from 'server/graphql/types/RemoveReflectTemp
 import RemoveReflectTemplatePromptPayload from 'server/graphql/types/RemoveReflectTemplatePromptPayload'
 import RenameReflectTemplatePayload from 'server/graphql/types/RenameReflectTemplatePayload'
 import RenameReflectTemplatePromptPayload from 'server/graphql/types/RenameReflectTemplatePromptPayload'
+import DowngradeToPersonalPayload from 'server/graphql/types/DowngradeToPersonalPayload'
 
 const types = [
   AcceptTeamInvitePayload,
@@ -49,6 +50,7 @@ const types = [
   AutoGroupReflectionsPayload,
   CreateReflectionPayload,
   CreateReflectionGroupPayload,
+  DowngradeToPersonalPayload,
   DragDiscussionTopicPayload,
   EndDraggingReflectionPayload,
   EditReflectionPayload,

--- a/src/server/utils/alreadyMutatedErrors.js
+++ b/src/server/utils/alreadyMutatedErrors.js
@@ -100,6 +100,15 @@ export const sendAlreadyProTierError = (authToken, orgId) => {
   return sendAuthRaven(authToken, 'Easy there', breadcrumb)
 }
 
+export const sendAlreadyPersonalTierError = (authToken, orgId) => {
+  const breadcrumb = {
+    message: 'You are already on the personal tier!',
+    category: 'Already personal tier',
+    data: {orgId}
+  }
+  return sendAuthRaven(authToken, 'Easy there', breadcrumb)
+}
+
 export const sendAlreadyRemovedVoteError = (authToken, reflectionGroupId) => {
   const breadcrumb = {
     message: 'You’ve already removed that vote',

--- a/src/universal/types/graphql.d.ts
+++ b/src/universal/types/graphql.d.ts
@@ -2619,6 +2619,11 @@ export interface IMutation {
   disconnectSocket: IDisconnectSocketPayload | null
 
   /**
+   * Downgrade a paid account to the personal service
+   */
+  downgradeToPersonal: IDowngradeToPersonalPayload | null
+
+  /**
    * Changes the priority of the discussion topics
    */
   dragDiscussionTopic: IDragDiscussionTopicPayload | null
@@ -3155,6 +3160,13 @@ export interface IDeleteTaskOnMutationArguments {
    * The taskId to delete
    */
   taskId: string
+}
+
+export interface IDowngradeToPersonalOnMutationArguments {
+  /**
+   * the org requesting the upgrade
+   */
+  orgId: string
 }
 
 export interface IDragDiscussionTopicOnMutationArguments {
@@ -4947,6 +4959,21 @@ export interface IDisconnectSocketPayload {
   user: IUser | null
 }
 
+export interface IDowngradeToPersonalPayload {
+  __typename: 'DowngradeToPersonalPayload'
+  error: IStandardMutationError | null
+
+  /**
+   * The new Personal Org
+   */
+  organization: IOrganization | null
+
+  /**
+   * The updated teams under the org
+   */
+  teams: Array<ITeam | null> | null
+}
+
 export interface IDragDiscussionTopicPayload {
   __typename: 'DragDiscussionTopicPayload'
   error: IStandardMutationError | null
@@ -6315,6 +6342,7 @@ export type OrgApprovalSubscriptionPayload =
 export type OrganizationSubscriptionPayload =
   | IAddOrgPayload
   | IApproveToOrgPayload
+  | IDowngradeToPersonalPayload
   | IRemoveOrgUserPayload
   | ISetOrgUserRoleAddedPayload
   | ISetOrgUserRoleRemovedPayload
@@ -6382,6 +6410,7 @@ export type TeamSubscriptionPayload =
   | IAutoGroupReflectionsPayload
   | ICreateReflectionPayload
   | ICreateReflectionGroupPayload
+  | IDowngradeToPersonalPayload
   | IDragDiscussionTopicPayload
   | IEndDraggingReflectionPayload
   | IEditReflectionPayload


### PR DESCRIPTION
fixes #2123
you can now run a downgrade mutation from the admin panel.
out of scope, but still necessary:
- allowing users to downgrade themselves
- showing ex-pro users their past invoices

TEST
- [ ] upgrade an org to pro using a fake CC
- [ ] go to /admin/graphql and run `mutation { downgradeToPersonal { error { title } } }`
- [ ] go to stripe, turn on mock data & search for the orgId. see that the subscription was cancelled

