### PR TITLE
fix #2497 add expandable ellipsis to draft-js entities

### DIFF
--- a/src/universal/components/ReflectionEditorWrapperForEmail.js
+++ b/src/universal/components/ReflectionEditorWrapperForEmail.js
@@ -1,4 +1,4 @@
-import {Editor, EditorState} from 'draft-js'
+import {convertFromRaw, Editor, EditorState} from 'draft-js'
 import React, {Component} from 'react'
 import editorDecorators from 'universal/components/TaskEditor/decorators'
 import truncateCard from 'universal/utils/draftjs/truncateCard'
@@ -8,15 +8,25 @@ type Props = {
 }
 
 class ReflectionEditorWrapperForEmail extends Component<Props> {
+  setEditorState = (content) => {
+    const contentState = convertFromRaw(JSON.parse(content))
+    this.setState({
+      editorState: EditorState.createWithContent(
+        contentState,
+        editorDecorators(this.getEditorState, this.setEditorState)
+      )
+    })
+  }
+
+  getEditorState = () => {
+    return this.state.editorState
+  }
+
   state = {
     editorState: EditorState.createWithContent(
       truncateCard(this.props.content, 6, 64),
-      editorDecorators(this.getEditorState)
+      editorDecorators(this.getEditorState, this.setEditorState)
     )
-  }
-
-  getEditorState () {
-    return this.state.editorState
   }
 
   render () {

--- a/src/universal/components/TaskEditor/TruncatedEllipsis.tsx
+++ b/src/universal/components/TaskEditor/TruncatedEllipsis.tsx
@@ -1,0 +1,29 @@
+import {ContentState} from 'draft-js'
+import React, {Component, ReactNode} from 'react'
+
+interface Props {
+  contentState: ContentState
+  offsetkey: string
+  entityKey: string
+  children: ReactNode
+}
+
+const TruncatedEllipsis = (setEditorState) =>
+  class TruncatedEllipsisClass extends Component<Props> {
+    onClick = () => {
+      const {contentState, entityKey} = this.props
+      const {value} = contentState.getEntity(entityKey).getData()
+      setEditorState(value)
+    }
+
+    render () {
+      const {offsetkey, children} = this.props
+      return (
+        <span data-offset-key={offsetkey} style={{cursor: 'pointer'}} onClick={this.onClick}>
+          {children}
+        </span>
+      )
+    }
+  }
+
+export default TruncatedEllipsis

--- a/src/universal/components/TaskEditor/decorators.js
+++ b/src/universal/components/TaskEditor/decorators.js
@@ -2,6 +2,7 @@ import EditorLink from './EditorLink'
 import {CompositeDecorator} from 'draft-js'
 import Hashtag from 'universal/components/TaskEditor/Hashtag'
 import Mention from 'universal/components/TaskEditor/Mention'
+import TruncatedEllipsis from 'universal/components/TaskEditor/TruncatedEllipsis'
 
 const findEntity = (entityType) => (contentBlock, callback, contentState) => {
   contentBlock.findEntityRanges((character) => {
@@ -10,7 +11,7 @@ const findEntity = (entityType) => (contentBlock, callback, contentState) => {
   }, callback)
 }
 
-const decorators = (getEditorState) =>
+const decorators = (getEditorState, setEditorState) =>
   new CompositeDecorator([
     {
       strategy: findEntity('LINK'),
@@ -23,6 +24,10 @@ const decorators = (getEditorState) =>
     {
       strategy: findEntity('MENTION'),
       component: Mention
+    },
+    {
+      strategy: findEntity('TRUNCATED_ELLIPSIS'),
+      component: TruncatedEllipsis(setEditorState)
     }
   ])
 

--- a/src/universal/modules/email/components/Card/Card.js
+++ b/src/universal/modules/email/components/Card/Card.js
@@ -1,4 +1,4 @@
-import {Editor, EditorState} from 'draft-js'
+import {convertFromRaw, Editor, EditorState} from 'draft-js'
 import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 import editorDecorators from 'universal/components/TaskEditor/decorators'
@@ -16,11 +16,19 @@ class Card extends Component {
     const contentState = truncateCard(content)
     this.editorState = EditorState.createWithContent(
       contentState,
-      editorDecorators(this.getEditorState)
+      editorDecorators(this.getEditorState, this.setEditorState)
     )
   }
 
   getEditorState = () => this.editorState
+  setEditorState = (content) => {
+    const contentState = convertFromRaw(JSON.parse(content))
+    this.editorState = EditorState.createWithContent(
+      contentState,
+      editorDecorators(this.getEditorState, this.setEditorState)
+    )
+    this.forceUpdate()
+  }
 
   render () {
     const {status, tags} = this.props

--- a/src/universal/utils/draftjs/truncateCard.js
+++ b/src/universal/utils/draftjs/truncateCard.js
@@ -42,7 +42,11 @@ const truncateCard = (content, maxBlocks = MAX_BLOCKS, maxChars = MAX_CHARS) => 
         isBackward: false,
         hasFocus: false
       })
-      return Modifier.replaceText(contentState, selection, ELLIPSIS)
+      const contentStateWithEntity = contentState.createEntity('TRUNCATED_ELLIPSIS', 'IMMUTABLE', {
+        value: content
+      })
+      const entityKey = contentStateWithEntity.getLastCreatedEntityKey()
+      return Modifier.replaceText(contentState, selection, ELLIPSIS, null, entityKey)
     }
     block = contentState.getBlockAfter(key)
     if (!block) break


### PR DESCRIPTION
TEST
- start a retro, write a long reflection, go to discuss phase, write a long task
- [ ] in the summary, the ellipses on the reflection & task show a pointer cursor. if you click them, the card expands 

fixes #2497