### PR TITLE
clean up completed phases

### DIFF
--- a/src/universal/Atmosphere.js
+++ b/src/universal/Atmosphere.js
@@ -8,6 +8,7 @@ import EventEmitter from 'eventemitter3'
 import handlerProvider from 'universal/utils/relay/handlerProvider'
 import getTrebuchet, {SocketTrebuchet, SSETrebuchet} from '@mattkrick/trebuchet-client'
 import GQLTrebuchetClient, {GQLHTTPClient} from '@mattkrick/graphql-trebuchet-client'
+// import sleep from 'universal/utils/sleep'
 
 const defaultErrorHandler = (err) => {
   console.error('Captured error:', err)

--- a/src/universal/components/ReflectionGroup/ReflectionGroup.tsx
+++ b/src/universal/components/ReflectionGroup/ReflectionGroup.tsx
@@ -59,10 +59,11 @@ interface Props extends WithAtmosphereProps, WithMutationProps, PassedProps, Col
 const reflectionsStyle = (
   canDrop: boolean | undefined,
   isDraggable: boolean | undefined,
-  canExpand: boolean | undefined
+  canExpand: boolean | undefined,
+  isComplete: boolean | null
 ) =>
   css({
-    cursor: isDraggable || canExpand ? 'pointer' : 'default',
+    cursor: !isComplete && (isDraggable || canExpand) ? 'pointer' : 'default',
     opacity: canDrop ? 0.6 : 1,
     position: 'relative'
   })
@@ -250,13 +251,16 @@ class ReflectionGroup extends Component<Props> {
   ) => {
     const {setItemRef, meeting, reflectionGroup} = this.props
     const {reflections} = reflectionGroup
+    const {
+      localStage: {isComplete}
+    } = meeting
     return (
       <DraggableReflectionCard
         // @ts-ignore
         closeGroupModal={isModal ? this.closeGroupModal : undefined}
         key={reflection.id}
         idx={reflections.length - idx - 1}
-        isDraggable={isDraggable}
+        isDraggable={isDraggable && !isComplete}
         isModal={isModal}
         meeting={meeting}
         reflection={reflection}
@@ -323,7 +327,7 @@ class ReflectionGroup extends Component<Props> {
           )}
           {connectDropTarget(
             <div
-              className={reflectionsStyle(canDrop, isDraggable, canExpand)}
+              className={reflectionsStyle(canDrop, isDraggable, canExpand, isComplete)}
               onClick={canExpand ? this.expandGroup : undefined}
             >
               {reflections.map((reflection, idx) =>
@@ -341,7 +345,7 @@ class ReflectionGroup extends Component<Props> {
               meeting={meeting}
               reflectionGroup={reflectionGroup}
             />
-            <div className={reflectionsStyle(canDrop, isDraggable, canExpand)}>
+            <div className={reflectionsStyle(canDrop, isDraggable, canExpand, isComplete)}>
               {reflections.map((reflection, idx) =>
                 this.renderReflection(reflection, idx, {isModal: true, isDraggable})
               )}

--- a/src/universal/components/RetroReflectPhase/PhaseItemColumn.tsx
+++ b/src/universal/components/RetroReflectPhase/PhaseItemColumn.tsx
@@ -166,31 +166,30 @@ class PhaseItemColumn extends Component<Props> {
     const columnStack = this.makeColumnStack(reflectionGroups, retroPhaseItemId)
     const reflectionStack = this.makeViewerStack(columnStack)
     const isViewerFacilitator = viewerId === facilitatorUserId
-    const tip = <div>Tap to highlight prompt for everybody</div>
-    const prompt = (
-      <React.Fragment>
-        <Tooltip
-          delay={200}
-          maxHeight={40}
-          maxWidth={500}
-          originAnchor={originAnchor}
-          targetAnchor={targetAnchor}
-          tip={tip}
-          isDisabled={this.hasFocused || isFocused || !isViewerFacilitator}
-        >
-          <span>{question}</span>
-        </Tooltip>
-      </React.Fragment>
-    )
     return (
       <ColumnWrapper>
         <ColumnHighlight isFocused={isFocused}>
           <ColumnContent>
             <HeaderAndEditor>
-              <TypeHeader isClickable={isViewerFacilitator} onClick={this.setColumnFocus}>
+              <TypeHeader
+                isClickable={isViewerFacilitator && !isComplete}
+                onClick={this.setColumnFocus}
+              >
                 <TypeDescription>
                   <FocusArrow isFocused={isFocused}>forward</FocusArrow>
-                  {prompt}
+                  <Tooltip
+                    delay={200}
+                    maxHeight={40}
+                    maxWidth={500}
+                    originAnchor={originAnchor}
+                    targetAnchor={targetAnchor}
+                    tip={<div>Tap to highlight prompt for everybody</div>}
+                    isDisabled={
+                      this.hasFocused || isFocused || !isViewerFacilitator || !!isComplete
+                    }
+                  >
+                    <span>{question}</span>
+                  </Tooltip>
                 </TypeDescription>
               </TypeHeader>
               <EditorAndStatus isPhaseComplete={!!isComplete}>

--- a/src/universal/components/RetroReflectPhase/ReflectionStack.tsx
+++ b/src/universal/components/RetroReflectPhase/ReflectionStack.tsx
@@ -17,6 +17,7 @@ import {
 } from 'universal/styles/cards'
 import {cardShadow} from 'universal/styles/elevation'
 import getDeCasteljau from 'universal/utils/getDeCasteljau'
+import isTempId from 'universal/utils/relay/isTempId'
 
 interface Props {
   idx: number
@@ -144,7 +145,9 @@ class ReflectionStack extends Component<Props, State> {
       return null
     }
     const duration = ANIMATION_DURATION - (Date.now() - this.animationStart)
-    if (duration <= 0) return {duration: ANIMATION_DURATION, easing: EASING}
+    if (duration <= 0) {
+      return isTempId(newTop.id) ? {duration: ANIMATION_DURATION, easing: EASING} : null
+    }
     // an animation is already in progress!
     return {
       startCoords: start.getBoundingClientRect(),

--- a/src/universal/mutations/VoteForReflectionGroupMutation.js
+++ b/src/universal/mutations/VoteForReflectionGroupMutation.js
@@ -3,6 +3,10 @@ import toTeamMemberId from 'universal/utils/relay/toTeamMemberId'
 
 graphql`
   fragment VoteForReflectionGroupMutation_team on VoteForReflectionGroupPayload {
+    error {
+      message
+      title
+    }
     meeting {
       votesRemaining
     }


### PR DESCRIPTION
TEST
- [ ] when on a slow connection, during reflection no double animation when the reflection is submitted (trust me on this one, or put a sleep in the Atmosphere.js, it's commented out)
- [ ] in the reflect phase after it's complete, the header does not look clickable
- [ ] when on the discuss phase, going back & trying to vote/unvote pops a toast
