### PR TITLE
refund new users [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
+    "@clusterws/cws": "^0.10.0",
     "@google-cloud/language": "^1.2.0",
     "@mattkrick/fast-rtc-peer": "^0.0.5",
     "@mattkrick/graphql-trebuchet-client": "^0.1.1",
@@ -244,7 +245,6 @@
     "tlds": "^1.192.0",
     "ts-node": "^7.0.1",
     "unicode-substring": "^1.0.0",
-    "uws": "10.148.1",
     "wrtc": "^0.1.6"
   },
   "engines": {

--- a/src/server/billing/helpers/adjustUserCount.js
+++ b/src/server/billing/helpers/adjustUserCount.js
@@ -73,7 +73,7 @@ const typeLookup = {
   [UNPAUSE_USER]: changePause(false)
 }
 
-export default async function adjustUserCount (userId, orgInput, type) {
+export default async function adjustUserCount (userId, orgInput, type, options = {}) {
   const r = getRethink()
   const now = new Date()
 
@@ -93,7 +93,7 @@ export default async function adjustUserCount (userId, orgInput, type) {
         })
         .count()
     }))
-  const prorationDate = toEpochSeconds(now)
+  const prorationDate = toEpochSeconds(type === REMOVE_USER ? options.prorationDate : now)
   const hooks = orgs.reduce((arr, org) => {
     const {stripeSubscriptionId} = org
     if (stripeSubscriptionId) {

--- a/src/server/graphql/mutations/removeOrgUser.js
+++ b/src/server/graphql/mutations/removeOrgUser.js
@@ -73,13 +73,13 @@ const removeOrgUser = {
       return arr
     }, [])
 
-    const {allRemovedOrgNotifications, user, organizationUserId} = await r({
-      organizationUserId: r
+    const {allRemovedOrgNotifications, user, organizationUser} = await r({
+      organizationUser: r
         .table('OrganizationUser')
         .getAll(userId, {index: 'userId'})
         .filter({orgId, removedAt: null})
         .nth(0)
-        .update({removedAt: now}, {returnChanges: true})('changes')(0)('new_val')('id')
+        .update({removedAt: now}, {returnChanges: true})('changes')(0)('new_val')
         .default(null),
       user: r.table('User').get(userId),
       // remove stale notifications
@@ -125,7 +125,9 @@ const removeOrgUser = {
     })
 
     // need to make sure the org doc is updated before adjusting this
-    await adjustUserCount(userId, orgId, REMOVE_USER)
+    const {newUserUntil} = organizationUser
+    const prorationDate = newUserUntil >= now ? newUserUntil : now
+    await adjustUserCount(userId, orgId, REMOVE_USER, {prorationDate})
 
     const {tms} = user
     publish(NEW_AUTH_TOKEN, userId, UPDATED, {tms})
@@ -140,7 +142,7 @@ const removeOrgUser = {
       removedTeamNotifications,
       removedOrgNotifications: allRemovedOrgNotifications.notifications,
       userId,
-      organizationUserId
+      organizationUserId: organizationUser.id
     }
 
     publish(ORGANIZATION, orgId, RemoveOrgUserPayload, data, subOptions)

--- a/src/server/graphql/queries/invoiceDetails.js
+++ b/src/server/graphql/queries/invoiceDetails.js
@@ -20,13 +20,12 @@ export default {
 
     // AUTH
     const viewerId = getUserId(authToken)
-    const [type, maybeOrgId] = invoiceId.split('_')
-    const isUpcoming = type === 'upcoming'
+    const isUpcoming = invoiceId.startsWith('upcoming_')
     const currentInvoice = await r
       .table('Invoice')
       .get(invoiceId)
       .default(null)
-    const orgId = (currentInvoice && currentInvoice.orgId) || maybeOrgId
+    const orgId = (currentInvoice && currentInvoice.orgId) || invoiceId.substring(9) // remove 'upcoming_'
     if (!(await isUserBillingLeader(viewerId, orgId, dataLoader))) {
       return sendOrgLeadAccessError(authToken, orgId, null)
     }

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -17,7 +17,7 @@ import sendICS from './sendICS'
 import './polyfills'
 import handleGitHubWebhooks from 'server/integrations/handleGitHubWebhooks'
 import SharedDataLoader from 'shared-dataloader'
-import {Server} from 'uws'
+import {WebSocketServer} from '@clusterws/cws'
 import http from 'http'
 // import startMemwatch from 'server/utils/startMemwatch'
 import packageJSON from '../../package.json'
@@ -40,7 +40,7 @@ const {PORT = 3000} = process.env
 
 const app = express()
 const server = http.createServer(app)
-const wss = new Server({server})
+const wss = new WebSocketServer({server})
 server.listen(PORT)
 // This houses a per-mutation dataloader. When GraphQL is its own microservice, we can move this there.
 const sharedDataLoader = new SharedDataLoader({

--- a/src/server/socketHandlers/wssConnectionHandler.js
+++ b/src/server/socketHandlers/wssConnectionHandler.js
@@ -12,8 +12,7 @@ import {TREBUCHET_WS} from '@mattkrick/trebuchet-client'
 
 const APP_VERSION = packageJSON.version
 export default function connectionHandler (sharedDataLoader, rateLimiter) {
-  return async function socketConnectionHandler (socket) {
-    const req = socket.upgradeReq
+  return async function socketConnectionHandler (socket, req) {
     const {headers} = req
     const protocol = headers['sec-websocket-protocol']
     if (protocol !== TREBUCHET_WS) {

--- a/src/universal/components/BillingLeaderActionMenu.tsx
+++ b/src/universal/components/BillingLeaderActionMenu.tsx
@@ -34,7 +34,7 @@ const BillingLeaderActionMenu = (props: Props) => {
   } = props
   const {orgId} = organization
   const {viewerId} = atmosphere
-  const {role, user} = organizationUser
+  const {newUserUntil, role, user} = organizationUser
   const isBillingLeader = role === BILLING_LEADER
   const {userId, preferredName} = user
 
@@ -70,7 +70,15 @@ const BillingLeaderActionMenu = (props: Props) => {
           orgId={orgId}
           preferredName={preferredName}
           userId={userId}
-          toggle={<MenuItemWithShortcuts label='Remove from Organization' />}
+          toggle={
+            <MenuItemWithShortcuts
+              label={
+                new Date(newUserUntil) > new Date()
+                  ? 'Refund and Remove'
+                  : 'Remove from Organization'
+              }
+            />
+          }
         />
       )}
     </MenuWithShortcuts>
@@ -86,6 +94,7 @@ export default createFragmentContainer(
 
     fragment BillingLeaderActionMenu_organizationUser on OrganizationUser {
       role
+      newUserUntil
       user {
         userId: id
         preferredName

--- a/src/universal/components/BillingLeaderActionMenu.tsx
+++ b/src/universal/components/BillingLeaderActionMenu.tsx
@@ -5,28 +5,27 @@ import {BILLING_LEADER} from 'universal/utils/constants'
 import SetOrgUserRoleMutation from 'universal/mutations/SetOrgUserRoleMutation'
 import LeaveOrgModal from 'universal/modules/userDashboard/components/LeaveOrgModal/LeaveOrgModal'
 import RemoveFromOrgModal from 'universal/modules/userDashboard/components/RemoveFromOrgModal/RemoveFromOrgModal'
-import {createFragmentContainer} from 'react-relay'
-import withAtmosphere from 'universal/decorators/withAtmosphere/withAtmosphere'
-import type {MutationProps} from 'universal/utils/relay/withMutationProps'
-import withMutationProps from 'universal/utils/relay/withMutationProps'
-import {BillingLeaderActionMenu_organization as Organization} from '__generated__/BillingLeaderActionMenu_organization.graphql'
-import {BillingLeaderActionMenu_orgMember as OrgMember} from '__generated__/BillingLeaderActionMenu_orgMember.graphql'
+import {createFragmentContainer, graphql} from 'react-relay'
+import withAtmosphere, {
+  WithAtmosphereProps
+} from 'universal/decorators/withAtmosphere/withAtmosphere'
+import withMutationProps, {WithMutationProps} from 'universal/utils/relay/withMutationProps'
+import {BillingLeaderActionMenu_organizationUser} from '__generated__/BillingLeaderActionMenu_organizationUser.graphql'
+import {BillingLeaderActionMenu_organization} from '__generated__/BillingLeaderActionMenu_organization.graphql'
 
-type Props = {|
-  atmosphere: Object,
-  closePortal: () => void,
-  isViewerLastBillingLeader: boolean,
-  orgMember: OrgMember,
-  organization: Organization,
-  ...MutationProps
-|}
+interface Props extends WithMutationProps, WithAtmosphereProps {
+  closePortal: () => void
+  isViewerLastBillingLeader: boolean
+  organizationUser: BillingLeaderActionMenu_organizationUser
+  organization: BillingLeaderActionMenu_organization
+}
 
 const BillingLeaderActionMenu = (props: Props) => {
   const {
     atmosphere,
     closePortal,
     isViewerLastBillingLeader,
-    orgMember,
+    organizationUser,
     submitting,
     submitMutation,
     onError,
@@ -35,7 +34,7 @@ const BillingLeaderActionMenu = (props: Props) => {
   } = props
   const {orgId} = organization
   const {viewerId} = atmosphere
-  const {role, user} = orgMember
+  const {role, user} = organizationUser
   const isBillingLeader = role === BILLING_LEADER
   const {userId, preferredName} = user
 
@@ -85,7 +84,7 @@ export default createFragmentContainer(
       orgId: id
     }
 
-    fragment BillingLeaderActionMenu_orgMember on OrganizationUser {
+    fragment BillingLeaderActionMenu_organizationUser on OrganizationUser {
       role
       user {
         userId: id

--- a/src/universal/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/src/universal/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -21,12 +21,12 @@ const OrgMembers = (props: Props) => {
   )
   return (
     <Panel label='Organization Members'>
-      {organizationUsers.edges.map(({node: orgMember}) => {
+      {organizationUsers.edges.map(({node: organizationUser}) => {
         return (
           <OrgMemberRow
-            key={orgMember.id}
+            key={organizationUser.id}
             billingLeaderCount={billingLeaderCount}
-            orgMember={orgMember}
+            organizationUser={organizationUser}
             organization={organization}
           />
         )
@@ -48,7 +48,7 @@ export default createPaginationContainer<Props>(
             node {
               id
               role
-              ...OrgMemberRow_orgMember
+              ...OrgMemberRow_organizationUser
             }
           }
           pageInfo {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16927,11 +16927,6 @@ uuid@3.3.2, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uws@10.148.1:
-  version "10.148.1"
-  resolved "https://registry.yarnpkg.com/uws/-/uws-10.148.1.tgz#fd1a79cf6118a388e0a1bed8a1397030d2c4fd2c"
-  integrity sha1-/Rp5z2EYo4jgob7YoTlwMNLE/Sw=
-
 v8-compile-cache@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz#a428b28bb26790734c4fc8bc9fa106fccebf6a6c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,6 +782,11 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@clusterws/cws@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@clusterws/cws/-/cws-0.10.0.tgz#59343ac6510653568019082724be7ec00ce5fcff"
+  integrity sha512-QEfyOFeGR0AZM8JzA5RqEnE8dGsnSUW3vk68hlspaqGj79SnlSHdSAhspxO3GEI/Xb92ON3FVZ/YxCOCxF0rLg==
+
 "@emotion/babel-utils@^0.6.4":
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.10.tgz#83dbf3dfa933fae9fc566e54fbb45f14674c6ccc"


### PR DESCRIPTION
TEST
- [x] app works in node v10 & node v11 (implemented uws replacement)
- [x] a "New" badge appears news to org users that have existed on the org for less than a week
- [x] Billing leader can select "Refund and Remove From Organization" for PRO new org users from the org user dropdown menu
- [ ] after removing an org user from the org dropdown, the invoice estimate updates (for PRO)
- [x] users who have already been refunded & then have been put back on the org are not eligible
- [ ] calling `sendNewOrganizationUsersConfirmation` sends an email to billing leaders of organizations including the names & email addresses of new users. it also resets the `newUserUntil` value to 7 days from the time it is sent. 