### PR TITLE
add segmentId to login payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/react-relay": "^1.3.9",
     "@types/react-router-dom": "^4.3.0",
     "@types/relay-runtime": "^1.3.6",
+    "@types/segment-analytics": "^0.0.28",
     "awesome-typescript-loader": "^5.2.0",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.2",

--- a/src/server/graphql/mutations/login.js
+++ b/src/server/graphql/mutations/login.js
@@ -19,6 +19,7 @@ import sleep from 'universal/utils/sleep'
 const handleSegment = async (userId, previousId) => {
   if (previousId) {
     await segmentIo.alias({previousId, userId})
+    // https://segment.com/docs/destinations/mixpanel/#aliasing-server-side
     await sleep(1000)
   }
   return sendSegmentIdentify(userId)
@@ -103,7 +104,8 @@ const login = {
       name: userInfo.name,
       preferredName,
       identities: userInfo.identities || [],
-      createdAt: ensureDate(userInfo.created_at)
+      createdAt: ensureDate(userInfo.created_at),
+      segmentId
     }
     await r.table('User').insert(newUser)
 

--- a/src/universal/components/AnalyticsIdentifier.tsx
+++ b/src/universal/components/AnalyticsIdentifier.tsx
@@ -4,19 +4,20 @@ import {Component} from 'react'
 import reactLifecyclesCompat from 'react-lifecycles-compat'
 import makeHref from 'universal/utils/makeHref'
 
+import AnalyticsJS = SegmentAnalytics.AnalyticsJS
+
+declare global {
+  interface Window {
+    analytics?: AnalyticsJS
+  }
+}
+
 interface Props {
   location: any
   viewer: AnalyticsIdentifierRootQueryResponse['viewer'] | null
 }
-
 interface State {
   viewer: AnalyticsIdentifierRootQueryResponse['viewer'] | null
-}
-
-declare global {
-  interface Window {
-    analytics?: {identify: any; page: any}
-  }
 }
 
 class AnalyticsIdentifier extends Component<Props, State> {

--- a/src/universal/components/AuthenticationPage.tsx
+++ b/src/universal/components/AuthenticationPage.tsx
@@ -67,7 +67,10 @@ class AuthenticationPage extends Component<Props> {
     }
     onCompleted()
     const {idToken} = res
-    LoginMutation(atmosphere, {auth0Token: idToken}, {history})
+    const isCreate = location.pathname.includes(CREATE_ACCOUNT_SLUG)
+    const segmentId =
+      isCreate && window.analytics ? window.analytics.user().anonymousId() : undefined
+    LoginMutation(atmosphere, {auth0Token: idToken, segmentId}, {history})
   }
 
   authFormRef = React.createRef<EmailPasswordAuthFormBase>()

--- a/src/universal/components/OAuthRedirect.tsx
+++ b/src/universal/components/OAuthRedirect.tsx
@@ -1,8 +1,8 @@
-import {Component} from 'react'
 import promisify from 'es6-promisify'
+import {Component} from 'react'
 import {RouteComponentProps, withRouter} from 'react-router'
-import withAtmosphere, {WithAtmosphereProps} from '../decorators/withAtmosphere/withAtmosphere'
 import LoginMutation from 'universal/mutations/LoginMutation'
+import withAtmosphere, {WithAtmosphereProps} from '../decorators/withAtmosphere/withAtmosphere'
 
 interface Props extends WithAtmosphereProps, RouteComponentProps<{}> {}
 
@@ -29,7 +29,8 @@ class OAuthRedirect extends Component<Props> {
       const {idToken} = res
       const invitationToken = window.localStorage.getItem('invitationToken')
       window.localStorage.removeItem('invitationToken')
-      LoginMutation(atmosphere, {auth0Token: idToken, invitationToken}, {history})
+      const segmentId = window.analytics ? window.analytics.user().anonymousId() : undefined
+      LoginMutation(atmosphere, {auth0Token: idToken, invitationToken, segmentId}, {history})
     }
   }
 

--- a/src/universal/mutations/LoginMutation.ts
+++ b/src/universal/mutations/LoginMutation.ts
@@ -7,8 +7,8 @@ import {ACTION, RETROSPECTIVE} from 'universal/utils/constants'
 import {meetingTypeToSlug} from 'universal/utils/meetings/lookups'
 
 const mutation = graphql`
-  mutation LoginMutation($auth0Token: String!, $invitationToken: ID) {
-    login(auth0Token: $auth0Token) {
+  mutation LoginMutation($auth0Token: String!, $invitationToken: ID, $segmentId: ID) {
+    login(auth0Token: $auth0Token, segmentId: $segmentId) {
       error {
         message
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1604,6 +1604,11 @@
   resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-1.3.6.tgz#839610054c1747217e814c8993fa642e902d0de0"
   integrity sha512-NobpY0XFh0O9FTRkFJsN5ZNd+M+4eac8ZgM5LP3C0tLd1JkfrwuGkyBUMTuDDGYf+T5zl6vTO6EGgXKD+0QpGA==
 
+"@types/segment-analytics@^0.0.28":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@types/segment-analytics/-/segment-analytics-0.0.28.tgz#a23e26d3171cf6a735ae2ae12974b5f6a707c414"
+  integrity sha512-Oo+1ZQPMlmAXWnE2du97uWOyifMbRWdbmQZDWkXGgZppMLmQB55kAFREf0Z5AfMUD2iymqGJgmu+FsbK8+QNsw==
+
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"


### PR DESCRIPTION
TEST
- be logged out, don't use adblockers, run a demo, & create an account from the demo summary
- [ ] see an `alias` call at https://app.segment.com/parabol-jordan/sources/actiondevelopment/debugger
- [ ] check the newly created user in the db. it has a `segmentId` that matches the `previousId` from the alias call above