### PR TITLE
fix #2601 improve phase completion logic

### DIFF
--- a/src/universal/components/PhaseItemMasonry.tsx
+++ b/src/universal/components/PhaseItemMasonry.tsx
@@ -36,7 +36,7 @@ interface CollectedProps {
 
 interface PassedProps {
   meeting: PhaseItemMasonry_meeting
-  resetActivityTimeout: () => void
+  resetActivityTimeout?: () => void
 }
 
 interface Props extends WithAtmosphereProps, WithMutationProps, CollectedProps, PassedProps {}
@@ -158,7 +158,7 @@ class PhaseItemMasonry extends React.Component<Props> {
 
   handleDragEnd = (payload: MasonryDragEndPayload) => {
     const {atmosphere, resetActivityTimeout} = this.props
-    resetActivityTimeout()
+    resetActivityTimeout && resetActivityTimeout()
     // const {dropTargetType, dropTargetId, childId, itemId, sourceId} = payload
     switch (payload.dropTargetType) {
       case DragReflectionDropTargetTypeEnum.REFLECTION_GRID:

--- a/src/universal/components/PhaseItemMasonry.tsx
+++ b/src/universal/components/PhaseItemMasonry.tsx
@@ -19,6 +19,7 @@ import withAtmosphere, {
   WithAtmosphereProps
 } from 'universal/decorators/withAtmosphere/withAtmosphere'
 import appTheme from 'universal/styles/theme/appTheme'
+import {DragReflectionDropTargetTypeEnum} from 'universal/types/graphql'
 import {REFLECTION_CARD} from 'universal/utils/constants'
 import handleDropOnGrid from 'universal/utils/multiplayerMasonry/handleDropOnGrid'
 import initializeGrid from 'universal/utils/multiplayerMasonry/initializeGrid'
@@ -27,7 +28,6 @@ import setClosingTransform from 'universal/utils/multiplayerMasonry/setClosingTr
 import updateColumnHeight from 'universal/utils/multiplayerMasonry/updateColumnHeight'
 import isTempId from 'universal/utils/relay/isTempId'
 import withMutationProps, {WithMutationProps} from 'universal/utils/relay/withMutationProps'
-import {DragReflectionDropTargetTypeEnum} from 'universal/types/graphql'
 
 interface CollectedProps {
   connectDropTarget: ConnectDropTarget
@@ -36,6 +36,7 @@ interface CollectedProps {
 
 interface PassedProps {
   meeting: PhaseItemMasonry_meeting
+  resetActivityTimeout: () => void
 }
 
 interface Props extends WithAtmosphereProps, WithMutationProps, CollectedProps, PassedProps {}
@@ -156,7 +157,8 @@ class PhaseItemMasonry extends React.Component<Props> {
   }
 
   handleDragEnd = (payload: MasonryDragEndPayload) => {
-    const {atmosphere} = this.props
+    const {atmosphere, resetActivityTimeout} = this.props
+    resetActivityTimeout()
     // const {dropTargetType, dropTargetId, childId, itemId, sourceId} = payload
     switch (payload.dropTargetType) {
       case DragReflectionDropTargetTypeEnum.REFLECTION_GRID:

--- a/src/universal/components/RetroVotePhase.tsx
+++ b/src/universal/components/RetroVotePhase.tsx
@@ -172,7 +172,7 @@ const RetroVotePhase = (props: Props) => {
         <StyledBottomBar>
           <BottomControlSpacer />
           <BottomNavControl
-            isBouncing={isDemoStageComplete}
+            isBouncing={isDemoStageComplete || teamVotesRemaining === 0}
             disabled={!discussStage.isNavigableByFacilitator}
             onClick={gotoNext}
             onKeyDown={handleRightArrow(gotoNext)}


### PR DESCRIPTION
TEST
- [ ] an "active editor" chit appears if someone has focused the editor or typed something within the last 5 seconds. after 5 seconds (or a blur) the active editor chit goes away 
- [ ] the "next" button starts to bounce on the reflection phase if no one else is editing after 2 minutes on that stage (note: if you're the facilitator & you're the only one editing, it'll bounce)
- [ ] the next button bounces on the group phase when no one has dragged a card for 30 seconds
- [ ] the next button bounces on the vote phase when there are no votes left
