### PR TITLE
rename settings to profile

### DIFF
--- a/src/server/database/migrations/20180509162156-addFreeRetros.js
+++ b/src/server/database/migrations/20180509162156-addFreeRetros.js
@@ -1,4 +1,4 @@
-import {PRO, RETROSPECTIVE_TRIAL_COUNT_DEFAULT} from 'universal/utils/constants'
+import {PRO} from 'universal/utils/constants'
 
 exports.up = async (r) => {
   try {
@@ -10,8 +10,8 @@ exports.up = async (r) => {
           retroMeetingsRemaining: 0
         },
         {
-          retroMeetingsOffered: RETROSPECTIVE_TRIAL_COUNT_DEFAULT,
-          retroMeetingsRemaining: RETROSPECTIVE_TRIAL_COUNT_DEFAULT
+          retroMeetingsOffered: 3,
+          retroMeetingsRemaining: 3
         }
       )
     })

--- a/src/universal/components/AuthenticationPage.tsx
+++ b/src/universal/components/AuthenticationPage.tsx
@@ -23,6 +23,7 @@ import {
 } from 'universal/utils/constants'
 import withMutationProps, {WithMutationProps} from 'universal/utils/relay/withMutationProps'
 import auth0Authorize from '../utils/auth0Authorize'
+import getAnonymousId from '../utils/getAnonymousId'
 import makeWebAuth from '../utils/makeWebAuth'
 import AuthDialog from './AuthDialog'
 import AuthPrivacyFooter from './AuthPrivacyFooter'
@@ -68,8 +69,7 @@ class AuthenticationPage extends Component<Props> {
     onCompleted()
     const {idToken} = res
     const isCreate = location.pathname.includes(CREATE_ACCOUNT_SLUG)
-    const segmentId =
-      isCreate && window.analytics ? window.analytics.user().anonymousId() : undefined
+    const segmentId = isCreate ? getAnonymousId() : undefined
     LoginMutation(atmosphere, {auth0Token: idToken, segmentId}, {history})
   }
 

--- a/src/universal/components/MasonryCSSGrid.tsx
+++ b/src/universal/components/MasonryCSSGrid.tsx
@@ -1,6 +1,6 @@
 import React, {Component, ReactNode} from 'react'
 import styled from 'react-emotion'
-import ResizeObserver from 'resize-observer-polyfill'
+import ResizeObserverPolyfill from 'resize-observer-polyfill'
 
 interface GridProps {
   colWidth: number
@@ -27,6 +27,7 @@ interface ItemRefs {
   [id: string]: HTMLElement
 }
 
+const ResizeObserver = (window as any).ResizeObserver || ResizeObserverPolyfill
 class MasonryCSSGrid extends Component<Props> {
   itemRefs: ItemRefs = {}
   gridRef = React.createRef<HTMLDivElement>()

--- a/src/universal/components/OAuthRedirect.tsx
+++ b/src/universal/components/OAuthRedirect.tsx
@@ -3,6 +3,7 @@ import {Component} from 'react'
 import {RouteComponentProps, withRouter} from 'react-router'
 import LoginMutation from 'universal/mutations/LoginMutation'
 import withAtmosphere, {WithAtmosphereProps} from '../decorators/withAtmosphere/withAtmosphere'
+import getAnonymousId from '../utils/getAnonymousId'
 
 interface Props extends WithAtmosphereProps, RouteComponentProps<{}> {}
 
@@ -29,7 +30,7 @@ class OAuthRedirect extends Component<Props> {
       const {idToken} = res
       const invitationToken = window.localStorage.getItem('invitationToken')
       window.localStorage.removeItem('invitationToken')
-      const segmentId = window.analytics ? window.analytics.user().anonymousId() : undefined
+      const segmentId = getAnonymousId()
       LoginMutation(atmosphere, {auth0Token: idToken, invitationToken, segmentId}, {history})
     }
   }

--- a/src/universal/components/RetroReflectPhase/ExpandedReflectionStack.tsx
+++ b/src/universal/components/RetroReflectPhase/ExpandedReflectionStack.tsx
@@ -1,7 +1,7 @@
 import {PhaseItemColumn_meeting} from '__generated__/PhaseItemColumn_meeting.graphql'
 import React, {Component} from 'react'
 import styled from 'react-emotion'
-import ResizeObserver from 'resize-observer-polyfill'
+import ResizeObserverPolyfill from 'resize-observer-polyfill'
 import Modal from 'universal/components/Modal'
 import ReflectionCard from 'universal/components/ReflectionCard/ReflectionCard'
 import FLIPGrid from 'universal/components/RetroReflectPhase/FLIPGrid'
@@ -32,6 +32,7 @@ const ModalReflectionWrapper = styled('div')({
   position: 'absolute'
 })
 
+const ResizeObserver = (window as any).ResizeObserver || ResizeObserverPolyfill
 class ExpandedReflectionStack extends Component<Props, State> {
   state = {
     isClosing: false

--- a/src/universal/components/StandardHubUserMenu.js
+++ b/src/universal/components/StandardHubUserMenu.js
@@ -31,7 +31,7 @@ const StandardHubUserMenu = (props: Props) => {
   } = props
 
   // nav menu routes
-  const goToSettings = () => history.push('/me/settings')
+  const goToProfile = () => history.push('/me/profile')
   const goToOrganizations = () => history.push('/me/organizations')
   const goToNotifications = () => history.push('/me/notifications')
   const signOut = () => history.push(`/${SIGNOUT_SLUG}`)
@@ -54,7 +54,7 @@ const StandardHubUserMenu = (props: Props) => {
   return (
     <MenuWithShortcuts ariaLabel={'Select your settings'} closePortal={closePortal}>
       <DropdownMenuLabel>{email}</DropdownMenuLabel>
-      <MenuItemWithShortcuts icon='account_box' label='Settings' onClick={goToSettings} />
+      <MenuItemWithShortcuts icon='account_box' label='Profile' onClick={goToProfile} />
       <MenuItemWithShortcuts
         icon='account_balance'
         label='Organizations'

--- a/src/universal/components/TimelineEventJoinedParabol.tsx
+++ b/src/universal/components/TimelineEventJoinedParabol.tsx
@@ -21,7 +21,7 @@ class TimelineEventJoinedParabol extends Component<Props> {
       >
         <TimelineEventBody>
           {'Get started by updating your name and avatar in '}
-          <StyledLink to='/me/settings'>User Settings</StyledLink>
+          <StyledLink to='/me/profile'>User Profile</StyledLink>
           {'.'}
         </TimelineEventBody>
       </TimelineEventCard>

--- a/src/universal/decorators/requireAuthAndRole/requireAuthAndRole.js
+++ b/src/universal/decorators/requireAuthAndRole/requireAuthAndRole.js
@@ -45,7 +45,7 @@ export default ({
               atmosphere.eventEmitter.emit('addToast', unauthorized)
             })
           }
-          history.push(unauthRoute)
+          history.replace(unauthRoute)
           this.redir = true
         }
       } else {
@@ -54,7 +54,7 @@ export default ({
             atmosphere.eventEmitter.emit('addToast', unauthenticated)
           })
         }
-        history.push({
+        history.replace({
           pathname: unauthRoute,
           search: `?redirectTo=${encodeURIComponent(pathname)}`
         })

--- a/src/universal/modules/userDashboard/components/SettingsHeader/SettingsHeader.js
+++ b/src/universal/modules/userDashboard/components/SettingsHeader/SettingsHeader.js
@@ -3,12 +3,12 @@ import React from 'react'
 import withStyles from 'universal/styles/withStyles'
 import {css} from 'aphrodite-local-styles/no-important'
 import {withRouter} from 'react-router-dom'
-import {SETTINGS, ORGANIZATIONS, NOTIFICATIONS} from 'universal/utils/constants'
+import {PROFILE, ORGANIZATIONS, NOTIFICATIONS} from 'universal/utils/constants'
 import ui from 'universal/styles/ui'
 
 const heading = {
-  [SETTINGS]: {
-    label: 'Settings'
+  [PROFILE]: {
+    label: 'Profile'
   },
   [ORGANIZATIONS]: {
     label: 'Organizations'

--- a/src/universal/modules/userDashboard/components/UserDashboard/UserDashboard.js
+++ b/src/universal/modules/userDashboard/components/UserDashboard/UserDashboard.js
@@ -11,8 +11,8 @@ const organization = () =>
   import(/* webpackChunkName: 'OrganizationRoot' */ 'universal/modules/userDashboard/containers/Organization/OrganizationRoot')
 const userDashMain = () =>
   import(/* webpackChunkName: 'UserDashMain' */ 'universal/modules/userDashboard/components/UserDashMain/UserDashMain')
-const userSettings = () =>
-  import(/* webpackChunkName: 'UserSettingsRoot' */ 'universal/modules/userDashboard/components/UserSettingsRoot')
+const userProfile = () =>
+  import(/* webpackChunkName: 'UserProfileRoot' */ 'universal/modules/userDashboard/components/UserProfileRoot')
 const notificationsMod = () =>
   import(/* webpackChunkName: 'NotificationsContainer' */ 'universal/modules/notifications/containers/Notifications/NotificationsContainer')
 
@@ -20,7 +20,7 @@ const UserDashboard = (props) => {
   const {match, notifications} = props
   return (
     <Switch>
-      <AsyncRoute path={`${match.url}/settings`} mod={userSettings} />
+      <AsyncRoute path={`${match.url}/profile`} mod={userProfile} />
       <AsyncRoute exact path={`${match.url}/organizations`} mod={organizations} />
       <AsyncRoute path={`${match.url}/organizations/:orgId`} mod={organization} />
       <AsyncRoute

--- a/src/universal/modules/userDashboard/components/UserProfile.tsx
+++ b/src/universal/modules/userDashboard/components/UserProfile.tsx
@@ -63,7 +63,7 @@ interface Props extends WithAtmosphereProps, WithMutationProps, WithFormProps {
   viewer: UserSettings_viewer
 }
 
-class UserSettings extends Component<Props> {
+class UserProfile extends Component<Props> {
   onSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     const {
@@ -88,7 +88,7 @@ class UserSettings extends Component<Props> {
     const pictureOrDefault = picture || defaultUserAvatar
     return (
       <UserSettingsWrapper>
-        <Helmet title='My Settings | Parabol' />
+        <Helmet title='My Profile | Parabol' />
         <SettingsBlock>
           <Panel label='My Information'>
             <SettingsForm onSubmit={this.onSubmit}>
@@ -146,7 +146,7 @@ const form = withForm({
 })
 
 export default createFragmentContainer(
-  withAtmosphere(withMutationProps(form(UserSettings))),
+  withAtmosphere(withMutationProps(form(UserProfile))),
   graphql`
     fragment UserSettings_viewer on User {
       preferredName

--- a/src/universal/modules/userDashboard/components/UserProfile.tsx
+++ b/src/universal/modules/userDashboard/components/UserProfile.tsx
@@ -18,7 +18,7 @@ import withAtmosphere, {
 } from 'universal/decorators/withAtmosphere/withAtmosphere'
 import withForm, {WithFormProps} from 'universal/utils/relay/withForm'
 import Legitity from 'universal/validation/Legitity'
-import {UserSettings_viewer} from '__generated__/UserSettings_viewer.graphql'
+import {UserProfile_viewer} from '__generated__/UserProfile_viewer.graphql'
 
 const SettingsBlock = styled('div')({
   width: '100%'
@@ -60,7 +60,7 @@ const UserAvatarInput = lazy(() =>
 )
 
 interface Props extends WithAtmosphereProps, WithMutationProps, WithFormProps {
-  viewer: UserSettings_viewer
+  viewer: UserProfile_viewer
 }
 
 class UserProfile extends Component<Props> {
@@ -148,7 +148,7 @@ const form = withForm({
 export default createFragmentContainer(
   withAtmosphere(withMutationProps(form(UserProfile))),
   graphql`
-    fragment UserSettings_viewer on User {
+    fragment UserProfile_viewer on User {
       preferredName
       picture
     }

--- a/src/universal/modules/userDashboard/components/UserProfileRoot.tsx
+++ b/src/universal/modules/userDashboard/components/UserProfileRoot.tsx
@@ -12,7 +12,7 @@ import withAtmosphere, {
 import NotificationSubscription from 'universal/subscriptions/NotificationSubscription'
 import {cacheConfig} from 'universal/utils/constants'
 import {connect} from 'react-redux'
-import UserSettings from './UserSettings/UserSettings'
+import UserProfile from './UserProfile'
 
 const query = graphql`
   query UserSettingsRootQuery {
@@ -29,7 +29,7 @@ interface Props extends WithAtmosphereProps, RouteComponentProps<{teamId: string
   dispatch: Dispatch<any>
 }
 
-const UserSettingsRoot = (props: Props) => {
+const UserProfileRoot = (props: Props) => {
   const {
     atmosphere,
     dispatch,
@@ -53,11 +53,11 @@ const UserSettingsRoot = (props: Props) => {
           error={<ErrorComponent height={'14rem'} />}
           loading={<LoadingView minHeight='50vh' />}
           // @ts-ignore
-          ready={<UserSettings />}
+          ready={<UserProfile />}
         />
       )}
     />
   )
 }
 
-export default (connect() as any)(withRouter(withAtmosphere(UserSettingsRoot)))
+export default (connect() as any)(withRouter(withAtmosphere(UserProfileRoot)))

--- a/src/universal/modules/userDashboard/components/UserProfileRoot.tsx
+++ b/src/universal/modules/userDashboard/components/UserProfileRoot.tsx
@@ -15,9 +15,9 @@ import {connect} from 'react-redux'
 import UserProfile from './UserProfile'
 
 const query = graphql`
-  query UserSettingsRootQuery {
+  query UserProfileRootQuery {
     viewer {
-      ...UserSettings_viewer
+      ...UserProfile_viewer
     }
   }
 `

--- a/src/universal/modules/userDashboard/components/UserSettingsWrapper/UserSettingsWrapper.js
+++ b/src/universal/modules/userDashboard/components/UserSettingsWrapper/UserSettingsWrapper.js
@@ -20,7 +20,7 @@ const UserSettingsWrapper = (props) => {
   const {children} = props
   return (
     <DashMain>
-      <DashHeader area='userSettings'>
+      <DashHeader>
         <SettingsHeader />
       </DashHeader>
       <DashContent padding='0 0 0 1rem'>

--- a/src/universal/utils/constants.js
+++ b/src/universal/utils/constants.js
@@ -20,8 +20,7 @@ export const RETRO_VOTED_LABEL = 'Upvoted'
 
 /* Phases */
 export const LOBBY = 'lobby'
-export const RETRO_LOBBY_FREE = 'retroLobbyFree'
-export const RETRO_LOBBY_PAID = 'retroLobbyPaid'
+
 // lowercase here to match url
 export const CHECKIN = 'checkin'
 export const UPDATES = 'updates'
@@ -98,22 +97,12 @@ export const TASK_INVOLVES = 'TASK_INVOLVES'
 // sent on socket connection
 export const VERSION_INFO = 'VERSION_INFO'
 
-export const notificationTypes = [
-  PAYMENT_REJECTED,
-  PROMOTE_TO_BILLING_LEADER,
-  REQUEST_NEW_USER,
-  DENY_NEW_USER,
-  TEAM_ARCHIVED,
-  TEAM_INVITE
-]
-
 export const billingLeaderTypes = [PAYMENT_REJECTED, REQUEST_NEW_USER]
 
 /* User Settings */
-export const SETTINGS = 'settings'
+export const PROFILE = 'profile'
 export const ORGANIZATIONS = 'organizations'
 export const NOTIFICATIONS = 'notifications'
-export const settingsOrder = [SETTINGS, ORGANIZATIONS, NOTIFICATIONS]
 
 /* Org Settings */
 export const BILLING_PAGE = 'billing'
@@ -207,15 +196,6 @@ export const ENTERPRISE = 'enterprise'
 export const ASSIGNEE = 'ASSIGNEE'
 export const MENTIONEE = 'MENTIONEE'
 
-/* Third-party authentication providers */
-export const GOOGLE_AUTH_PROVIDER = {
-  displayName: 'Google',
-  auth0Connection: 'google-oauth2',
-  iconName: 'google'
-}
-
-export const THIRD_PARTY_AUTH_PROVIDERS = [GOOGLE_AUTH_PROVIDER]
-
 /* Auth Labels, Slugs */
 export const SIGNIN_LABEL = 'Sign In'
 export const SIGNIN_SLUG = 'signin'
@@ -239,4 +219,3 @@ export const DISCUSSION_TOPIC = 'DISCUSSION_TOPIC'
 /* Retro constants */
 export const RETROSPECTIVE_TOTAL_VOTES_DEFAULT = 5
 export const RETROSPECTIVE_MAX_VOTES_PER_GROUP_DEFAULT = 3
-export const RETROSPECTIVE_TRIAL_COUNT_DEFAULT = 3

--- a/src/universal/utils/getAnonymousId.ts
+++ b/src/universal/utils/getAnonymousId.ts
@@ -1,0 +1,8 @@
+const getAnonymousId = (): string | undefined => {
+  const analytics: any = window && window.analytics
+  return analytics && typeof analytics.user === 'function'
+    ? analytics.user().anonymousId()
+    : undefined
+}
+
+export default getAnonymousId


### PR DESCRIPTION
TEST
- [ ] User Settings is now User Profile (page title, url, menu link, etc)
- fix analytics.user missing (no need to test)
- turn history.push into history.replace for login routes
- use native ResizeObserver (the only errors happened on Chrome, and Chrome offers a native implementation, so we'll try using that)

fix #2615 
fix #2608
fix #2604
fix #2461