### PR TITLE
fix #2663 no agendaId for demo bot if human deletes task

### DIFF
--- a/src/universal/modules/demo/ClientGraphQLServer.ts
+++ b/src/universal/modules/demo/ClientGraphQLServer.ts
@@ -841,7 +841,9 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         isSoftTask: false,
         userId: null
       }
-      const task = this.db.tasks.find((task) => task.id === updatedTask.id)!
+      const task = this.db.tasks.find((task) => task.id === updatedTask.id)
+      // if the human deleted the task, exit fast
+      if (!task) return null
       if (assigneeId) {
         const isSoftTask = getIsSoftTeamMember(assigneeId)
         taskUpdates.isSoftTask = isSoftTask


### PR DESCRIPTION
fix #2663

not sure about repro. my guess is the user deleted a task before the bot had a chance to call update on it.
merging immediately due to size & scope.