### PR TITLE
don't send sentry error when google nlp fails due to unsupported lang

### DIFF
--- a/src/server/demoEntityHandler.ts
+++ b/src/server/demoEntityHandler.ts
@@ -4,6 +4,15 @@ import getSyntaxFromText from 'server/graphql/mutations/helpers/autoGroup/getSyn
 import sanitizeAnalyzedEntitiesResponse from 'server/graphql/mutations/helpers/autoGroup/sanitizeAnalyzedEntititesResponse'
 import promiseAllObj from 'universal/utils/promiseAllObj'
 import promiseAllPartial from 'universal/utils/promiseAllPartial'
+import sendToSentry from './utils/sendToSentry'
+
+const catchHandler = (e: Error) => {
+  const re = /the language \S+ is not supported/
+  if (!re.test(e.message)) {
+    sendToSentry(new Error(`Demo Error: Google NLP: ${e.message}`))
+  }
+  return null
+}
 
 const demoEntityHandler = async (req, res) => {
   if (!req.body || !Array.isArray(req.body.texts)) {
@@ -13,8 +22,8 @@ const demoEntityHandler = async (req, res) => {
   const texts = req.body.texts as Array<string>
   // intelligently extract the entities from the body of the text
   const {reflectionResponses, reflectionSyntax} = await promiseAllObj({
-    reflectionResponses: promiseAllPartial(texts.map(getEntitiesFromText)),
-    reflectionSyntax: promiseAllPartial(texts.map(getSyntaxFromText))
+    reflectionResponses: promiseAllPartial(texts.map(getEntitiesFromText), catchHandler),
+    reflectionSyntax: promiseAllPartial(texts.map(getSyntaxFromText), catchHandler)
   })
 
   // for each entity, look in the tokens array to first the first word of the entity

--- a/src/types/generics.ts
+++ b/src/types/generics.ts
@@ -1,2 +1,13 @@
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 export type Subtract<T, K> = Omit<T, keyof K>
+
+// there's rumor of a negated operator coming to TS soon...
+export type NotVoid =
+  | {[key: string]: NotVoid}
+  | object
+  | string
+  | boolean
+  | symbol
+  | number
+  | null
+  | undefined

--- a/src/universal/utils/promiseAllPartial.ts
+++ b/src/universal/utils/promiseAllPartial.ts
@@ -4,8 +4,14 @@
  * This does that, and does it quickly, assuming that the first promise in the array will resolve first
  */
 
-const promiseAllPartial = async (promiseArr, catchValue = null) => {
-  const arr = []
+import {NotVoid} from '../../types/generics'
+
+type CatchHandler = (e: Error) => NotVoid
+
+const defaultCatchHandler: CatchHandler = (_e: Error) => null
+
+const promiseAllPartial = async (promiseArr, catchHandler: CatchHandler = defaultCatchHandler) => {
+  const arr: any[] = []
   for (let ii = 0; ii < promiseArr.length; ii++) {
     const promise = promiseArr[ii]
     try {
@@ -13,6 +19,7 @@ const promiseAllPartial = async (promiseArr, catchValue = null) => {
       const res = await promise
       arr.push(res)
     } catch (e) {
+      const catchValue = catchHandler(e)
       arr.push(catchValue)
     }
   }


### PR DESCRIPTION
TEST
- [ ] in the retrospective-demo, write a reflection in polish. sentry is not notified (must turn on sentry API key in .env)