### PR TITLE
fix registerQuery logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "react-virtualized": "^9.18.5",
     "redux": "^4.0.1",
     "redux-thunk": "2.2.0",
-    "relay-runtime": "https://github.com/mattkrick/relay/tarball/e9ed4923b44978ab4363dd20f2f96d5416d5aa45",
+    "relay-runtime": "https://github.com/mattkrick/relay/tarball/f198dc30b76ce97076f17da0e92f155437fbe82c",
     "resize-observer-polyfill": "^1.5.0",
     "rethinkdbdash": "^2.3.31",
     "secure-compare": "^3.0.1",
@@ -283,7 +283,7 @@
     "@types/relay-runtime": "https://github.com/mattkrick/relay-runtime-strict-types/tarball/2b79845de58b8f26a37a5b5886e0b66534ffa23d",
     "@types/react": "16.8.2",
     "@types/react-dom": "16.8.0",
-    "relay-runtime": "https://github.com/mattkrick/relay/tarball/e9ed4923b44978ab4363dd20f2f96d5416d5aa45"
+    "relay-runtime": "https://github.com/mattkrick/relay/tarball/f198dc30b76ce97076f17da0e92f155437fbe82c"
   },
   "standard": {
     "parser": "babel-eslint",

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "react-virtualized": "^9.18.5",
     "redux": "^4.0.1",
     "redux-thunk": "2.2.0",
-    "relay-runtime": "https://github.com/mattkrick/relay/tarball/f198dc30b76ce97076f17da0e92f155437fbe82c",
+    "relay-runtime": "https://github.com/mattkrick/relay/tarball/e9b10262a7ec4bc0715ca1242e4fad25f9900c1f",
     "resize-observer-polyfill": "^1.5.0",
     "rethinkdbdash": "^2.3.31",
     "secure-compare": "^3.0.1",
@@ -283,7 +283,7 @@
     "@types/relay-runtime": "https://github.com/mattkrick/relay-runtime-strict-types/tarball/2b79845de58b8f26a37a5b5886e0b66534ffa23d",
     "@types/react": "16.8.2",
     "@types/react-dom": "16.8.0",
-    "relay-runtime": "https://github.com/mattkrick/relay/tarball/f198dc30b76ce97076f17da0e92f155437fbe82c"
+    "relay-runtime": "https://github.com/mattkrick/relay/tarball/e9b10262a7ec4bc0715ca1242e4fad25f9900c1f"
   },
   "standard": {
     "parser": "babel-eslint",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",
     "babel-plugin-module-resolver": "^3.1.3",
-    "babel-plugin-relay": "^2.0.0",
+    "babel-plugin-relay": "3.0.0",
     "chance": "^1.0.6",
     "clean-webpack-plugin": "^0.1.19",
     "codecov": "^2.3.0",
@@ -229,7 +229,7 @@
     "react-loadable": "^5.3.1",
     "react-notification-system": "^0.2.16",
     "react-redux": "^6.0.0",
-    "react-relay": "2.0.0",
+    "react-relay": "3.0.0",
     "react-router": "4.4.0-beta.6",
     "react-router-dom": "4.4.0-beta.6",
     "react-test-renderer": "^16.0.0",
@@ -237,7 +237,7 @@
     "react-virtualized": "^9.18.5",
     "redux": "^4.0.1",
     "redux-thunk": "2.2.0",
-    "relay-runtime": "https://github.com/mattkrick/relay/tarball/e9b10262a7ec4bc0715ca1242e4fad25f9900c1f",
+    "relay-runtime": "https://github.com/mattkrick/relay/tarball/0a49c03689370fc471fe066fb0515b7992dd04b1",
     "resize-observer-polyfill": "^1.5.0",
     "rethinkdbdash": "^2.3.31",
     "secure-compare": "^3.0.1",
@@ -283,7 +283,7 @@
     "@types/relay-runtime": "https://github.com/mattkrick/relay-runtime-strict-types/tarball/2b79845de58b8f26a37a5b5886e0b66534ffa23d",
     "@types/react": "16.8.2",
     "@types/react-dom": "16.8.0",
-    "relay-runtime": "https://github.com/mattkrick/relay/tarball/e9b10262a7ec4bc0715ca1242e4fad25f9900c1f"
+    "relay-runtime": "https://github.com/mattkrick/relay/tarball/0a49c03689370fc471fe066fb0515b7992dd04b1"
   },
   "standard": {
     "parser": "babel-eslint",

--- a/src/universal/components/DashboardRoot.tsx
+++ b/src/universal/components/DashboardRoot.tsx
@@ -2,7 +2,7 @@ import React, {lazy} from 'react'
 import {DragDropContext as dragDropContext} from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import {graphql} from 'react-relay'
-import {Route} from 'react-router'
+import {Route, Switch} from 'react-router'
 import {RouteComponentProps, withRouter} from 'react-router-dom'
 import DashLayout from 'universal/components/Dashboard/DashLayout'
 import DashSidebar from 'universal/components/Dashboard/DashSidebar'
@@ -75,12 +75,14 @@ const DashboardRoot = ({atmosphere, history, location}: Props) => {
         return (
           <DashLayout viewer={viewer}>
             <DashSidebar viewer={viewer} location={location} />
-            <Route
-              path='/me'
-              render={(p) => <UserDashboard {...p} notifications={notifications} />}
-            />
-            <Route path='/team/:teamId' component={TeamRoot} />
-            <Route path='/newteam/:defaultOrgId?' component={NewTeam} />
+            <Switch>
+              <Route
+                path='/me'
+                render={(p) => <UserDashboard {...p} notifications={notifications} />}
+              />
+              <Route path='/team/:teamId' component={TeamRoot} />
+              <Route path='/newteam/:defaultOrgId?' component={NewTeam} />
+            </Switch>
           </DashLayout>
         )
       }}

--- a/src/universal/components/MeetingDashAlert/MeetingDashAlert.js
+++ b/src/universal/components/MeetingDashAlert/MeetingDashAlert.js
@@ -21,7 +21,10 @@ class MeetingDashAlert extends Component {
     const {atmosphere} = this.props
     const {viewerId} = atmosphere
     commitLocalUpdate(atmosphere, (store) => {
-      store.get(viewerId).setValue(false, 'hasMeetingAlert')
+      const viewer = store.get(viewerId)
+      if (viewer) {
+        viewer.setValue(false, 'hasMeetingAlert')
+      }
     })
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14903,9 +14903,9 @@ relateurl@0.2.x:
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-relay-runtime@2.0.0, "relay-runtime@https://github.com/mattkrick/relay/tarball/e9ed4923b44978ab4363dd20f2f96d5416d5aa45":
-  version "2.0.0"
-  resolved "https://github.com/mattkrick/relay/tarball/e9ed4923b44978ab4363dd20f2f96d5416d5aa45#25f032e0acc547a343bc926512013460a8410532"
+relay-runtime@2.0.0, "relay-runtime@https://github.com/mattkrick/relay/tarball/f198dc30b76ce97076f17da0e92f155437fbe82c":
+  version "3.0.0"
+  resolved "https://github.com/mattkrick/relay/tarball/f198dc30b76ce97076f17da0e92f155437fbe82c#6d46b5ac0bf0d8850b9c5f54de19f34a075c0b71"
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
@@ -15430,7 +15430,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -16833,17 +16833,6 @@ ts-fs-promise@^1.0.4:
   dependencies:
     es6-promise "^2.0.1"
     fs-extra "^0.16.5"
-
-ts-loader@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.3.3.tgz#8b4af042e773132d86b3c99ef0acf3b4d325f473"
-  integrity sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^3.1.4"
-    semver "^5.0.1"
 
 ts-node@^7.0.1:
   version "7.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,10 +3606,10 @@ babel-plugin-react-docgen@^2.0.0:
     react-docgen "^3.0.0"
     recast "^0.14.7"
 
-babel-plugin-relay@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-relay/-/babel-plugin-relay-2.0.0.tgz#f5c408f81427f3e97b65ea3f6bccf6821f1615b9"
-  integrity sha512-NFQ+TzQtr4Wh1/FEpjeZqghS1Orpn0gAvksrBOgn606bMf2vd1YYed8z4gMAyAPkwSgWzsNtsLzq84pMJi6agQ==
+babel-plugin-relay@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-relay/-/babel-plugin-relay-3.0.0.tgz#dc5b66c94c8565f2e52edf8fbe86aadff6e7966d"
+  integrity sha512-lI+PR4/H8XytNVUtz8cYYM7sR2unFMeTsBbnKFvuU/mnxxmDO3JA7OHxtTdctLjlRSYrcCVmvIEL2JDehMxlTg==
   dependencies:
     babel-plugin-macros "^2.0.0"
 
@@ -14334,16 +14334,16 @@ react-redux@^6.0.0:
     prop-types "^15.6.2"
     react-is "^16.6.3"
 
-react-relay@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-2.0.0.tgz#967eb66159202264cbf6daa9b1acfa78dfbd13e7"
-  integrity sha512-TLQdW9AVo7Zlu7z81MuNm2Y9Mp3im6rVSKs357uS3cEz6vr2x3ZEQr+HAXDQn8Hb4gFQ+9+iRRlv+hd2Rid/0Q==
+react-relay@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-3.0.0.tgz#b3fe7931f812a6700e2420a853adb74156e162b9"
+  integrity sha512-HZQ1CXhF2EBt6f5XG2nWoT5FZIn9zdoHeo8+u5rqQ3fCRBr4qmvLihfehWlCcYCcx57pnAiqsjUdJmwxGUmbsg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
     nullthrows "^1.1.0"
     prop-types "^15.5.8"
-    relay-runtime "2.0.0"
+    relay-runtime "3.0.0"
 
 react-router-dom@4.4.0-beta.6:
   version "4.4.0-beta.6"
@@ -14903,9 +14903,9 @@ relateurl@0.2.x:
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-relay-runtime@2.0.0, "relay-runtime@https://github.com/mattkrick/relay/tarball/f198dc30b76ce97076f17da0e92f155437fbe82c":
+relay-runtime@2.0.0, relay-runtime@3.0.0, "relay-runtime@https://github.com/mattkrick/relay/tarball/0a49c03689370fc471fe066fb0515b7992dd04b1":
   version "3.0.0"
-  resolved "https://github.com/mattkrick/relay/tarball/f198dc30b76ce97076f17da0e92f155437fbe82c#6d46b5ac0bf0d8850b9c5f54de19f34a075c0b71"
+  resolved "https://github.com/mattkrick/relay/tarball/0a49c03689370fc471fe066fb0515b7992dd04b1#c4ed078045fb23690ee0e475017beadcf6442391"
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"


### PR DESCRIPTION
fix #2700

issues found:
- code in the DashAlert would fail if the component unmounted after the store was cleared
- MyTimelineRoot has a ttl but did not have any subscriptions, which caused a queryFetcher to never get disposed of. Fixed by registering all queries with a TTL, subscriptions or not.

additional fixes:
- i brought back aggressive query caching. this means you can navigate around the site & if you go back to a page in a reasonable amount of time (5 minutes) then you won't need to requery (since the subscriptions are still active & populating the new stuff). this should make the site feel a lot faster when clicking around.

TEST
- open devtools>network>websocket frames
- go to timeline, tasks, a team, another team
- [ ] revisit each of the routes, no new queries are sent to the server
- [ ] login, logout, login, logout. no errors in the console
- [ ] filter cards on a team dashboard, it works