### PR TITLE
submit Task on Enter fix #2684

### DIFF
--- a/src/universal/components/TaskEditor/TaskEditor.js
+++ b/src/universal/components/TaskEditor/TaskEditor.js
@@ -114,9 +114,13 @@ class TaskEditor extends Component {
   }
 
   handleReturn = (e) => {
-    const {handleReturn} = this.props
+    const {editorRef, handleReturn, renderModal} = this.props
     if (handleReturn) {
       return handleReturn(e)
+    }
+    if (!e.shiftKey && !renderModal) {
+      editorRef.blur()
+      return 'handled'
     }
     return 'not-handled'
   }
@@ -171,7 +175,6 @@ class TaskEditor extends Component {
 
   render () {
     const {editorState, readOnly, renderModal, setEditorRef} = this.props
-    // console.log('es', Editor.getClipboard())
     const noText = !editorState.getCurrentContent().hasText()
     const placeholder = 'Describe what “Done” looks like'
     return (


### PR DESCRIPTION
TEST
- [ ] pressing Enter blurs the card & submit the content to be persisted
- [ ] pressing Enter when the emoji, `@mention` and hashtag menus are open does not
