### PR TITLE
support superuser get teams for org fix #2707

### DIFF
--- a/src/server/utils/RethinkDataLoader.js
+++ b/src/server/utils/RethinkDataLoader.js
@@ -225,11 +225,9 @@ export default class RethinkDataLoader {
     }, this.dataloaderOptions)
     this.teamsByOrgId = makeCustomLoader(async (orgIds) => {
       const r = getRethink()
-      const tms = this.authToken.tms || []
       const teams = await r
         .table('Team')
-        .getAll(r.args(tms), {index: 'id'})
-        .filter((team) => r(orgIds).contains(team('orgId')))
+        .getAll(r.args(orgIds), {index: 'orgId'})
         .filter((team) =>
           team('isArchived')
             .default(false)


### PR DESCRIPTION
TEST

- [ ] the query in #2707 works
- [ ] as a non-superuser, `organization { teams { id}}` does not list teams that they are not a part of