### PR TITLE
add android fallback for draft-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,6 +242,7 @@
     "react-router": "4.4.0-beta.6",
     "react-router-dom": "4.4.0-beta.6",
     "react-test-renderer": "^16.0.0",
+    "react-textarea-autosize": "^7.1.0",
     "react-transition-group": "https://github.com/mattkrick/react-transition-group/tarball/d2dac2cb5de9a7757c6e430b2b90f200c34d5369",
     "react-virtualized": "^9.18.5",
     "redux": "^4.0.1",

--- a/src/universal/components/AndroidEditorFallback.tsx
+++ b/src/universal/components/AndroidEditorFallback.tsx
@@ -1,0 +1,56 @@
+import React, {Ref, useEffect, useState} from 'react'
+import styled from 'react-emotion'
+import TextArea from 'react-textarea-autosize'
+import {cardContentFontSize, cardContentLineHeight} from 'universal/styles/cards'
+import {EditorState} from 'draft-js'
+
+interface Props {
+  editorState: EditorState
+  onBlur: (e: React.FocusEvent) => void
+  onFocus: (e: React.FocusEvent) => void
+  onKeyDown: (e: React.KeyboardEvent) => void
+  placeholder: string
+  setEditorRef: Ref<HTMLTextAreaElement>
+  onChange: () => void
+}
+
+const TextAreaStyles = styled(TextArea)({
+  border: 0,
+  fontSize: cardContentFontSize,
+  lineHeight: cardContentLineHeight,
+  overflow: 'hidden',
+  outline: 0,
+  padding: 12,
+  resize: 'none',
+  width: '100%'
+})
+
+const AndroidEditorFallback = (props: Props) => {
+  const {editorState, onBlur, onFocus, onKeyDown, placeholder, setEditorRef} = props
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    const currentContent = editorState.getCurrentContent()
+    const text = currentContent.getPlainText()
+    setValue(text)
+  }, [editorState])
+
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(e.target.value)
+  }
+
+  return (
+    <TextAreaStyles
+      inputRef={setEditorRef}
+      spellCheck
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      onBlur={onBlur}
+      onFocus={onFocus}
+      onKeyDown={onKeyDown}
+    />
+  )
+}
+
+export default AndroidEditorFallback

--- a/src/universal/components/AndroidEditorFallback.tsx
+++ b/src/universal/components/AndroidEditorFallback.tsx
@@ -1,10 +1,11 @@
+import {EditorState} from 'draft-js'
 import React, {Ref, useEffect, useState} from 'react'
 import styled from 'react-emotion'
 import TextArea from 'react-textarea-autosize'
 import {cardContentFontSize, cardContentLineHeight} from 'universal/styles/cards'
-import {EditorState} from 'draft-js'
 
 interface Props {
+  className?: string
   editorState: EditorState
   onBlur: (e: React.FocusEvent) => void
   onFocus: (e: React.FocusEvent) => void
@@ -26,8 +27,9 @@ const TextAreaStyles = styled(TextArea)({
 })
 
 const AndroidEditorFallback = (props: Props) => {
-  const {editorState, onBlur, onFocus, onKeyDown, placeholder, setEditorRef} = props
+  const {className, editorState, onBlur, onFocus, onKeyDown, placeholder, setEditorRef} = props
   const [value, setValue] = useState('')
+  const [height, setHeight] = useState<number | undefined>(44)
 
   useEffect(() => {
     const currentContent = editorState.getCurrentContent()
@@ -41,6 +43,9 @@ const AndroidEditorFallback = (props: Props) => {
 
   return (
     <TextAreaStyles
+      className={className}
+      onHeightChange={(height) => setHeight(height)}
+      style={{height}}
       inputRef={setEditorRef}
       spellCheck
       placeholder={placeholder}

--- a/src/universal/components/ReflectionEditorWrapper.js
+++ b/src/universal/components/ReflectionEditorWrapper.js
@@ -13,6 +13,8 @@ import {
   reflectionCardMaxHeight
 } from 'universal/styles/cards'
 import withEmojis from 'universal/components/TaskEditor/withEmojis'
+import AndroidEditorFallback from 'universal/components/AndroidEditorFallback'
+import isAndroid from 'universal/utils/draftjs/isAndroid'
 
 type Props = {
   ariaLabel: string,
@@ -51,10 +53,10 @@ const codeBlock = css({
   padding: '0 .5rem'
 })
 
-const EditorStyles = styled('div')(({userSelect}) => ({
+const EditorStyles = styled('div')(({showFallback, userSelect}) => ({
   color: appTheme.palette.dark,
   fontSize: cardContentFontSize,
-  lineHeight: cardContentLineHeight,
+  lineHeight: showFallback ? '14px' : cardContentLineHeight,
   maxHeight: reflectionCardMaxHeight,
   minHeight: '1rem',
   overflow: 'auto',
@@ -175,34 +177,48 @@ class ReflectionEditorWrapper extends PureComponent<Props> {
       onBlur,
       onFocus,
       placeholder,
+      handleKeyDownFallback,
       renderModal,
       readOnly,
       userSelect
     } = this.props
+    const showFallback = isAndroid && !readOnly
+    // const showFallback = true
     return (
-      <EditorStyles userSelect={userSelect}>
-        <Editor
-          spellCheck
-          ariaLabel={ariaLabel}
-          blockStyleFn={this.blockStyleFn}
-          editorState={editorState}
-          handleBeforeInput={this.handleBeforeInput}
-          handleKeyCommand={this.handleKeyCommand}
-          handlePastedText={this.handlePastedText}
-          handleReturn={this.handleReturn}
-          keyBindingFn={this.keyBindingFn}
-          onBlur={onBlur}
-          onFocus={onFocus}
-          onChange={this.handleChange}
-          placeholder={placeholder}
-          readOnly={readOnly}
-          ref={this.setEditorRef}
-          style={{
-            padding: '.75rem',
-            userSelect,
-            WebkitUserSelect: userSelect
-          }}
-        />
+      <EditorStyles userSelect={userSelect} showFallback={showFallback}>
+        {showFallback ? (
+          <AndroidEditorFallback
+            editorState={editorState}
+            onBlur={onBlur}
+            onFocus={onFocus}
+            placeholder={placeholder}
+            onKeyDown={handleKeyDownFallback}
+            setEditorRef={this.setEditorRef}
+          />
+        ) : (
+          <Editor
+            spellCheck
+            ariaLabel={ariaLabel}
+            blockStyleFn={this.blockStyleFn}
+            editorState={editorState}
+            handleBeforeInput={this.handleBeforeInput}
+            handleKeyCommand={this.handleKeyCommand}
+            handlePastedText={this.handlePastedText}
+            handleReturn={this.handleReturn}
+            keyBindingFn={this.keyBindingFn}
+            onBlur={onBlur}
+            onFocus={onFocus}
+            onChange={this.handleChange}
+            placeholder={placeholder}
+            readOnly={readOnly}
+            ref={this.setEditorRef}
+            style={{
+              padding: 12,
+              userSelect,
+              WebkitUserSelect: userSelect
+            }}
+          />
+        )}
         {renderModal && renderModal()}
       </EditorStyles>
     )

--- a/src/universal/styles/theme/globalStyles.js
+++ b/src/universal/styles/theme/globalStyles.js
@@ -60,6 +60,11 @@ export default `
     -webkit-font-smoothing: antialiased;
   }
 
+  textarea {
+    font-family: ${appTheme.typography.sansSerif};
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+  }
   img {
     max-width: 100%;
   }

--- a/src/universal/utils/draftjs/isAndroid.ts
+++ b/src/universal/utils/draftjs/isAndroid.ts
@@ -1,0 +1,5 @@
+const isAndroid = () => {
+  return navigator.userAgent.toLowerCase().indexOf('android') > -1
+}
+
+export default isAndroid()

--- a/src/universal/utils/draftjs/isRichDraft.ts
+++ b/src/universal/utils/draftjs/isRichDraft.ts
@@ -1,0 +1,16 @@
+import {EditorState} from 'draft-js'
+
+const isRichDraft = (editorState: EditorState) => {
+  const content = editorState.getCurrentContent()
+  return !content.getBlockMap().every((block) => {
+    if (!block) return false
+    if (block.get('type') !== 'unstyled') return false
+    const charList = block.getCharacterList()
+    return charList.every((char) => {
+      if (!char) return false
+      return char.getStyle().size === 0 && !char.getEntity()
+    })
+  })
+}
+
+export default isRichDraft

--- a/yarn.lock
+++ b/yarn.lock
@@ -14446,7 +14446,7 @@ react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0:
     react-is "^16.8.1"
     scheduler "^0.13.1"
 
-react-textarea-autosize@^7.0.4:
+react-textarea-autosize@^7.0.4, react-textarea-autosize@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.0.tgz#3132cb77e65d94417558d37c0bfe415a5afd3445"
   integrity sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==


### PR DESCRIPTION
TEST
- [ ] can add reflections
- [ ] can add tasks
- [ ] can edit tasks/reflections that have no rich text styles
- [ ] cards with rich text are readonly for android users 

tip: edit the return value of `isAndroid.ts` to test