### PR TITLE
#2837 email invite with active meeting copy, CTA

### DIFF
--- a/src/server/graphql/mutations/inviteToTeam.ts
+++ b/src/server/graphql/mutations/inviteToTeam.ts
@@ -61,7 +61,7 @@ export default {
         return !(user && user.tms && user.tms.includes(teamId))
       })
       const team = await dataLoader.get('teams').load(teamId)
-      const {name: teamName, isOnboardTeam} = team
+      const {name: teamName, isOnboardTeam, meetingId} = team
       const inviter = await dataLoader.get('users').load(viewerId)
       const bufferTokens = await Promise.all<Buffer>(newInvitees.map(() => randomBytes(48)))
       const tokens = bufferTokens.map((buffer: Buffer) => buffer.toString('hex'))
@@ -103,6 +103,10 @@ export default {
       if (notificationsToInsert.length > 0) {
         await r.table('Notification').insert(notificationsToInsert)
       }
+      let meeting
+      if (meetingId) {
+        meeting = await r.table('NewMeeting').get(meetingId)
+      }
 
       // send emails
       const emailResults = await Promise.all(
@@ -114,7 +118,8 @@ export default {
             inviteeEmail: invitation.email,
             inviterName: inviter.preferredName,
             inviterEmail: inviter.email,
-            teamName
+            teamName,
+            meeting
           })
         })
       )

--- a/src/universal/modules/email/containers/TeamInvite/TeamInvite.js
+++ b/src/universal/modules/email/containers/TeamInvite/TeamInvite.js
@@ -8,6 +8,7 @@ import Header from '../../components/Header/Header'
 import EmailFooter from '../../components/EmailFooter/EmailFooter'
 import {emailCopyStyle, emailLinkStyle, emailProductTeamSignature} from 'universal/styles/email'
 import emailDir from 'universal/modules/email/emailDir'
+import {meetingTypeToLabel} from 'universal/utils/meetings/lookups'
 
 const innerMaxWidth = 480
 
@@ -33,13 +34,45 @@ const videoGraphicStyle = {
 const videoGraphicSrc = `${emailDir}retro-video-still.png`
 
 const TeamInvite = (props) => {
-  const {inviterName, inviterEmail, inviteeEmail, inviteeName, teamName, inviteLink} = props
+  const {
+    inviterName,
+    inviterEmail,
+    inviteeEmail,
+    inviteeName,
+    meeting,
+    teamName,
+    inviteLink
+  } = props
   const inviteeEmailBlock = (
     <a href={`mailto:${inviteeEmail}`} style={emailCopyStyle}>
       {inviteeEmail}
     </a>
   )
   const nameOrEmail = inviteeName || inviteeEmailBlock
+  const buttonLabel = meeting
+    ? `Join ${meetingTypeToLabel[meeting.meetingType]} Meeting`
+    : 'Join Team'
+  const meetingCopyLabelLookup = {
+    action: 'an Action Meeting',
+    retrospective: 'a Retrospective Meeting'
+  }
+  const activeMeetingCopy = meeting ? (
+    <span>
+      {`) has started ${meetingCopyLabelLookup[meeting.meetingType]} for your team (`}
+      <b>{teamName}</b>
+      {'). Just a few clicks and you’re in!'}
+    </span>
+  ) : (
+    undefined
+  )
+  const defaultCopy = (
+    <span>
+      {') has invited you to join a team ('}
+      <b>{teamName}</b>
+      {') on Parabol.'}
+    </span>
+  )
+  const copy = meeting ? activeMeetingCopy : defaultCopy
   return (
     <Layout maxWidth={544}>
       <EmailBlock innerMaxWidth={innerMaxWidth}>
@@ -55,10 +88,9 @@ const TeamInvite = (props) => {
           <a href={`mailto:${inviterEmail}`} style={emailLinkStyle}>
             {inviterEmail}
           </a>
-          {') has invited you to join a team on Parabol: '}
-          <span style={boldStyle}>{teamName}</span>
+          {copy}
         </p>
-        <Button url={inviteLink}>{'Join Team'}</Button>
+        <Button url={inviteLink}>{buttonLabel}</Button>
         <EmptySpace height={24} />
         <p style={emailCopyStyle}>
           <span style={boldStyle}>{'New to Parabol?'}</span>
@@ -118,7 +150,8 @@ TeamInvite.propTypes = {
   inviteeEmail: PropTypes.string.isRequired,
   inviterName: PropTypes.string.isRequired,
   inviterEmail: PropTypes.string.isRequired,
-  teamName: PropTypes.string.isRequired
+  teamName: PropTypes.string.isRequired,
+  meeting: PropTypes.object
 }
 
 export const teamInviteText = (props) => {

--- a/src/universal/modules/email/containers/TeamInvite/TeamInvite.js
+++ b/src/universal/modules/email/containers/TeamInvite/TeamInvite.js
@@ -49,48 +49,53 @@ const TeamInvite = (props) => {
     </a>
   )
   const nameOrEmail = inviteeName || inviteeEmailBlock
-  const buttonLabel = meeting
-    ? `Join ${meetingTypeToLabel[meeting.meetingType]} Meeting`
-    : 'Join Team'
   const meetingCopyLabelLookup = {
     action: 'an Action Meeting',
     retrospective: 'a Retrospective Meeting'
   }
-  const activeMeetingCopy = meeting ? (
-    <span>
-      {`) has started ${meetingCopyLabelLookup[meeting.meetingType]} for your team (`}
-      <b>{teamName}</b>
-      {'). Just a few clicks and you’re in!'}
-    </span>
-  ) : (
-    undefined
-  )
-  const defaultCopy = (
-    <span>
-      {') has invited you to join a team ('}
-      <b>{teamName}</b>
-      {') on Parabol.'}
-    </span>
-  )
-  const copy = meeting ? activeMeetingCopy : defaultCopy
   return (
     <Layout maxWidth={544}>
       <EmailBlock innerMaxWidth={innerMaxWidth}>
         <Header />
-        <p style={emailCopyStyle}>
-          {'Hi '}
-          <span style={emailCopyStyle}>{nameOrEmail}</span>
-          {','}
-        </p>
-        <p style={emailCopyStyle}>
-          <span style={boldStyle}>{inviterName}</span>
-          {' ('}
-          <a href={`mailto:${inviterEmail}`} style={emailLinkStyle}>
-            {inviterEmail}
-          </a>
-          {copy}
-        </p>
-        <Button url={inviteLink}>{buttonLabel}</Button>
+        {meeting ? (
+          <div>
+            <p style={emailCopyStyle}>
+              {'Hi '}
+              <span style={emailCopyStyle}>{nameOrEmail}</span>
+              {','}
+            </p>
+            <p style={emailCopyStyle}>
+              <span style={boldStyle}>{inviterName}</span>
+              {' ('}
+              <a href={`mailto:${inviterEmail}`} style={emailLinkStyle}>
+                {inviterEmail}
+              </a>
+              {`) has started ${meetingCopyLabelLookup[meeting.meetingType]} for your team (`}
+              <b>{teamName}</b>
+              {'). Just a few clicks and you’re in!'}
+            </p>
+            <Button url={inviteLink}>Join {meetingTypeToLabel[meeting.meetingType]} Meeting</Button>
+          </div>
+        ) : (
+          <div>
+            <p style={emailCopyStyle}>
+              {'Hi '}
+              <span style={emailCopyStyle}>{nameOrEmail}</span>
+              {','}
+            </p>
+            <p style={emailCopyStyle}>
+              <span style={boldStyle}>{inviterName}</span>
+              {' ('}
+              <a href={`mailto:${inviterEmail}`} style={emailLinkStyle}>
+                {inviterEmail}
+              </a>
+              {') has invited you to join a team ('}
+              <b>{teamName}</b>
+              {') on Parabol.'}
+            </p>
+            <Button url={inviteLink}>Join Team</Button>
+          </div>
+        )}
         <EmptySpace height={24} />
         <p style={emailCopyStyle}>
           <span style={boldStyle}>{'New to Parabol?'}</span>


### PR DESCRIPTION
### Tests
- [ ] send an invite from Team Dash, see default copy to join team in invite email
- [ ] send an invite from a meeting lobby, see default copy to join team in invite email
- [ ] send an invite from an active Retro meeting, see copy/CTA to join Retro meeting in invite email
- [ ] send an invite from an active Action meeting, see copy/CTA to join Action meeting in invite email
- Note: accepting an invite to a team with an active meeting automatically redirects to the meeting, so I kept the condition simple (without any consideration for time e.g. within the last hour). Once we update the redirect logic and work on more async meetings, we can implement the timing aspect of it.