### PR TITLE
remove need for calling postdeploy in dev

### DIFF
--- a/src/server/graphql/isQueryAllowed.ts
+++ b/src/server/graphql/isQueryAllowed.ts
@@ -1,8 +1,10 @@
 import {isSuperUser} from 'server/utils/authorization'
 import ConnectionContext from '../socketHelpers/ConnectionContext'
 
+const PROD = process.env.NODE_ENV === 'production'
+
 const isQueryAllowed = (_query: string, connectionContext: ConnectionContext) => {
-  return isSuperUser(connectionContext.authToken)
+  return !PROD || isSuperUser(connectionContext.authToken)
 }
 
 export default isQueryAllowed

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -1,3 +1,5 @@
 // this is just to get typescript to stop complaining about imports
 // declare module '*'
 declare module '*.png'
+
+declare const __PRODUCTION__: string

--- a/src/universal/Atmosphere.ts
+++ b/src/universal/Atmosphere.ts
@@ -188,10 +188,19 @@ export default class Atmosphere extends Environment {
     const {name, id: documentId} = operation
     const subKey = Atmosphere.getKey(name, variables)
     await this.upgradeTransport()
-    this.subscriptions[subKey] = (this.transport as GQLTrebuchetClient).subscribe(
-      {documentId, variables},
-      observer
-    )
+    if (!__PRODUCTION__) {
+      const queryMap = await import('../server/graphql/queryMap.json')
+      const query = queryMap[documentId!]
+      this.subscriptions[subKey] = (this.transport as GQLTrebuchetClient).subscribe(
+        {query, variables},
+        observer
+      )
+    } else {
+      this.subscriptions[subKey] = (this.transport as GQLTrebuchetClient).subscribe(
+        {documentId, variables},
+        observer
+      )
+    }
     return this.makeDisposable(subKey)
   }
 
@@ -248,6 +257,12 @@ export default class Atmosphere extends Environment {
     _cacheConfig?: CacheConfig
   ): Promise<ObservableFromValue<GraphQLResponse>> => {
     // await sleep(500)
+    if (!__PRODUCTION__ && request.id) {
+      const queryMap = await import('../server/graphql/queryMap.json')
+      const query = queryMap[request.id]
+      // @ts-ignore
+      return this.transport.fetch({query, variables})
+    }
     const field = request.id ? 'documentId' : 'query'
     const data = request.id || request.text
     // @ts-ignore


### PR DESCRIPTION
this only affects development. everything in production stays the same.

on the client, this sends the full query string instead of a persisted documentId.
on the server, it accepts full length queries.