### PR TITLE
Hotfix mem leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows conventions [outlined here](http://keepachangelog.com/).
 
+## v4.0.1 2019-Aug-09
+
+## Fixed
+* Temporarily remove tags from sentry to see if it caused mem leak
+
 ## v4.0.0 2019-Aug-05
 
 ### Added

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "3.17.2",
+  "version": "4.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/action"

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/action"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/action"

--- a/packages/server/utils/sendToSentry.ts
+++ b/packages/server/utils/sendToSentry.ts
@@ -16,7 +16,7 @@ const sendToSentry = async (error: Error, options: SentryOptions = {}): void => 
     console.error(error)
   }
   const r = getRethink()
-  const {userId, tags} = options
+  const {userId} = options
   let user
   if (userId) {
     user = await r
@@ -27,11 +27,11 @@ const sendToSentry = async (error: Error, options: SentryOptions = {}): void => 
   }
   Sentry.withScope((scope) => {
     user && scope.setUser(user)
-    if (tags) {
-      Object.keys(tags).forEach((tag) => {
-        scope.setTag(tag, tags[tag])
-      })
-    }
+    // if (tags) {
+    //   Object.keys(tags).forEach((tag) => {
+    //     scope.setTag(tag, tags[tag])
+    //   })
+    // }
     Sentry.captureException(error)
   })
 }


### PR DESCRIPTION
Only 50 files changed on the server between v3.15.0 and v3.16.0, which is when the memory leak was introduced.

After some research, it looks like sentry is guilty of having a memory leak built in, and v3.16.0 fixed a bug in our sentry implementation to make it correctly load tags.

I'm undoing that bugfix to see if that fixes the problem.