### PR TITLE
Fix agenda scrolling

### DIFF
--- a/packages/client/components/ActionSidebarAgendaItemsSection.tsx
+++ b/packages/client/components/ActionSidebarAgendaItemsSection.tsx
@@ -9,6 +9,11 @@ import AgendaListAndInput from '../modules/teamDashboard/components/AgendaListAn
 import {NewMeetingPhaseTypeEnum} from '../types/graphql'
 import UNSTARTED_MEETING from '../utils/meetings/unstartedMeeting'
 import MeetingSidebarPhaseItemChild from './MeetingSidebarPhaseItemChild'
+import styled from '@emotion/styled'
+
+const StyledLabelBlock = styled(MeetingSidebarLabelBlock)({
+  marginTop: 16
+})
 
 interface Props {
   gotoStageId: ReturnType<typeof useGotoStageId>
@@ -32,11 +37,10 @@ const ActionSidebarAgendaItemsSection = (props: Props) => {
   }
   return (
     <MeetingSidebarPhaseItemChild>
-      <MeetingSidebarLabelBlock>
+      <StyledLabelBlock>
         <LabelHeading>{'Agenda Topics'}</LabelHeading>
-      </MeetingSidebarLabelBlock>
+      </StyledLabelBlock>
       <AgendaListAndInput
-        isMeeting
         gotoStageId={handleClick}
         isDisabled={phaseType === NewMeetingPhaseTypeEnum.checkin}
         team={team!}

--- a/packages/client/components/MeetingSidebarLabelBlock.js
+++ b/packages/client/components/MeetingSidebarLabelBlock.js
@@ -3,8 +3,8 @@ import {meetingSidebarGutterInner} from '../styles/meeting'
 import styled from '@emotion/styled'
 
 const MeetingSidebarLabelBlock = styled('div')({
-  borderTop: `.0625rem solid ${ui.palette.light}`,
-  margin: `1.25rem 0 0 ${meetingSidebarGutterInner}`,
+  borderTop: `1px solid ${ui.palette.light}`,
+  margin: `0 0 0 ${meetingSidebarGutterInner}`,
   padding: '1rem 0'
 })
 

--- a/packages/client/components/NewMeetingSidebar.tsx
+++ b/packages/client/components/NewMeetingSidebar.tsx
@@ -17,6 +17,7 @@ import {NewMeetingSidebar_viewer} from '../__generated__/NewMeetingSidebar_viewe
 const SidebarHeader = styled('div')({
   alignItems: 'center',
   display: 'flex',
+  paddingBottom: 16,
   position: 'relative'
 })
 
@@ -39,12 +40,21 @@ const SidebarParent = styled('div')({
 const TeamDashboardLink = styled(Link)({
   fontSize: 20,
   fontWeight: 600,
+  lineHeight: '24px',
   paddingLeft: 16,
   wordBreak: 'break-word',
   ':hover': {
     color: PALETTE.TEXT_PURPLE,
     cursor: 'pointer'
   }
+})
+
+const SidebarNavBlock = styled('div')({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  overflow: 'auto',
+  width: '100%'
 })
 
 interface Props {
@@ -68,10 +78,12 @@ const NewMeetingSidebar = (props: Props) => {
         <StyledToggle onClick={toggleSidebar} />
         <TeamDashboardLink to={teamLink}>{teamName}</TeamDashboardLink>
       </SidebarHeader>
-      <MeetingSidebarLabelBlock>
-        <LabelHeading>{`${meetingLabel} Meeting`}</LabelHeading>
-      </MeetingSidebarLabelBlock>
-      {children}
+      <SidebarNavBlock>
+        <MeetingSidebarLabelBlock>
+          <LabelHeading>{`${meetingLabel} Meeting`}</LabelHeading>
+        </MeetingSidebarLabelBlock>
+        {children}
+      </SidebarNavBlock>
       <LogoBlock variant='primary' onClick={handleMenuClick} />
     </SidebarParent>
   )

--- a/packages/client/components/RetroSidebarDiscussSection.tsx
+++ b/packages/client/components/RetroSidebarDiscussSection.tsx
@@ -63,6 +63,10 @@ const ScrollWrapper = styled('div')({
   height: '100%'
 })
 
+const StyledLabelBlock = styled(MeetingSidebarLabelBlock)({
+  marginTop: 16
+})
+
 const RetroSidebarDiscussSection = (props: Props) => {
   const {
     atmosphere,
@@ -116,11 +120,11 @@ const RetroSidebarDiscussSection = (props: Props) => {
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <MeetingSidebarPhaseItemChild>
-        <MeetingSidebarLabelBlock>
+        <StyledLabelBlock>
           <LabelHeading>
             {plural(stages.length, `${RETRO_VOTED_LABEL} ${RETRO_TOPIC_LABEL}`)}
           </LabelHeading>
-        </MeetingSidebarLabelBlock>
+        </StyledLabelBlock>
         <Droppable droppableId={DISCUSSION_TOPIC}>
           {(provided) => {
             return (

--- a/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.js
+++ b/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.js
@@ -99,7 +99,7 @@ const AgendaMain = styled('div')(({hideAgenda}) => ({
 
 const AgendaContent = styled('div')({
   display: 'flex',
-  overflow: 'hidden',
+  overflow: 'auto',
   height: '100%',
   flexDirection: 'column',
   width: '100%'

--- a/packages/client/modules/teamDashboard/components/AgendaList/AgendaList.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaList/AgendaList.tsx
@@ -18,9 +18,6 @@ import useEventCallback from '../../../../hooks/useEventCallback'
 const AgendaListRoot = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  // react-beautiful-dnd supports scrolling on 1 parent
-  // this is where we need it, in order to scroll a long list
-  overflow: 'auto',
   height: '100%', // trickle down height for overflow
   width: '100%'
 })

--- a/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
@@ -8,17 +8,15 @@ import AgendaInput from '../AgendaInput/AgendaInput'
 import AgendaList from '../AgendaList/AgendaList'
 import {meetingSidebarGutter} from '../../../../styles/meeting'
 
-const RootStyles = styled('div')<{isMeeting: boolean | undefined; disabled: boolean}>(
-  ({disabled, isMeeting}) => ({
+const RootStyles = styled('div')<{disabled: boolean}>(
+  ({disabled}) => ({
     display: 'flex',
     flexDirection: 'column',
-    paddingTop: isMeeting ? meetingSidebarGutter : 0,
     position: 'relative',
     width: '100%',
     cursor: disabled ? 'not-allowed' : undefined,
     filter: disabled ? 'blur(3px)' : undefined,
-    pointerEvents: disabled ? 'none' : undefined,
-    height: isMeeting ? '100%' : undefined // 100% is required due to the flex logo in the meeting sidebar
+    pointerEvents: disabled ? 'none' : undefined
   })
 )
 
@@ -26,15 +24,14 @@ interface Props {
   gotoStageId: ReturnType<typeof useGotoStageId> | undefined
   isDisabled?: boolean
   team: AgendaListAndInput_team
-  isMeeting?: boolean
 }
 
 const AgendaListAndInput = (props: Props) => {
   const {gotoStageId, isDisabled, team, isMeeting} = props
   return (
-    <RootStyles disabled={!!isDisabled} isMeeting={isMeeting}>
-      <AgendaList gotoStageId={gotoStageId} team={team} />
+    <RootStyles disabled={!!isDisabled}>
       <AgendaInput disabled={!!isDisabled} team={team} />
+      <AgendaList gotoStageId={gotoStageId} team={team} />
     </RootStyles>
   )
 }

--- a/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
@@ -6,7 +6,6 @@ import graphql from 'babel-plugin-relay/macro'
 import {useGotoStageId} from '../../../../hooks/useMeeting'
 import AgendaInput from '../AgendaInput/AgendaInput'
 import AgendaList from '../AgendaList/AgendaList'
-import {meetingSidebarGutter} from '../../../../styles/meeting'
 
 const RootStyles = styled('div')<{disabled: boolean}>(
   ({disabled}) => ({
@@ -27,11 +26,11 @@ interface Props {
 }
 
 const AgendaListAndInput = (props: Props) => {
-  const {gotoStageId, isDisabled, team, isMeeting} = props
+  const {gotoStageId, isDisabled, team} = props
   return (
     <RootStyles disabled={!!isDisabled}>
-      <AgendaInput disabled={!!isDisabled} team={team} />
       <AgendaList gotoStageId={gotoStageId} team={team} />
+      <AgendaInput disabled={!!isDisabled} team={team} />
     </RootStyles>
   )
 }

--- a/packages/client/modules/teamDashboard/components/AgendaToggle/AgendaToggle.js
+++ b/packages/client/modules/teamDashboard/components/AgendaToggle/AgendaToggle.js
@@ -13,7 +13,7 @@ import IconLabel from '../../../../components/IconLabel'
 const RootBlock = styled('div')({
   alignItems: 'flex-end',
   display: 'flex',
-  padding: `16px ${ui.dashGutterSmall} 5px`,
+  padding: `16px ${ui.dashGutterSmall} 8px`,
   width: '100%',
 
   [ui.dashBreakpoint]: {

--- a/packages/client/modules/teamDashboard/components/AgendaToggle/AgendaToggle.js
+++ b/packages/client/modules/teamDashboard/components/AgendaToggle/AgendaToggle.js
@@ -13,7 +13,7 @@ import IconLabel from '../../../../components/IconLabel'
 const RootBlock = styled('div')({
   alignItems: 'flex-end',
   display: 'flex',
-  padding: `1rem ${ui.dashGutterSmall}`,
+  padding: `16px ${ui.dashGutterSmall} 5px`,
   width: '100%',
 
   [ui.dashBreakpoint]: {


### PR DESCRIPTION
Fixes #3099 

It’s not perfect as we lost behaviors as noted in #2900. Most noticeably the input isn’t always visible. It used to stick to the bottom of the long list when it overflowed. Also, when adding new items it automatically scrolled.

One option we have is to flip the input to be before the list. The pro is it’s always visible. The con is once the list is long, there’s no visual feedback that the item was added to the list.

This is a short-term fix. We need a better, mobile-first design.

### Test
- [ ] On team dash, can scroll to bottom of long agenda list
- [ ] In the check-in meeting, can scroll to bottom meeting nav including long agenda list
- [ ] In the retrospective meeting, can scroll to bottom meeting nav including long list of upvoted topics
- [ ] Tested scrolling in demo left nav (should be the same as the item above)