### PR TITLE
add tolerance to matching hooks to user count events

### DIFF
--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -77,9 +77,8 @@ interface OrgWithQty extends IOrganization {
   stripeSubscriptionId: string
 }
 
-export default async function adjustUserCount(userId: string, orgInput: string | string[], type: InvoiceItemType, options: Options = {}) {
+export default async function adjustUserCount (userId: string, orgInput: string | string[], type: InvoiceItemType, options: Options = {}) {
   const r = getRethink()
-  const now = new Date()
 
   const orgIds = Array.isArray(orgInput) ? orgInput : [orgInput]
   const dbAction = typeLookup[type]
@@ -99,9 +98,10 @@ export default async function adjustUserCount(userId: string, orgInput: string |
         .count()
     })) as OrgWithQty[]
 
+  const now = new Date()
   const prorationDate = toEpochSeconds(type === InvoiceItemType.REMOVE_USER ? options.prorationDate! : now)
   const hooks = orgs.map((org) => {
-    return new InvoiceItemHook({stripeSubscriptionId: org.stripeSubscriptionId, prorationDate, type, userId})
+    return new InvoiceItemHook({stripeSubscriptionId: org.stripeSubscriptionId, prorationDate, type, userId, quantity: org.quantity})
   })
   // wait here to make sure the webhook finds what it's looking for
   await r.table('InvoiceItemHook').insert(hooks)

--- a/packages/server/database/types/InvoiceItemHook.ts
+++ b/packages/server/database/types/InvoiceItemHook.ts
@@ -5,6 +5,7 @@ interface Input {
   id?: string
   stripeSubscriptionId: string
   prorationDate: number | false
+  quantity: number
   type: InvoiceItemType
   userId: string
 }
@@ -13,12 +14,14 @@ export default class InvoiceItemHook {
   id: string
   stripeSubscriptionId: string
   prorationDate: number | false
+  quantity: number
   type: InvoiceItemType
   userId: string
 
-  constructor(input: Input) {
-    const {id, userId, type, prorationDate, stripeSubscriptionId} = input
+  constructor (input: Input) {
+    const {id, quantity, userId, type, prorationDate, stripeSubscriptionId} = input
     this.id = id || shortid.generate()
+    this.quantity = quantity
     this.userId = userId
     this.type = type
     this.prorationDate = prorationDate

--- a/packages/server/graphql/intranetSchema/mutations/stripeUpdateInvoiceItem.ts
+++ b/packages/server/graphql/intranetSchema/mutations/stripeUpdateInvoiceItem.ts
@@ -3,6 +3,21 @@ import {InternalContext} from '../../graphql'
 import {isSuperUser} from '../../../utils/authorization'
 import getRethink from '../../../database/rethinkDriver'
 import StripeManager from '../../../utils/StripeManager'
+import InvoiceItemHook from '../../../database/types/InvoiceItemHook'
+
+const MAX_STRIPE_DELAY = 3 // seconds
+
+const getBestHook = (possibleHooks: InvoiceItemHook[], hookQuantity: number) => {
+  if (possibleHooks.length === 1) return possibleHooks[0]
+  for (let i =0 ; i < possibleHooks.length; i++) {
+    const curHook = possibleHooks[i]
+    const {quantity} = curHook
+    // if 2 hooks occurred at the same second, try grabbing the one with the accurate quantity
+    if (quantity === hookQuantity) return curHook
+  }
+  console.log('imperfect invoice item hook selected', possibleHooks[0])
+  return possibleHooks[0]
+}
 
 export default {
   name: 'StripeUpdateInvoiceItem',
@@ -26,17 +41,26 @@ export default {
     const invoiceItem = await manager.retrieveInvoiceItem(invoiceItemId)
     const {
       subscription,
-      period: {start}
+      period: {start},
+      quantity,
+      amount
     } = invoiceItem
-    const hook = await r
+
+    const possibleHooks = await r
       .table('InvoiceItemHook')
-      .getAll(start, {index: 'prorationDate'})
+      .between(start - MAX_STRIPE_DELAY, start, {index: 'prorationDate', rightBound: 'closed'})
       .filter({stripeSubscriptionId: subscription})
-      .nth(0)
-      .default(null)
+      .orderBy(r.desc('prorationDate'))
 
-    if (!hook) return false
+    if (possibleHooks.length === 0) {
+      console.log('No hook found for', invoiceItemId)
+      return false
+    }
 
+    // if amount < 0, then the line item is a refund for unused time. else, it is a charge for remaining time
+    // the InvoiceItemHook.quantity is for the remaining time
+    const hookQty = amount < 0 ? quantity - 1 : quantity
+    const hook = getBestHook(possibleHooks, hookQty)
     const {type, userId} = hook
     await manager.updateInvoiceItem(invoiceItemId, type, userId)
     return true

--- a/packages/server/graphql/types/InvoiceLineItemDetails.ts
+++ b/packages/server/graphql/types/InvoiceLineItemDetails.ts
@@ -16,7 +16,9 @@ const InvoiceLineItemDetails = new GraphQLObjectType({
     },
     email: {
       type: new GraphQLNonNull(GraphQLEmailType),
-      description: 'The email affected by this line item change'
+      description: 'The email affected by this line item change',
+      // the request could come before the hook fires
+      resolve: ({email}) => email || '*New User*'
     },
     endAt: {
       type: GraphQLISO8601Type,


### PR DESCRIPTION
fixes #3229 by searching for invoices within 3 seconds of the time that the invoice item was created.