### PR TITLE
show body scroll on sidebar unmount

### DIFF
--- a/packages/client/components/SwipeableDashSidebar.tsx
+++ b/packages/client/components/SwipeableDashSidebar.tsx
@@ -111,6 +111,7 @@ const SwipeableDashSidebar = (props: Props) => {
     openPortal()
     return () => {
       window.clearTimeout(swipe.peekTimeout)
+      swipe.showBodyScroll && swipe.showBodyScroll()
     }
   }, [/* eslint-disable-line react-hooks/exhaustive-deps*/])
 


### PR DESCRIPTION
Still can't reproduce this, so I'm flying blind, but it would make sense that this would fix #3120  

TEST
- [ ] run a meeting, get to the summary & you can scroll.