### PR TITLE
remove removal of non-existant table

### DIFF
--- a/packages/server/database/migrations/20190912093945-remove-legacy-tables.js
+++ b/packages/server/database/migrations/20190912093945-remove-legacy-tables.js
@@ -3,7 +3,6 @@ exports.up = async (r) => {
     await Promise.all(
       [
         r.tableDrop('Meeting'),
-        r.tableDrop('AtlassianProject'),
         r.tableDrop('Outcome')
       ])
   } catch (e) {
@@ -16,7 +15,6 @@ exports.down = async (r) => {
     await Promise.all(
       [
         r.tableCreate('Meeting'),
-        r.tableCreate('AtlassianProject'),
         r.tableCreate('Outcome')
       ])
   } catch (e) {


### PR DESCRIPTION

Starting from a clean DB, the table `'AtlassianProject'` never gets created. Removing the table from this migration ensures folks can build up our database schema from scratch