### PR TITLE
Fix 3276 agenda dnd during retro

### DIFF
--- a/packages/server/graphql/mutations/updateAgendaItem.ts
+++ b/packages/server/graphql/mutations/updateAgendaItem.ts
@@ -22,7 +22,7 @@ export default {
       description: 'The updated item including an id, content, status, sortOrder'
     }
   },
-  async resolve (
+  async resolve(
     _source,
     {updatedAgendaItem},
     {authToken, dataLoader, socketId: mutatorId}: GQLContext
@@ -60,31 +60,59 @@ export default {
       })
     const team = await dataLoader.get('teams').load(teamId)
     const {meetingId} = team
+    // if (meetingId) {
+    //   const meeting = (await r.table('NewMeeting').get(meetingId)) as Meeting | null
+    //   if (!meeting || meeting.meetingType !== ACTION) {
+    //     return standardError(new Error('Invalid meetingId'))
+    //   }
+    //   const {phases} = meeting
+    //   const agendaItemPhase = phases.find(
+    //     (phase) => phase.phaseType === AGENDA_ITEMS
+    //   )! as AgendaItemsPhase
+    //   const {stages} = agendaItemPhase
+    //   const agendaItems = (await dataLoader
+    //     .get('agendaItemsByTeamId')
+    //     .load(teamId)) as IAgendaItem[]
+    //   const getSortOrder = (stage: AgendaItemsStage) => {
+    //     const agendaItem = agendaItems.find((item) => item.id === stage.agendaItemId)
+    //     return (agendaItem && agendaItem.sortOrder) || 0
+    //   }
+    //   stages.sort((a, b) => (getSortOrder(a) > getSortOrder(b) ? 1 : -1))
+    //   await r
+    //     .table('NewMeeting')
+    //     .get(meetingId)
+    //     .update({
+    //       phases
+    //     })
+    // }
+
     if (meetingId) {
       const meeting = (await r.table('NewMeeting').get(meetingId)) as Meeting | null
-      if (!meeting || meeting.meetingType !== ACTION) {
-        return standardError(new Error('Invalid meetingId'))
+      if (meeting && meeting.meetingType === ACTION) {
+        const {phases} = meeting
+        const agendaItemPhase = phases.find(
+          (phase) => phase.phaseType === AGENDA_ITEMS
+        )! as AgendaItemsPhase
+        const {stages} = agendaItemPhase
+        const agendaItems = (await dataLoader
+          .get('agendaItemsByTeamId')
+          .load(teamId)) as IAgendaItem[]
+        const getSortOrder = (stage: AgendaItemsStage) => {
+          const agendaItem = agendaItems.find((item) => item.id === stage.agendaItemId)
+          return (agendaItem && agendaItem.sortOrder) || 0
+        }
+        stages.sort((a, b) => (getSortOrder(a) > getSortOrder(b) ? 1 : -1))
+        await r
+          .table('NewMeeting')
+          .get(meetingId)
+          .update({
+            phases
+          })
       }
-      const {phases} = meeting
-      const agendaItemPhase = phases.find(
-        (phase) => phase.phaseType === AGENDA_ITEMS
-      )! as AgendaItemsPhase
-      const {stages} = agendaItemPhase
-      const agendaItems = (await dataLoader
-        .get('agendaItemsByTeamId')
-        .load(teamId)) as IAgendaItem[]
-      const getSortOrder = (stage: AgendaItemsStage) => {
-        const agendaItem = agendaItems.find((item) => item.id === stage.agendaItemId)
-        return (agendaItem && agendaItem.sortOrder) || 0
-      }
-      stages.sort((a, b) => (getSortOrder(a) > getSortOrder(b) ? 1 : -1))
-      await r
-        .table('NewMeeting')
-        .get(meetingId)
-        .update({
-          phases
-        })
     }
+
+    console.log('did updateAgendaItem.ts')
+
     const data = {agendaItemId, meetingId}
     publish(TEAM, teamId, UpdateAgendaItemPayload, data, subOptions)
     return data

--- a/packages/server/graphql/mutations/updateAgendaItem.ts
+++ b/packages/server/graphql/mutations/updateAgendaItem.ts
@@ -60,35 +60,13 @@ export default {
       })
     const team = await dataLoader.get('teams').load(teamId)
     const {meetingId} = team
-    // if (meetingId) {
-    //   const meeting = (await r.table('NewMeeting').get(meetingId)) as Meeting | null
-    //   if (!meeting || meeting.meetingType !== ACTION) {
-    //     return standardError(new Error('Invalid meetingId'))
-    //   }
-    //   const {phases} = meeting
-    //   const agendaItemPhase = phases.find(
-    //     (phase) => phase.phaseType === AGENDA_ITEMS
-    //   )! as AgendaItemsPhase
-    //   const {stages} = agendaItemPhase
-    //   const agendaItems = (await dataLoader
-    //     .get('agendaItemsByTeamId')
-    //     .load(teamId)) as IAgendaItem[]
-    //   const getSortOrder = (stage: AgendaItemsStage) => {
-    //     const agendaItem = agendaItems.find((item) => item.id === stage.agendaItemId)
-    //     return (agendaItem && agendaItem.sortOrder) || 0
-    //   }
-    //   stages.sort((a, b) => (getSortOrder(a) > getSortOrder(b) ? 1 : -1))
-    //   await r
-    //     .table('NewMeeting')
-    //     .get(meetingId)
-    //     .update({
-    //       phases
-    //     })
-    // }
 
     if (meetingId) {
       const meeting = (await r.table('NewMeeting').get(meetingId)) as Meeting | null
-      if (meeting && meeting.meetingType === ACTION) {
+      if (!meeting) {
+        return standardError(new Error('Invalid meetingId'))
+      }
+      if (meeting.meetingType === ACTION) {
         const {phases} = meeting
         const agendaItemPhase = phases.find(
           (phase) => phase.phaseType === AGENDA_ITEMS
@@ -110,8 +88,6 @@ export default {
           })
       }
     }
-
-    console.log('did updateAgendaItem.ts')
 
     const data = {agendaItemId, meetingId}
     publish(TEAM, teamId, UpdateAgendaItemPayload, data, subOptions)


### PR DESCRIPTION
Fixes #3276 

### Tests
- [ ] Users can sort agenda items from Team Dash or Action Lobby when there is no active meeting. The next Action meeting navigates each agenda item in the latest order.
- [ ] Users can sort agenda items from Team Dash when there is an active Retro meeting. The next Action meeting navigates each agenda item in the latest order.
- [ ] Users can sort agenda items from Team Dash or Action Meeting when there is an active Action meeting. The active Action meeting navigates each agenda item in the latest order.
- [ ] Smoke test Action meeting
- [ ] Smoke test Retro meeting
- [ ] Smoke test Demo