### PR TITLE
Meeting sidebar updates

### DIFF
--- a/packages/client/components/ActionMeetingAgendaItems.tsx
+++ b/packages/client/components/ActionMeetingAgendaItems.tsx
@@ -22,9 +22,11 @@ import MeetingAgendaCards from '../modules/meeting/components/MeetingAgendaCards
 import EditorHelpModalContainer from '../containers/EditorHelpModalContainer/EditorHelpModalContainer'
 import findStageAfterId from '../utils/meetings/findStageAfterId'
 import {NewMeetingPhaseTypeEnum} from '../types/graphql'
+import {phaseLabelLookup} from '../utils/meetings/lookups'
 import useTimeoutWithReset from '../hooks/useTimeoutWithReset'
 import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
 import PhaseWrapper from './PhaseWrapper'
+import PhaseHeaderTitle from './PhaseHeaderTitle'
 
 const BottomControlSpacer = styled('div')({
   minWidth: 90
@@ -117,7 +119,11 @@ const ActionMeetingAgendaItems = (props: Props) => {
           avatarGroup={avatarGroup}
           isMeetingSidebarCollapsed={!!isMeetingSidebarCollapsed}
           toggleSidebar={toggleSidebar}
-        />
+        >
+          <PhaseHeaderTitle>
+            {phaseLabelLookup[NewMeetingPhaseTypeEnum.agendaitems]}
+          </PhaseHeaderTitle>
+        </MeetingTopBar>
         <PhaseWrapper>
           <AgendaVerbatim>
             <Avatar picture={picture} size={64} />

--- a/packages/client/components/ActionMeetingFirstCall.tsx
+++ b/packages/client/components/ActionMeetingFirstCall.tsx
@@ -20,10 +20,12 @@ import MeetingPhaseHeading from '../modules/meeting/components/MeetingPhaseHeadi
 import {AGENDA_ITEM_LABEL, AGENDA_ITEMS} from '../utils/constants'
 import handleRightArrow from '../utils/handleRightArrow'
 import lazyPreload from '../utils/lazyPreload'
+import {NewMeetingPhaseTypeEnum} from '../types/graphql'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
 import EndMeetingButton from './EndMeetingButton'
 import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
 import PhaseWrapper from './PhaseWrapper'
+import PhaseHeaderTitle from './PhaseHeaderTitle'
 
 const BottomControlSpacer = styled('div')({
   minWidth: 90
@@ -65,7 +67,11 @@ const ActionMeetingFirstCall = (props: Props) => {
           avatarGroup={avatarGroup}
           isMeetingSidebarCollapsed={!!isMeetingSidebarCollapsed}
           toggleSidebar={toggleSidebar}
-        />
+        >
+          <PhaseHeaderTitle>
+            {phaseLabelLookup[NewMeetingPhaseTypeEnum.agendaitems]}
+          </PhaseHeaderTitle>
+        </MeetingTopBar>
         <PhaseWrapper>
           <FirstCallWrapper>
             <MeetingPhaseHeading>{'Now, what do you need?'}</MeetingPhaseHeading>

--- a/packages/client/components/ActionMeetingLastCall.tsx
+++ b/packages/client/components/ActionMeetingLastCall.tsx
@@ -19,8 +19,10 @@ import PrimaryButton from './PrimaryButton'
 import EndNewMeetingMutation from '../mutations/EndNewMeetingMutation'
 import useRouter from '../hooks/useRouter'
 import {NewMeetingPhaseTypeEnum} from '../types/graphql'
+import {phaseLabelLookup} from '../utils/meetings/lookups'
 import plural from '../utils/plural'
 import useMutationProps from '../hooks/useMutationProps'
+import PhaseHeaderTitle from './PhaseHeaderTitle'
 
 interface Props extends ActionMeetingPhaseProps {
   team: ActionMeetingLastCall_team
@@ -69,7 +71,9 @@ const ActionMeetingLastCall = (props: Props) => {
         avatarGroup={avatarGroup}
         isMeetingSidebarCollapsed={!!isMeetingSidebarCollapsed}
         toggleSidebar={toggleSidebar}
-      />
+      >
+        <PhaseHeaderTitle>{phaseLabelLookup[NewMeetingPhaseTypeEnum.agendaitems]}</PhaseHeaderTitle>
+      </MeetingTopBar>
       <ErrorBoundary>
         <LastCallWrapper>
           <MeetingPhaseHeading>

--- a/packages/client/components/MeetingSubnavItem.tsx
+++ b/packages/client/components/MeetingSubnavItem.tsx
@@ -25,6 +25,7 @@ const ItemRoot = styled('div')<ItemRootProps>(
     borderRadius: '0 4px 4px 0',
     color: PALETTE.TEXT_MAIN,
     display: 'flex',
+    flexShrink: 0,
     fontSize: 14,
     fontWeight: 400,
     minHeight: 40,

--- a/packages/client/components/NewMeetingSidebarPhaseListItem.tsx
+++ b/packages/client/components/NewMeetingSidebarPhaseListItem.tsx
@@ -5,16 +5,17 @@ import {NavSidebar} from '../types/constEnums'
 import {phaseIconLookup, phaseLabelLookup} from '../utils/meetings/lookups'
 import Icon from './Icon'
 import Badge from './Badge/Badge'
+import {NewMeetingPhaseTypeEnum} from '../types/graphql'
 
-const NavListItem = styled('li')({
+const NavListItem = styled('li')<{phaseType: string}>(({phaseType}) => ({
   fontWeight: 600,
   display: 'flex',
   flexDirection: 'column',
   margin: 0,
   // hack to work around broken flexbox
   // https://bugs.chromium.org/p/chromium/issues/detail?id=927066
-  minHeight: 40
-})
+  minHeight: phaseType === NewMeetingPhaseTypeEnum.agendaitems ? 98 : 40
+}))
 
 const NavItemIcon = styled(Icon)<{isUnsyncedFacilitatorPhase: boolean}>(
   {
@@ -139,7 +140,7 @@ const NewMeetingSidebarPhaseListItem = (props: Props) => {
   const icon = phaseIconLookup[phaseType]
   const showPhaseCount = Boolean(phaseCount || phaseCount === 0)
   return (
-    <NavListItem>
+    <NavListItem phaseType={phaseType}>
       <NavListItemLink
         isActive={isActive}
         isCollapsible={isCollapsible}

--- a/packages/client/modules/teamDashboard/components/AgendaInput/AgendaInput.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaInput/AgendaInput.tsx
@@ -78,6 +78,7 @@ const StyledIcon = styled(Icon)({
 })
 
 interface Props {
+  className?: string
   disabled: boolean
   team: AgendaInput_team
 }
@@ -102,7 +103,7 @@ const AgendaInput = (props: Props) => {
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
   const {newItem} = fields
   const {resetValue, value} = newItem
-  const {disabled, team} = props
+  const {className, disabled, team} = props
   const {id: teamId, agendaItems} = team
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -130,7 +131,7 @@ const AgendaInput = (props: Props) => {
 
   const showTooltip = Boolean(agendaItems.length > 0 && !disabled)
   return (
-    <AgendaInputBlock>
+    <AgendaInputBlock className={className}>
       <Tooltip
         delay={1000}
         hideOnFocus

--- a/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
@@ -23,6 +23,10 @@ const RootStyles = styled('div')<{isMeeting: boolean | undefined; disabled: bool
   })
 )
 
+const StyledAgendaInput = styled(AgendaInput)<{isMeeting: boolean | undefined}>(({isMeeting}) => ({
+  paddingRight: isMeeting ? 8 : undefined
+}))
+
 interface Props {
   gotoStageId?: ReturnType<typeof useGotoStageId>
   isDisabled?: boolean
@@ -35,7 +39,7 @@ const AgendaListAndInput = (props: Props) => {
   return (
     <RootStyles disabled={!!isDisabled} isMeeting={isMeeting}>
       <AgendaList gotoStageId={gotoStageId} team={team} />
-      <AgendaInput disabled={!!isDisabled} team={team} />
+      <StyledAgendaInput disabled={!!isDisabled} isMeeting={isMeeting} team={team} />
     </RootStyles>
   )
 }

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -5372,7 +5372,7 @@ export interface ISegmentEventTrackOptions {
 export interface ISelectRetroTemplatePayload {
   __typename: 'SelectRetroTemplatePayload'
   error: IStandardMutationError | null
-  retroMeetingSettings: IRetrospectiveMeetingSettings
+  retroMeetingSettings: IRetrospectiveMeetingSettings | null
 }
 
 export type SetOrgUserRolePayload = ISetOrgUserRoleAddedPayload | ISetOrgUserRoleRemovedPayload


### PR DESCRIPTION
- fixes #3280 
- fixes #3305 

### Tests
- [ ] The meeting subnav item for a team member with a wrapping name doesn’t collapse during Social Check-In or Solo Updates phases
- [ ] The agenda input has a right gutter in the meeting nav of 8px instead of running into the edge of the sidebar box
- [ ] The team agenda nav item has a min-height that prevents collapsing so that the input is never hidden
- [ ] Sidebar looks good at mobile breakpoints (suggested, use Chrome emulator) during the Action meeting
- [ ] Team Agenda has its phase label in the top bar