### PR TITLE
zIndex scrubbed

### DIFF
--- a/packages/client/components/Dashboard/DashModal.tsx
+++ b/packages/client/components/Dashboard/DashModal.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import {modalShadow} from '../../styles/elevation'
 import {PALETTE} from '../../styles/paletteV2'
 import {DECELERATE} from '../../styles/animation'
-import {Radius} from '../../types/constEnums'
+import {Radius, ZIndex} from '../../types/constEnums'
 
 const animateIn = {
   '0%': {
@@ -29,7 +29,7 @@ const Backdrop = styled('div')({
   right: 0,
   textAlign: 'center',
   top: 0,
-  zIndex: 200
+  zIndex: ZIndex.DIALOG
 })
 
 const Modal = styled('div')({

--- a/packages/client/components/EditableAvatar/EditableAvatar.tsx
+++ b/packages/client/components/EditableAvatar/EditableAvatar.tsx
@@ -38,7 +38,7 @@ const EditableAvatarEditOverlay = styled('div')<Pick<Props, 'hasPanel' | 'size'>
     position: 'absolute',
     top: 0,
     width: size,
-    zIndex: 200,
+    zIndex: 2,
 
     '&:hover': {
       opacity: 0.75,
@@ -52,7 +52,7 @@ const EditableAvatarImgBlock = styled('div')<Pick<Props, 'hasPanel' | 'size'>>(
     height: hasPanel ? size - panelPaddingHorizontal : size,
     position: 'relative',
     width: hasPanel ? size - panelPaddingHorizontal : size,
-    zIndex: 100
+    zIndex: 1
   })
 )
 

--- a/packages/client/components/LoadableModalAbstract.tsx
+++ b/packages/client/components/LoadableModalAbstract.tsx
@@ -4,6 +4,7 @@ import AnimatedFade from './AnimatedFade'
 import Modal from './Modal'
 import {PALETTE} from '../styles/paletteV2'
 import {modalShadow} from '../styles/elevation'
+import {ZIndex} from '../types/constEnums'
 import {WithAnimatedPortalProps} from '../decorators/withAnimatedPortal'
 
 const ModalBlock = styled('div')({
@@ -15,7 +16,7 @@ const ModalBlock = styled('div')({
   position: 'fixed',
   top: 0,
   width: '100%',
-  zIndex: 400
+  zIndex: ZIndex.DIALOG
 })
 
 const ModalContents = styled('div')({

--- a/packages/client/components/MeetingArea.tsx
+++ b/packages/client/components/MeetingArea.tsx
@@ -3,8 +3,6 @@ import styled from '@emotion/styled'
 const MeetingArea = styled('div')({
   display: 'flex',
   width: '100%'
-  // This just seemed wrong & blocked modals
-  // zIndex: 100
 })
 
 export default MeetingArea

--- a/packages/client/components/MeetingHelp/HelpMenuToggle.tsx
+++ b/packages/client/components/MeetingHelp/HelpMenuToggle.tsx
@@ -2,6 +2,7 @@ import IconLabel from '../IconLabel'
 import React, {forwardRef, Ref} from 'react'
 import styled from '@emotion/styled'
 import FloatingActionButton from '../FloatingActionButton'
+import {ZIndex} from '../../types/constEnums'
 
 const StyledButton = styled(FloatingActionButton)({
   bottom: 20,
@@ -11,7 +12,7 @@ const StyledButton = styled(FloatingActionButton)({
   position: 'absolute',
   right: 20,
   width: 32,
-  zIndex: 200
+  zIndex: ZIndex.FAB
 })
 
 interface Props {

--- a/packages/client/components/ReflectionCard/ReflectionCardDeleteButton.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCardDeleteButton.tsx
@@ -38,7 +38,7 @@ const Background = styled('div')({
   position: 'absolute',
   top: 4,
   width: 10,
-  zIndex: 100
+  zIndex: 1
 })
 
 const StyledIcon = styled(Icon)({
@@ -47,7 +47,7 @@ const StyledIcon = styled(Icon)({
   fontSize: ICON_SIZE.MD18,
   position: 'relative',
   textAlign: 'center',
-  zIndex: 200
+  zIndex: 2
 })
 
 class ReflectionCardDeleteButton extends Component<Props> {

--- a/packages/client/components/RetroReflectPhase/ExpandedReflectionStack.tsx
+++ b/packages/client/components/RetroReflectPhase/ExpandedReflectionStack.tsx
@@ -1,7 +1,6 @@
 import React, {ReactNode, Ref, useMemo} from 'react'
 import styled from '@emotion/styled'
 import getBBox from './getBBox'
-import {ZINDEX_MODAL} from '../../styles/elevation'
 import {PALETTE} from '../../styles/paletteV2'
 import {BBox} from '../../types/animations'
 import {RefCallbackInstance} from '../../types/generics'
@@ -14,7 +13,7 @@ const PortalBlock = styled('div')({
   position: 'absolute',
   top: 0,
   width: '100%',
-  zIndex: ZIndex.MODAL
+  zIndex: ZIndex.DIALOG
 })
 
 const Scrim = styled('div')({
@@ -28,7 +27,7 @@ const PhaseArea = styled('div')<{phaseBBox: BBox}>(({phaseBBox}) => ({
   justifyContent: 'center',
   alignItems: 'center',
   position: 'absolute',
-  zIndex: ZINDEX_MODAL,
+  zIndex: ZIndex.DIALOG,
   // use phaseBBox to center in the phase, not the screen (ignores left nav & fac nav bar)
   top: phaseBBox.top,
   left: phaseBBox.left,

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -9,7 +9,7 @@ import useAtmosphere from '../../hooks/useAtmosphere'
 import useMutationProps from '../../hooks/useMutationProps'
 import getBBox from './getBBox'
 import styled from '@emotion/styled'
-import {BezierCurve} from '../../types/constEnums'
+import {BezierCurve, ZIndex} from '../../types/constEnums'
 import {ReflectColumnCardInFlight} from './PhaseItemColumn'
 import {Elevation} from '../../styles/elevation'
 import usePortal from '../../hooks/usePortal'
@@ -22,7 +22,7 @@ const CardInFlightStyles = styled(ReflectionCardRoot)<{transform: string; isStar
     top: 0,
     transform,
     transition: `all ${FLIGHT_TIME}ms ${BezierCurve.DECELERATE}`,
-    zIndex: 10
+    zIndex: ZIndex.REFLECTION_IN_FLIGHT
   })
 )
 

--- a/packages/client/components/RetroReflectPhase/StageTimerDisplayGauge.tsx
+++ b/packages/client/components/RetroReflectPhase/StageTimerDisplayGauge.tsx
@@ -3,8 +3,9 @@ import styled from '@emotion/styled'
 import {countdown} from '../../utils/date/relativeDate'
 import {PALETTE} from '../../styles/paletteV2'
 import useRefreshInterval from '../../hooks/useRefreshInterval'
-import {buttonRaisedShadow} from '../../styles/elevation'
+import {snackbarShadow} from '../../styles/elevation'
 import {DECELERATE, fadeIn} from '../../styles/animation'
+import {ZIndex} from '../../types/constEnums'
 
 interface Props {
   endTime: string
@@ -15,7 +16,7 @@ const Gauge = styled('div')<{isTimeUp: boolean}>(({isTimeUp}) => ({
   animation: `${fadeIn.toString()} 300ms ${DECELERATE}`,
   color: isTimeUp ? PALETTE.TEXT_MAIN : '#FFFFFF',
   background: isTimeUp ? PALETTE.BACKGROUND_YELLOW : PALETTE.BACKGROUND_GREEN,
-  boxShadow: buttonRaisedShadow,
+  boxShadow: snackbarShadow,
   borderRadius: 2,
   display: 'flex',
   fontWeight: 600,
@@ -24,7 +25,7 @@ const Gauge = styled('div')<{isTimeUp: boolean}>(({isTimeUp}) => ({
   padding: 8,
   transition: `background 1s ${DECELERATE}`,
   userSelect: 'none',
-  zIndex: 8 // same as boxShadown elevation (required to show timbebox in reflect phase)
+  zIndex: ZIndex.SNACKBAR
 }))
 
 const StageTimerDisplayGauge = (props: Props) => {

--- a/packages/client/components/StaticSidebar.tsx
+++ b/packages/client/components/StaticSidebar.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import React, {ReactNode} from 'react'
 import {DECELERATE} from '../styles/animation'
-import {NavSidebar} from '../types/constEnums'
+import {NavSidebar, ZIndex} from '../types/constEnums'
 
 const DURATION = 200
 
@@ -14,7 +14,7 @@ const Placeholder = styled('div')<StyleProps>(({isOpen}) => ({
   // changing width is expensive, but this is only run on non-mobile devices, so it's not horrible & looks better than alternatives
   transition: `all ${DURATION}ms ${DECELERATE}`,
   // needs to be above the main view area
-  zIndex: 200
+  zIndex: ZIndex.SIDE_SHEET
 }))
 
 const Fixed = styled('div')<StyleProps>(({isOpen}) => ({

--- a/packages/client/components/TeamInvitationMeetingAbstract.tsx
+++ b/packages/client/components/TeamInvitationMeetingAbstract.tsx
@@ -22,7 +22,7 @@ const CenteredBlock = styled('div')({
   maxWidth: '100%',
   padding: '2rem 1rem',
   width: '100%',
-  zIndex: 300
+  zIndex: 3
 })
 
 const Backdrop = styled('div')({
@@ -32,7 +32,7 @@ const Backdrop = styled('div')({
   position: 'absolute',
   top: 0,
   width: '100vw',
-  zIndex: 200
+  zIndex: 2
 })
 
 const MeetingAbstractContainer = styled(PageContainer)({
@@ -43,7 +43,7 @@ const MeetingAbstractContainer = styled(PageContainer)({
   minWidth: '100vw',
   position: 'absolute',
   top: 0,
-  zIndex: 100
+  zIndex: 1
 })
 
 const AbstractSidebar = styled('div')({

--- a/packages/client/components/Tooltip/Tooltip.js
+++ b/packages/client/components/Tooltip/Tooltip.js
@@ -11,7 +11,7 @@ import withCoordsV2 from '../../decorators/withCoordsV2'
 const ModalBlock = styled('div')(({maxWidth}) => ({
   padding: '4px 8px',
   position: 'absolute',
-  zIndex: 400,
+  zIndex: 16, // at least equal to SIDEBAR, this component deprecated
   maxWidth
 }))
 

--- a/packages/client/hooks/useMenuPortal.tsx
+++ b/packages/client/hooks/useMenuPortal.tsx
@@ -14,7 +14,7 @@ import {Duration, ZIndex} from '../types/constEnums'
 const MenuBlock = styled('div')({
   // no margins or paddings since they could force it too low & cause a scrollbar to appear
   position: 'absolute',
-  zIndex: ZIndex.DIALOG
+  zIndex: ZIndex.MENU
 })
 
 const useMenuPortal = (

--- a/packages/client/hooks/useMenuPortal.tsx
+++ b/packages/client/hooks/useMenuPortal.tsx
@@ -14,7 +14,7 @@ import {Duration, ZIndex} from '../types/constEnums'
 const MenuBlock = styled('div')({
   // no margins or paddings since they could force it too low & cause a scrollbar to appear
   position: 'absolute',
-  zIndex: ZIndex.MODAL
+  zIndex: ZIndex.DIALOG
 })
 
 const useMenuPortal = (

--- a/packages/client/hooks/useModalPortal.tsx
+++ b/packages/client/hooks/useModalPortal.tsx
@@ -19,7 +19,7 @@ const ModalBlock = styled('div')({
   position: 'absolute',
   top: 0,
   width: '100%',
-  zIndex: ZIndex.MODAL
+  zIndex: ZIndex.DIALOG
 })
 
 const backdropStyles = {

--- a/packages/client/hooks/useTooltipPortal.tsx
+++ b/packages/client/hooks/useTooltipPortal.tsx
@@ -7,7 +7,7 @@ import {ZIndex} from '../types/constEnums'
 
 const TooltipBlock = styled('div')({
   position: 'absolute',
-  zIndex: ZIndex.DIALOG
+  zIndex: ZIndex.TOOLTIP
 })
 
 const useTooltipPortal = (

--- a/packages/client/hooks/useTooltipPortal.tsx
+++ b/packages/client/hooks/useTooltipPortal.tsx
@@ -7,7 +7,7 @@ import {ZIndex} from '../types/constEnums'
 
 const TooltipBlock = styled('div')({
   position: 'absolute',
-  zIndex: ZIndex.MODAL
+  zIndex: ZIndex.DIALOG
 })
 
 const useTooltipPortal = (

--- a/packages/client/modules/meeting/components/MeetingControlBar/MeetingFacilitatorBar.tsx
+++ b/packages/client/modules/meeting/components/MeetingControlBar/MeetingFacilitatorBar.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import {bottomBarShadow, desktopBarShadow} from '../../../../styles/elevation'
 import {PALETTE} from '../../../../styles/paletteV2'
-import {Breakpoint} from '../../../../types/constEnums'
+import {Breakpoint, ZIndex} from '../../../../types/constEnums'
 import React, {ReactNode} from 'react'
 
 const MeetingFacilitatorBarStyles = styled('div')({
@@ -17,11 +17,11 @@ const MeetingFacilitatorBarStyles = styled('div')({
   minHeight: 56,
   overflowX: 'auto',
   width: '100%',
-  zIndex: 8,
+  zIndex: ZIndex.BOTTOM_BAR,
 
   [`@media screen and (min-width: ${Breakpoint.MEETING_FACILITATOR_BAR}px)`]: {
     boxShadow: desktopBarShadow,
-    zIndex: 4
+    zIndex: ZIndex.BOTTOM_BAR_DESKTOP
   }
 })
 

--- a/packages/client/modules/meeting/components/RejoinFacilitatorButton/RejoinFacilitatorButton.tsx
+++ b/packages/client/modules/meeting/components/RejoinFacilitatorButton/RejoinFacilitatorButton.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import styled from '@emotion/styled'
 import FloatingActionButton from '../../../../components/FloatingActionButton'
 import IconLabel from '../../../../components/IconLabel'
+import {ZIndex} from '../../../../types/constEnums'
 
 const RejoinButton = styled(FloatingActionButton)({
   bottom: '1.25rem',
   position: 'fixed',
   right: '4.5rem',
-  zIndex: 400
+  zIndex: ZIndex.FAB
 })
 
 interface Props {

--- a/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.tsx
@@ -9,7 +9,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {desktopSidebarShadow, navDrawerShadow} from '../../../../styles/elevation'
 import {AgendaAndTasks_viewer} from '__generated__/AgendaAndTasks_viewer.graphql'
-import {RightSidebar} from '../../../../types/constEnums'
+import {RightSidebar, ZIndex} from '../../../../types/constEnums'
 
 const RootBlock = styled('div')({
   display: 'flex',
@@ -68,7 +68,7 @@ const AgendaMain = styled('div')<{hideAgenda: boolean | null}>(({hideAgenda}) =>
   '@media screen and (min-width: 800px)': {
     boxShadow: hideAgenda ? 'none' : desktopSidebarShadow
   },
-  zIndex: 2 // make sure shadow is above cards
+  zIndex: ZIndex.SIDE_SHEET // make sure shadow is above cards
 }))
 
 const AgendaContent = styled('div')({

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingReassuranceQuote.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingReassuranceQuote.tsx
@@ -68,7 +68,7 @@ const PictureBlock = styled('div')({
     position: 'absolute',
     top: 0,
     width: 48,
-    zIndex: 200
+    zIndex: 2
   }
 })
 

--- a/packages/client/styles/elevation.ts
+++ b/packages/client/styles/elevation.ts
@@ -55,7 +55,6 @@ export const fabShadow = Elevation.Z6
 export const fabRaisedShadow = Elevation.Z12
 export const menuShadow = Elevation.Z8
 export const modalShadow = Elevation.Z24
-export const ZINDEX_MODAL = 24
 export const bottomBarShadow = Elevation.Z8
 export const navItemRaised = Elevation.Z8
 export const navDrawerShadow = Elevation.Z16

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -227,13 +227,15 @@ export const enum Times {
 }
 
 /* https://material.io/design/environment/elevation.html#default-elevations */
-/* Use MD elevation * 100 to leave room to solve for collisions */
-/* See https://github.com/ParabolInc/action/issues/2772 */
 export const enum ZIndex {
-  MODAL = 2400 /* MD 24 */,
-  SIDEBAR = 1600 /* MD 16 */,
-  SNACKBAR = 600 /* MD 6 */,
-  REFLECTION_IN_FLIGHT = 800 /* MD 8 */
+  BOTTOM_BAR = 8,
+  BOTTOM_BAR_DESKTOP = 4,
+  DIALOG = 24,
+  FAB = 6,
+  SIDEBAR = 16,
+  SIDE_SHEET = 8,
+  SNACKBAR = 7,
+  REFLECTION_IN_FLIGHT = 8
 }
 
 export const enum AuthTokenRole {

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -232,10 +232,12 @@ export const enum ZIndex {
   BOTTOM_BAR_DESKTOP = 4,
   DIALOG = 24,
   FAB = 6,
+  MENU = 24 /* portal needs to float above other components, especially sidebars */,
   SIDEBAR = 16,
   SIDE_SHEET = 8,
   SNACKBAR = 7,
-  REFLECTION_IN_FLIGHT = 8
+  REFLECTION_IN_FLIGHT = 8,
+  TOOLTIP = 24 /* portal needs to float above other components, especially sidebars */
 }
 
 export const enum AuthTokenRole {

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -226,11 +226,14 @@ export const enum Times {
   REFLECTION_COLUMN_SWIPE_THRESH = 600
 }
 
+/* https://material.io/design/environment/elevation.html#default-elevations */
+/* Use MD elevation * 100 to leave room to solve for collisions */
+/* See https://github.com/ParabolInc/action/issues/2772 */
 export const enum ZIndex {
-  MODAL = 400 /*should be 24, https://github.com/ParabolInc/action/issues/2772 */,
-  SIDEBAR = 200,
-  SNACKBAR = 200,
-  REFLECTION_IN_FLIGHT = 500
+  MODAL = 2400 /* MD 24 */,
+  SIDEBAR = 1600 /* MD 16 */,
+  SNACKBAR = 600 /* MD 6 */,
+  REFLECTION_IN_FLIGHT = 800 /* MD 8 */
 }
 
 export const enum AuthTokenRole {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9144,12 +9144,7 @@ hoek@6.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.3.tgz#73b7d33952e01fe27a38b0457294b79dd8da242c"
   integrity sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==
 
-hoist-non-react-statics@^2.3.1:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
-
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
@@ -9494,20 +9489,10 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
-immutable@3.8.2, immutable@^3.8.2:
+immutable@3.8.2, immutable@^3.8.2, immutable@^4.0.0-rc.12, immutable@~3.7.4, immutable@~3.7.6:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
   integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
-
-immutable@^4.0.0-rc.12:
-  version "4.0.0-rc.12"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
-  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
-
-immutable@~3.7.4, immutable@~3.7.6:
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
-  integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Fixes #3295 
Fixes #2772 

In a few cases there’s a difference between the visual elevation and the necessary z-index of the portal components since they sit on a different plane. Tooltips by spec are an elevation of 0 but must show above sidebars at 16 (invite button tooltip has to be above open agenda sidebar). Menus have a visual elevation of 8 but also must show above sidebars of 16 (user hub menu needs to open above mobile dash nav sidebar, change facilitator menu must show above mobile meeting left nav). Tooltips and menus are at a z-index of 24 like dialogs, but with the correct box-shadow or lack thereof.

### Test
- [ ] Browser windows side by side: with user 1, open a group dialog in the Group phase. With user 2, drag another card. The card should not fly above the open dialog in user 1’s view
- [ ] The facilitator’s bottom bar is above the content of a meeting phase/stage
- [ ] The sidebars are at the right elevation at both mobile and laptop breakpoints: dash left nav, team dash agenda sidebar, meeting left nav
- [ ] Menus are at the right elevation (showing above sidebars when “in” sidebars): card menus, help menus, sidebar menus, kanban filter menus, top/bottom bar menus (users, timer), select menus (new team form, integrations), etc.
- [ ] Dialogs are at the right elevation: invite, update avatar for me/org, member action confirmation dialogs, etc.
- [ ] Tooltips are at the right elevation (no shadow, but showing above sidebars, etc.): agenda input, phase column header, team invite button, copy URL, org member is only billing leader
- [ ] Drag and drop is at the right elevation: reflections cards, task cards, agenda items
- [ ] Snackbars are at the right elevation: meeting alerts, team alerts, timer gauge
- [ ] FABs are at the right elevation: help FAB, rejoin FAB

~My recommendation is to use a simple formula `MD elevation * 100` to allow for collisions, because it would be confusing to have to override a component and bump it up or down 1 if there was something else at the same elevation (e.g. 16 and 16, make one component 15 or 17 or change the order of the DOM?). Whereas `1600 + 10` gets us a 16.1 and with a comment might make for a more clear adjustment. Probably overly cautious.~