### PR TITLE
Add walrus.ai tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,11 @@ jobs:
             if [ -n "${GITHUB_REMOTE}" ]; then
               git push -f dokku $CIRCLE_BRANCH:master
             fi
+      - run:
+          name: walrus.ai end-to-end tests
+          command: |
+            npm install -g @walrusai/cli
+            walrus -a ${WALRUS_API_KEY} ./walrus
       - store_artifacts:
           path: ~/action/build
           destination: build

--- a/walrus/basic-demo.yml
+++ b/walrus/basic-demo.yml
@@ -1,0 +1,7 @@
+---
+url: https://parabol.co
+instructions:
+  - Go to demo
+  - Add one reflection for each category and submit
+  - Stack 2 reflections on top of each other
+  - Ensure you can edit the reflection group title


### PR DESCRIPTION
Per our email thread @jordanh.

This PR adds a basic walrus.ai test for the Parabol demo. It makes sure that reflections can be grouped and their titles can be edited. This should be ready to go from a CI perspective, once your team creates an API token [here](https://walrus.ai).