### PR TITLE
Fix 2857 back to sign in

### DIFF
--- a/packages/client/components/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/packages/client/components/ResetPasswordPage/ResetPasswordPage.tsx
@@ -15,6 +15,7 @@ import AuthenticationDialog from '../AuthenticationDialog'
 import {GotoAuathPage} from '../GenericAuthentication'
 import DialogTitle from '../DialogTitle'
 import {PALETTE} from '../../styles/paletteV2'
+import IconLabel from '../IconLabel'
 
 interface State {
   isSent: boolean
@@ -54,6 +55,11 @@ const LinkButton = styled(PlainButton)({
 
 const SubmitButton = styled(PrimaryButton)({
   marginTop: 16
+})
+
+const StyledPrimaryButton = styled(PrimaryButton)({
+  margin: '16px auto 0',
+  width: 240
 })
 
 const BrandedLink = styled(PlainButton)({
@@ -154,6 +160,9 @@ class ResetPasswordPage extends Component<Props, State> {
                 <LinkButton onClick={this.resetState}>click here</LinkButton>
                 {' to try again.'}
               </P>
+              <StyledPrimaryButton onClick={gotoSignIn} size='medium'>
+                <IconLabel icon='arrow_back' label='Back to Sign In' />
+              </StyledPrimaryButton>
             </Fragment>
           ) : (
             <Fragment>


### PR DESCRIPTION
Fix #2857 

### Test
- Go to forgot password form
- Submit an email address
- There’s a clear way to get back to the Sign In view

![Screenshot 2019-11-15 17 34 11](https://user-images.githubusercontent.com/307286/68982884-4aee2580-07ce-11ea-8fb8-694919e179d1.png)

![Screenshot 2019-11-15 17 34 17](https://user-images.githubusercontent.com/307286/68982885-4aee2580-07ce-11ea-99b4-eba4511b5fad.png)
