### PR TITLE
fix race condition where the first 2 votes come in too fast

### DIFF
--- a/packages/server/graphql/mutations/voteForReflectionGroup.ts
+++ b/packages/server/graphql/mutations/voteForReflectionGroup.ts
@@ -97,10 +97,21 @@ export default {
 
     let isUnlock
     let unlockedStageIds
-    if (voteCount === 0) {
+
+    if (!isUnvote) {
+      const discussPhase = phases.find(
+        (phase) => phase.phaseType === NewMeetingPhaseTypeEnum.discuss
+      )
+      const {stages} = discussPhase
+      const [firstStage] = stages
+      const {isNavigableByFacilitator} = firstStage
+      if (!isNavigableByFacilitator) {
+        isUnlock = true
+      }
+    } else if (voteCount === 0) {
+      // technically, this is still a possible race condition if someone removes & adds 1 very quickly
+      // but then can fix that by casting another vote, so it's not terrible
       isUnlock = false
-    } else if (voteCount === 1 && !isUnvote) {
-      isUnlock = true
     }
     if (isUnlock !== undefined) {
       unlockedStageIds = unlockAllStagesForPhase(


### PR DESCRIPTION
TEST
- [ ] get to vote phase, can't advance until you vote
- [ ] vote on something, now you can advance
- [ ] remove the votes, no you can't advance