### PR TITLE
fix #3404 - failed to fail on acceptTeamInvite

### DIFF
--- a/packages/server/utils/authorization.ts
+++ b/packages/server/utils/authorization.ts
@@ -8,7 +8,7 @@ export const getUserId = (authToken: any) => {
   return authToken && typeof authToken === 'object' ? (authToken.sub as string) : ''
 }
 
-export const isAuthenticated = (authToken) => Boolean(authToken)
+export const isAuthenticated = (authToken: any) => typeof authToken?.sub === 'string'
 
 export const isSuperUser = (authToken) => {
   const userId = getUserId(authToken)


### PR DESCRIPTION
when an auth token is invalid, it's an empty object, not falsy.
live & learn.

TEST
- [ ] be signed out, visit the team-invitation link, login with a bad password, get the "invalid password" error.