### PR TITLE
Add titles to card footer toggles

### DIFF
--- a/packages/client/modules/outcomeCard/components/OutcomeCardFooter/TaskFooterIntegrateToggle.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardFooter/TaskFooterIntegrateToggle.tsx
@@ -33,6 +33,7 @@ const TaskFooterIntegrateToggle = (props: Props) => {
         onClick={togglePortal}
         ref={originRef}
         onMouseEnter={TaskFooterIntegrateMenuRoot.preload}
+        title='Integrations'
       >
         <IconLabel icon='publish' />
       </CardButton>

--- a/packages/client/modules/outcomeCard/components/OutcomeCardFooter/TaskFooterTagMenuToggle.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardFooter/TaskFooterTagMenuToggle.tsx
@@ -28,7 +28,12 @@ const TaskFooterTagMenuToggle = (props: Props) => {
 
   return (
     <>
-      <CardButton onMouseEnter={TaskFooterTagMenu.preload} ref={originRef} onClick={togglePortal}>
+      <CardButton
+        onMouseEnter={TaskFooterTagMenu.preload}
+        ref={originRef}
+        onClick={togglePortal}
+        title='Card actions'
+      >
         <IconLabel icon='more_vert' />
       </CardButton>
       {menuPortal(


### PR DESCRIPTION
This simply adds titles to the card footer toggles in order to afford some discovery and reduce the mystery-meatness—especially for first-time users like myself.

![Kapture 2019-12-12 at 11 54 24](https://user-images.githubusercontent.com/99067/70736532-28203580-1cd6-11ea-8d63-9d85cf47385d.gif)