### PR TITLE
docs(README): add top level quickstart command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start": "yarn workspace parabol-server start",
     "build": "yarn workspace parabol-server build",
     "build:relay": "yarn workspace parabol-server build:relay",
+    "quickstart": "yarn workspace parabol-server quickstart",
     "debug": "yarn workspace parabol-server debug",
     "debug:prod": "yarn workspace parabol-server debug:prod",
     "dev": "yarn workspace parabol-server dev",


### PR DESCRIPTION
Following the [source-code](https://github.com/ParabolInc/action#source-code) docs in README, one would see the following:

```sh
➜  action git:(master) ✗ yarn quickstart                                       
yarn run v1.21.1
error Command "quickstart" not found 
```

This PR adds a top level `quickstart` command that just proxies it to the `packages/server` workspace.

Another option would be to add one extra `cd packages/server` to the docs, but that seems unnecessary.