### PR TITLE
fix mass invitation null after expiry

### DIFF
--- a/packages/client/mutations/CreateMassInvitationMutation.ts
+++ b/packages/client/mutations/CreateMassInvitationMutation.ts
@@ -9,6 +9,7 @@ graphql`
       massInvitation {
         id
         expiration
+        meetingId
       }
     }
   }
@@ -34,6 +35,16 @@ const CreateMassInvitationMutation: StandardMutation<TCreateMassInvitationMutati
 ) => {
   return commitMutation<TCreateMassInvitationMutation>(atmosphere, {
     mutation,
+    updater: (store) => {
+      const payload = store.getRootField('createMassInvitation')
+      if (!payload) return
+      const team = payload.getLinkedRecord('team')
+      const massInvitation = team.getLinkedRecord('massInvitation')
+      const meetingId = massInvitation.getValue('meetingId')
+      if (!meetingId) return
+      // satisfy the need of the query
+      team.setLinkedRecord(massInvitation, 'massInvitation', {meetingId})
+    },
     variables,
     onCompleted,
     onError

--- a/packages/server/graphql/types/MassInvitation.ts
+++ b/packages/server/graphql/types/MassInvitation.ts
@@ -13,6 +13,9 @@ const MassInvitation = new GraphQLObjectType<any, GQLContext>({
     expiration: {
       type: GraphQLNonNull(GraphQLISO8601Type),
       description: 'the expiration for the token'
+    },
+    meetingId: {
+      type: GraphQLID
     }
   })
 })


### PR DESCRIPTION
TEST 
- [ ] on master (not this branch)
- [ ] start a meeting, go to invite someone, copy the mass invitation link, exit the modal
- [ ] go to DB and expire the link manually:
```
r.db('actionDevelopment')
.table('MassInvitation')
  .get('RHPMU031RNSS')
  .update({expiration: new Date()})
```
- [ ] go back to the meeting & go to invite someone again. see •••••••••

- [ ] repeat the steps on this branch, it works

fix #3551 