### PR TITLE
emoji pop up works again

### DIFF
--- a/packages/client/components/Menu.tsx
+++ b/packages/client/components/Menu.tsx
@@ -62,7 +62,7 @@ const Menu = forwardRef((props: Props, ref: any) => {
 
   useEffect(
     () => {
-      menuRef.current && menuRef.current.focus()
+      if (!keepParentFocus) menuRef.current && menuRef.current.focus()
     },
     resetActiveOnChanges ||
       [


### PR DESCRIPTION
Resolves #4096

**AC:**
- [ ] Start a retro meeting. When adding a reflection, press colon key to bring up emoji pop up.

**Regression tests:**
- [ ] On homepage sidebar, click + to Add Team. Click dropdown to select Organization. Verify you can navigate thru options by pressing the arrow keys up and down. If you only have 1 org, you'll need to add another org.
- [ ] on homepage top nav right side, click on the three icons. No options should be selected by default in the dropdowns.
- [ ] start a new meeting. click on team select dropdown. No options should be selected by default.