### PR TITLE
Fix undefined teamMember Sentry errors

### DIFF
--- a/packages/client/components/ActionSidebarPhaseListItemChildren.tsx
+++ b/packages/client/components/ActionSidebarPhaseListItemChildren.tsx
@@ -25,14 +25,17 @@ const ActionSidebarPhaseListItemChildren = (props: Props) => {
       />
     )
   }
-  return (
-    <MeetingSidebarTeamMemberStageItems
-      phaseType={phaseType}
-      gotoStageId={gotoStageId}
-      handleMenuClick={handleMenuClick}
-      meeting={meeting}
-    />
-  )
+  if (['checkin', 'updates'].includes(phaseType)) {
+    return (
+      <MeetingSidebarTeamMemberStageItems
+        phaseType={phaseType}
+        gotoStageId={gotoStageId}
+        handleMenuClick={handleMenuClick}
+        meeting={meeting}
+      />
+    )
+  }
+  return null
 }
 
 export default createFragmentContainer(ActionSidebarPhaseListItemChildren, {

--- a/packages/client/components/PokerSidebarPhaseListItemChildren.tsx
+++ b/packages/client/components/PokerSidebarPhaseListItemChildren.tsx
@@ -27,14 +27,17 @@ const PokerSidebarPhaseListItemChildren = (props: Props) => {
       />
     )
   }
-  return (
-    <MeetingSidebarTeamMemberStageItems
-      gotoStageId={gotoStageId}
-      handleMenuClick={handleMenuClick}
-      meeting={meeting}
-      phaseType={phaseType}
-    />
-  )
+  if (phaseType === 'checkin') {
+    return (
+      <MeetingSidebarTeamMemberStageItems
+        gotoStageId={gotoStageId}
+        handleMenuClick={handleMenuClick}
+        meeting={meeting}
+        phaseType={phaseType}
+      />
+    )
+  }
+  return null
 }
 
 export default createFragmentContainer(PokerSidebarPhaseListItemChildren, {

--- a/packages/client/components/RetroSidebarPhaseListItemChildren.tsx
+++ b/packages/client/components/RetroSidebarPhaseListItemChildren.tsx
@@ -30,14 +30,17 @@ const RetroSidebarPhaseListItemChildren = (props: Props) => {
       />
     )
   }
-  return (
-    <MeetingSidebarTeamMemberStageItems
-      gotoStageId={gotoStageId}
-      handleMenuClick={handleMenuClick}
-      meeting={meeting}
-      phaseType={phaseType}
-    />
-  )
+  if (phaseType === 'checkin') {
+    return (
+      <MeetingSidebarTeamMemberStageItems
+        gotoStageId={gotoStageId}
+        handleMenuClick={handleMenuClick}
+        meeting={meeting}
+        phaseType={phaseType}
+      />
+    )
+  }
+  return null
 }
 
 export default createFragmentContainer(RetroSidebarPhaseListItemChildren, {


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/5317

`MeetingSidebarTeamMemberStageItems` was being rendered in phases where we don't show the teamMember avatars in the sidebar. The teamMember could be undefined in those phases which triggered the Sentry error