### PR TITLE
Support Jira rotating refresh tokens

### DIFF
--- a/packages/server/dataloader/atlassianLoaders.ts
+++ b/packages/server/dataloader/atlassianLoaders.ts
@@ -50,9 +50,13 @@ export const freshAtlassianAuth = (parent: RethinkDataLoader) => {
           const inAMinute = Math.floor((now.getTime() + 60000) / 1000)
           if (!decodedToken || decodedToken.exp < inAMinute) {
             const manager = await AtlassianServerManager.refresh(refreshToken)
-            const {accessToken} = manager
+            const {accessToken, refreshToken: newRefreshToken} = manager
             atlassianAuth.accessToken = accessToken
             atlassianAuth.updatedAt = now
+
+            if (newRefreshToken) {
+              atlassianAuth.refreshToken = newRefreshToken
+            }
 
             await upsertAtlassianAuth(atlassianAuth)
           }


### PR DESCRIPTION
fix #5250

Jira is deprecating persistent refresh tokens. That means:

- Refresh token could be used only once
- Refresh token expires after 30 days
- With rotating refresh tokens enabled, Jira returns a new `refresh_token` along with `access_token`
- Every time we need to store a new `refresh_token`  and use it next time

What happens when the refresh token expires?

- User must initiate the entire authorization flow from the beginning again

How to test?

- Go to OAuth app authorization settings in Jira developer console and enable `Use rotating refresh tokens` (https://developer.atlassian.com/console/myapps/)
- Create poker meeting, connect Jira account to import issues
- Wait till your access token expired (1 hour) or remove the expiration check in code (see `atlassianLoaders`)
- Refresh the page. See Jira issues are loaded successfully.
- Also, check that it is still working with a persistent token setting enabled

Actions need to be taken:

- After merging, we need to edit dev OAuth settings and enable `Use rotating refresh tokens` 
- After deploying to PROD, we need to edit PROD Oauth settings and enable `Use rotating refresh tokens`. It should work without enabling it, but enabling this before the deadline is better.

@BartoszJarocki Can you please review?