### PR TITLE
replace codeblock with zero width space

### DIFF
--- a/packages/server/utils/makeScoreGitHubComment.ts
+++ b/packages/server/utils/makeScoreGitHubComment.ts
@@ -8,7 +8,7 @@ const makeScoreGitHubComment = (
   discussionURL: string
 ) =>
   `**${dimensionName}: ${finalScore}**
-  [See the discussion](${discussionURL}) in “${meetingName.replace(/(#\d+)/g, '`$1`')}”
+  [See the discussion](${discussionURL}) in ${meetingName.replace(/#(\d+)/g, '#​\u200b$1')}
 
   *Powered by [Parabol](${ExternalLinks.GETTING_STARTED_SPRINT_POKER})*`
 


### PR DESCRIPTION
GitHub markdown loves to turn any number like #1 and turn it into a link to an issue.
We got around this by putting it in a codeblock like this `#1`
A prettier solution would be using the zero-width space unicode char.
So we can say we're #​1 instead of #1.
Muahahaha we hacked it.