### PR TITLE
Fix parabol estimates synced with jira

### DIFF
--- a/packages/server/dataloader/atlassianLoaders.ts
+++ b/packages/server/dataloader/atlassianLoaders.ts
@@ -127,7 +127,7 @@ export const jiraIssue = (parent: RethinkDataLoader) => {
           // update our records
           await Promise.all(
             estimates.map((estimate) => {
-              const {jiraFieldId, label, discussionId, dimensionName, taskId, userId} = estimate
+              const {jiraFieldId, label, discussionId, name, taskId, userId} = estimate
               const freshEstimate = String(fields[jiraFieldId])
               if (freshEstimate === label) return undefined
               // mutate current dataloader
@@ -138,7 +138,7 @@ export const jiraIssue = (parent: RethinkDataLoader) => {
                 discussionId,
                 jiraFieldId,
                 label: freshEstimate,
-                name: dimensionName,
+                name,
                 meetingId: null,
                 stageId: null,
                 taskId,

--- a/packages/server/graphql/types/Task.ts
+++ b/packages/server/graphql/types/Task.ts
@@ -62,7 +62,9 @@ const Task = new GraphQLObjectType<any, GQLContext>({
         if (integration?.service === 'jira') {
           const {accessUserId, cloudId, issueKey} = integration
           // this dataloader has the side effect of guaranteeing fresh estimates
-          await dataLoader.get('jiraIssue').load({teamId, userId: accessUserId, cloudId, issueKey})
+          await dataLoader
+            .get('jiraIssue')
+            .load({teamId, userId: accessUserId, cloudId, issueKey, taskId})
         }
         return dataLoader.get('latestTaskEstimates').load(taskId)
       }
@@ -76,13 +78,15 @@ const Task = new GraphQLObjectType<any, GQLContext>({
     integration: {
       type: TaskIntegration,
       description: 'The reference to the single source of truth for this task',
-      resolve: async ({integration, teamId}: DBTask, _args, context, info) => {
+      resolve: async ({integration, teamId, id: taskId}: DBTask, _args, context, info) => {
         const {dataLoader} = context
         if (!integration) return null
         const {accessUserId} = integration
         if (integration.service === 'jira') {
           const {cloudId, issueKey} = integration
-          return dataLoader.get('jiraIssue').load({teamId, userId: accessUserId, cloudId, issueKey})
+          return dataLoader
+            .get('jiraIssue')
+            .load({teamId, userId: accessUserId, cloudId, issueKey, taskId})
         } else if (integration.service === 'github') {
           const githubAuth = await dataLoader.get('githubAuth').load({userId: accessUserId, teamId})
           if (!githubAuth) return null


### PR DESCRIPTION
fix #5522
When we queried an issue from Jira, no estimates were updated in our database

How to test:

- Create a poker meeting
- Import an issue from Jira to poker meeting
- Set some estimate and click update
- Update estimate of the issue on Jira
- Check the `TaskEstimate` table in postgresql, see new row added


