### PR TITLE
hotifx: bump pm2 memory limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows conventions [outlined here](http://keepachangelog.com/).
 
+## 6.31.2 2021-Oct-20
+
+### Fixed
+
+- Increase PM2 max memory to 8GB per service
+
 ## 6.31.1 2021-Oct-06
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.co> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.31.0",
+  "version": "6.31.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"

--- a/pm2.config.js
+++ b/pm2.config.js
@@ -6,7 +6,7 @@ module.exports = {
       instances: 1,
       autorestart: true,
       watch: false,
-      max_memory_restart: '1228M',
+      max_memory_restart: '8192M',
       env_production: {
         NODE_ENV: 'production'
       }
@@ -17,7 +17,7 @@ module.exports = {
       instances: 1,
       autorestart: true,
       watch: false,
-      max_memory_restart: '1228M',
+      max_memory_restart: '8192M',
       env_production: {
         NODE_ENV: 'production'
       }


### PR DESCRIPTION
our little app is all grown up & actively using over 1.28GB of memory :cry: 
the last time that happened we had a nasty memory leak that took 2 weeks to find.

i have no clue why the limit was set so low. bumping it up to 8GB. that should buy us some more time.