### PR TITLE
Fix pg query count datatype

### DIFF
--- a/packages/server/graphql/intranetSchema/queries/dailyPulse.ts
+++ b/packages/server/graphql/intranetSchema/queries/dailyPulse.ts
@@ -38,7 +38,7 @@ const filterCounts = (domainCount: DomainCount[]) =>
 const addAllTimeTotals = async (domainCount: DomainCount[]): Promise<DomainCountWithAllTime[]> => {
   const pg = getPg()
   const allTimeCount = await pg.query(
-    `SELECT count(*) as "allTimeTotal", split_part(email, '@', 2) as domain from "User"
+    `SELECT count(*)::float as "allTimeTotal", split_part(email, '@', 2) as domain from "User"
      WHERE split_part(email, '@', 2) = ANY($1::text[])
      GROUP BY split_part(email, '@', 2)`,
     [domainCount.map((count) => count.domain)]

--- a/packages/server/graphql/intranetSchema/queries/helpers/authCount.ts
+++ b/packages/server/graphql/intranetSchema/queries/helpers/authCount.ts
@@ -15,12 +15,12 @@ const authCount = async (
 
   const count = after
     ? await pg.query(
-        `SELECT count(*) FROM "User"
+        `SELECT count(*)::float FROM "User"
          WHERE (NOT $1 OR inactive = FALSE)
          AND "${filterField}" >= $2`,
         [countOnlyActive ?? false, after]
       )
-    : await pg.query('SELECT count(*) FROM "User" WHERE (NOT $1 OR inactive = FALSE)', [
+    : await pg.query('SELECT count(*)::float FROM "User" WHERE (NOT $1 OR inactive = FALSE)', [
         countOnlyActive ?? false
       ])
 

--- a/packages/server/graphql/intranetSchema/queries/helpers/authCountByDomain.ts
+++ b/packages/server/graphql/intranetSchema/queries/helpers/authCountByDomain.ts
@@ -2,6 +2,7 @@ import getPg from '../../../../postgres/getPg'
 
 const domainFilterFields = ['createdAt', 'lastSeenAt'] as const
 type DomainFilterField = typeof domainFilterFields[number]
+type DomainTotal = {domain: string; total: number}
 
 const authCountByDomain = async (
   after: Date | null | undefined,
@@ -14,20 +15,20 @@ const authCountByDomain = async (
   const pg = getPg()
 
   const count = after
-    ? await pg.query(
-        `SELECT count(*) as total, split_part(email, '@', 2) as "domain" from "User"
+    ? await pg.query<DomainTotal>(
+        `SELECT count(*)::float as total, split_part(email, '@', 2) as "domain" from "User"
          WHERE (NOT $1 OR inactive = FALSE)
          AND "${filterField}" >= $2
          GROUP BY split_part(email, '@', 2)`,
         [countOnlyActive ?? false, after]
       )
-    : await pg.query(
-        `SELECT count(*) as total, split_part(email, '@', 2) as "domain" from "User"
+    : await pg.query<DomainTotal>(
+        `SELECT count(*)::float as total, split_part(email, '@', 2) as "domain" from "User"
          WHERE (NOT $1 OR inactive = FALSE)
          GROUP BY split_part(email, '@', 2)`,
         [countOnlyActive ?? false]
       )
-  return count.rows as {domain: string; total: number}[]
+  return count.rows
 }
 
 export default authCountByDomain

--- a/packages/server/graphql/queries/suUserCount.ts
+++ b/packages/server/graphql/queries/suUserCount.ts
@@ -20,7 +20,7 @@ export default {
     // RESOLUTION
     const pg = getPg()
     const result = await pg.query(
-      'SELECT count(*) FROM "User" WHERE inactive = FALSE AND tier = $1',
+      'SELECT count(*)::float FROM "User" WHERE inactive = FALSE AND tier = $1',
       [tier]
     )
     return result.rows[0].count


### PR DESCRIPTION
node-postgres returns numeric fields as string unless it is clear that
these can be converted lossless to JS Number. Cast the count to ::float
(double precission by default) to match the JS type.

Resolves: #5528