### PR TITLE
Avoid `JSON.stringify(JSON.parse(...))` in `disconnectSocket`

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/disconnectSocket.ts
+++ b/packages/server/graphql/intranetSchema/mutations/disconnectSocket.ts
@@ -24,12 +24,13 @@ export default {
     const user = await db.read('User', userId)
     const tms = user?.tms ?? []
     const userPresence = await redis.lrange(`presence:${userId}`, 0, -1)
-    const parsedUserPresence = userPresence.map((socket) => JSON.parse(socket)) as UserPresence[]
-    const disconnectingSocket = parsedUserPresence.find((socket) => socket.socketId === socketId)
+    const disconnectingSocket = userPresence.find(
+      (socket) => (JSON.parse(socket) as UserPresence).socketId === socketId
+    )
     if (!disconnectingSocket) {
       throw new Error('Called disconnect without a valid socket')
     }
-    await redis.lrem(`presence:${userId}`, 0, JSON.stringify(disconnectingSocket))
+    await redis.lrem(`presence:${userId}`, 0, disconnectingSocket)
 
     // If this is the last socket, tell everyone they're offline
     if (userPresence.length === 1) {


### PR DESCRIPTION
Using the original string coming from redis to remove it from the list
is safer. Nothing is stopping us from calling `JSON.stringify(...,
undefined, 2)` when we initially write that property, which would render
those two strings unequal.