### PR TITLE
Support comma separated issueKey list

### DIFF
--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -600,35 +600,46 @@ export default abstract class AtlassianManager {
     }
   }
 
-  private readonly buildIssueKeyJQL = (queryString: string | null, filteredProjectKeys: string[]) => {
-    if (!queryString) return ""
+  private readonly buildIssueKeyJQL = (
+    queryString: string | null,
+    filteredProjectKeys: string[]
+  ) => {
+    if (!queryString) return ''
     const maybeIssueKeys = queryString.split(/[\s,]+/)
-    if (maybeIssueKeys.length === 0) return ""
+    if (maybeIssueKeys.length === 0) return ''
 
-    const validIssueKeys = maybeIssueKeys.map((rawIssueKey) => {
-      const maybeIssueKey = rawIssueKey.toUpperCase()
-      const match = maybeIssueKey.match(/(?<projectKey>[A-Za-z][A-Za-z_0-9]+)*-*(?<issueNumber>\d+)/)
-      if (!match || !match.groups) return ""
+    const validIssueKeys = maybeIssueKeys
+      .map((rawIssueKey) => {
+        const maybeIssueKey = rawIssueKey.toUpperCase()
+        const match = maybeIssueKey.match(
+          /(?<projectKey>[A-Za-z][A-Za-z_0-9]+)*-*(?<issueNumber>\d+)/
+        )
+        if (!match || !match.groups) return ''
 
-      const {projectKey: maybeProjectKey, issueNumber: maybeIssueNumber} = match.groups
-      if (maybeProjectKey && !maybeIssueNumber)
-        return ""
-      else if (maybeProjectKey && maybeIssueNumber) {
-        if (filteredProjectKeys.length == 0 || (filteredProjectKeys.length != 0 && filteredProjectKeys.includes(maybeProjectKey))) {
-          return `${maybeProjectKey}-${maybeIssueNumber}`
+        const {projectKey: maybeProjectKey, issueNumber: maybeIssueNumber} = match.groups
+        if (maybeProjectKey && !maybeIssueNumber) return ''
+        else if (maybeProjectKey && maybeIssueNumber) {
+          if (
+            filteredProjectKeys.length === 0 ||
+            (filteredProjectKeys.length !== 0 && filteredProjectKeys.includes(maybeProjectKey))
+          ) {
+            return `${maybeProjectKey}-${maybeIssueNumber}`
+          } else {
+            return ''
+          }
+        } else if (!maybeProjectKey && maybeIssueNumber) {
+          if (filteredProjectKeys.length === 0) {
+            return ''
+          } else {
+            return filteredProjectKeys.map((projectKey) => `${projectKey}-${maybeIssueNumber}`)
+          }
         } else {
-          return ""
+          return ''
         }
-      } else if (!maybeProjectKey && maybeIssueNumber) {
-        if (filteredProjectKeys.length == 0) {
-          return ""
-        } else {
-          return filteredProjectKeys.map((projectKey) => `${projectKey}-${maybeIssueNumber}`)
-        }
-      } else {
-        return ""
-      }
-    }).flat().filter(String).map((issueKey) => `\"${issueKey}\"`)
+      })
+      .flat()
+      .filter(String)
+      .map((issueKey) => `\"${issueKey}\"`)
     return validIssueKeys.length > 0 ? ` OR issueKey in (${validIssueKeys.join(', ')})` : ''
   }
 


### PR DESCRIPTION
Fixes #6005 .

Tests:

1.  Start a Poker meeting and select Jira tab in the Scope phase
2.  In the search bar, put in the following test cases

*   [ ] Single valid issueKey: `BRUCE-1` should return the issue BRUCE-1
*   [ ] Comma separated valid issueKeys: `BRUCE-1,BRUCE-2` should return issues BRUCE-1 and BRUCE-2
*   [ ] Single invalid issueKey: `XYZ-1` should return no result
*   [ ] Mixed valid & invalid issueKeys: `BRUCE-1,BRUCE-2,XYZ-1` should return issues BRUCE-1 and BRUCE-2
*   [ ] single or comma separated issueNumbers: `1,2,3` should return no result
*   [ ] single or comma separated issueNumbers with project filter selected: `1,2,3` with `Bruce's Test Project` selected should return issues BRUCE-1, 2 and 3
*   [ ] With project filter selected, input issueKey must match: e.g., with `Bruce's Test Project` selected and input as `KARL-1` should return no result
*   [ ] With project filter selected, input is a mix of matched & not matched issueKey: e.g., with `Bruce's Test Project` selected and input is `KARL-1,BRUCE-1` should return the issue BRUCE-1
*   [ ] With project filter selected, input is a mix of issueKey & issueNumber: e.g., with `Bruce's Test Project` selected and input is `KARL-1,BRUCE-1,2` should return issues BRUCE-1 and BRUCE-2
*   [ ] Input is case insensitive: `bruce-1, BRuce-2, bRUCE-3` should return issues BRUCE-1, 2 and 3. Also works with project filter selected