### PR TITLE
feat(standups): Changed standups default title to contain a date, not seq number

### DIFF
--- a/packages/server/database/types/MeetingTeamPrompt.ts
+++ b/packages/server/database/types/MeetingTeamPrompt.ts
@@ -18,6 +18,15 @@ export function isMeetingTeamPrompt(meeting: Meeting): meeting is MeetingTeamPro
   return meeting.meetingType === 'teamPrompt'
 }
 
+function createTeamPromptDefaultTitle() {
+  const formattedDate = new Date().toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric'
+  })
+
+  return `Async Standup - ${formattedDate}`
+}
+
 export default class MeetingTeamPrompt extends Meeting {
   meetingType!: 'teamPrompt'
   meetingPrompt: string
@@ -31,7 +40,7 @@ export default class MeetingTeamPrompt extends Meeting {
       phases,
       facilitatorUserId,
       meetingType: 'teamPrompt',
-      name: name ?? `Async Standup #${meetingCount + 1}`
+      name: name ?? createTeamPromptDefaultTitle()
     })
     this.meetingPrompt = meetingPrompt
   }


### PR DESCRIPTION
# Description

Fixes #6850 

## Demo

![localhost_3000_meetings](https://user-images.githubusercontent.com/1017620/177697373-81a05fc4-fffb-43f1-a424-d40453d3cca6.png)


## Testing scenarios

- [ ] Add a new standup meeting and make sure the title has a current date and month added to a title

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
