### PR TITLE
chore(tailwind): Add default colors

### DIFF
--- a/packages/client/tailwindTheme.ts
+++ b/packages/client/tailwindTheme.ts
@@ -1,12 +1,12 @@
 /**
  * Palette definition from https://www.figma.com/file/OA9NkpSTlHVqqRL9IE9KsF/Palette-v3?node-id=15%3A2184&t=waDBAOGfSqB0wtCc-0
  */
+const defaultColors = require('tailwindcss/colors')
 
 export default {
   theme: {
     colors: {
-      white: '#FFFFFF',
-      black: '#000000',
+      ...defaultColors,
       primary: '#493272',
       tomato: {
         '100': '#FFE2E0',


### PR DESCRIPTION
# Description
See [slack](https://parabol.slack.com/archives/C608QL4RH/p1678292967429019) 🔒
We don't currently have all the built-in default tailwind colors in our tailwind config, so classes like `bg-transparent` don't work.

Add all default colors. 

## Demo
N/A (changes that need this fix are on a separate branch)

## Testing scenarios
N/A

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
