### PR TITLE
fix: update recurrenceSettings call

### DIFF
--- a/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
@@ -1,14 +1,14 @@
-import React, {useMemo, useState} from 'react'
-import DialogContainer from '../../DialogContainer'
 import clsx from 'clsx'
-import EndTeamPromptMutation from '../../../mutations/EndTeamPromptMutation'
+import React, {useMemo, useState} from 'react'
+import {RRule} from 'rrule'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useMutationProps from '../../../hooks/useMutationProps'
 import useRouter from '../../../hooks/useRouter'
+import EndTeamPromptMutation from '../../../mutations/EndTeamPromptMutation'
 import UpdateRecurrenceSettingsMutation from '../../../mutations/UpdateRecurrenceSettingsMutation'
-import {RRule} from 'rrule'
-import {humanReadableCountdown} from '../../../utils/date/relativeDate'
 import {CompletedHandler} from '../../../types/relayMutations'
+import {humanReadableCountdown} from '../../../utils/date/relativeDate'
+import DialogContainer from '../../DialogContainer'
 
 interface RadioToggleProps {
   checked: boolean
@@ -57,7 +57,7 @@ export const EndRecurringMeetingModal = (props: Props) => {
     if (!isMeetingOnly) {
       UpdateRecurrenceSettingsMutation(
         atmosphere,
-        {meetingId, recurrenceRule: null},
+        {meetingId, recurrenceSettings: {name: null, rrule: null}},
         {onError, onCompleted}
       )
     } else {


### PR DESCRIPTION
# Description

Fun merge conflict happened because 2 PRs landed back to back, both passing, neither touching the same files, but it didn't fail the GH actions check until both landed on master.
Once on master, we don't run GH actions as part of the release process, so this didn't pop up during the release cycle, but it did pop up in PRs based off master.