### PR TITLE
fix: Changing meeting settings affected existing meetings

### DIFF
--- a/packages/client/components/ActionMeetingSidebar.tsx
+++ b/packages/client/components/ActionMeetingSidebar.tsx
@@ -31,9 +31,6 @@ const ActionMeetingSidebar = (props: Props) => {
       fragment ActionMeetingSidebar_meeting on ActionMeeting {
         ...ActionSidebarPhaseListItemChildren_meeting
         ...NewMeetingSidebar_meeting
-        settings {
-          phaseTypes
-        }
         facilitatorUserId
         facilitatorStageId
         localPhase {
@@ -62,9 +59,8 @@ const ActionMeetingSidebar = (props: Props) => {
   )
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
-  const {team, settings} = meeting
+  const {team} = meeting
   const {agendaItems} = team
-  const {phaseTypes} = settings
   const {facilitatorUserId, facilitatorStageId, localPhase, localStage, phases} = meeting
   const localPhaseType = localPhase ? localPhase.phaseType : ''
   const facilitatorStageRes = findStageById(phases, facilitatorStageId)
@@ -79,9 +75,9 @@ const ActionMeetingSidebar = (props: Props) => {
       meeting={meeting}
     >
       <MeetingNavList>
-        {phaseTypes
-          .filter((phaseType) => !blackList.includes(phaseType))
-          .map((phaseType) => {
+        {phases
+          .filter(({phaseType}) => !blackList.includes(phaseType))
+          .map(({phaseType}) => {
             const itemStage = getSidebarItemStage(phaseType, phases, facilitatorStageId)
             const {
               id: itemStageId = '',

--- a/packages/client/components/PokerMeetingSidebar.tsx
+++ b/packages/client/components/PokerMeetingSidebar.tsx
@@ -35,9 +35,6 @@ const PokerMeetingSidebar = (props: Props) => {
         ...PokerSidebarPhaseListItemChildren_meeting
         ...NewMeetingSidebar_meeting
         showSidebar
-        settings {
-          phaseTypes
-        }
         id
         endedAt
         facilitatorUserId
@@ -71,10 +68,8 @@ const PokerMeetingSidebar = (props: Props) => {
     facilitatorStageId,
     localPhase,
     localStage,
-    phases,
-    settings
+    phases
   } = meeting
-  const {phaseTypes} = settings
   const localPhaseType = localPhase ? localPhase.phaseType : ''
   const facilitatorStageRes = findStageById(phases, facilitatorStageId)
   const facilitatorPhaseType = facilitatorStageRes ? facilitatorStageRes.phase.phaseType : ''
@@ -88,7 +83,7 @@ const PokerMeetingSidebar = (props: Props) => {
       meeting={meeting}
     >
       <MeetingNavList>
-        {phaseTypes.map((phaseType) => {
+        {phases.map(({phaseType}) => {
           const itemStage = getSidebarItemStage(phaseType, phases, facilitatorStageId)
           const {
             id: itemStageId = '',

--- a/packages/client/components/RetroDiscussPhase.tsx
+++ b/packages/client/components/RetroDiscussPhase.tsx
@@ -163,8 +163,10 @@ const RetroDiscussPhase = (props: Props) => {
         localStage {
           ...RetroDiscussPhase_stage @relay(mask: false)
         }
-        settings {
-          ...DiscussionThreadListEmptyState_settings
+        team {
+          meetingSettings(meetingType: retrospective) {
+            ...DiscussionThreadListEmptyState_settings
+          }
         }
       }
     `,
@@ -179,8 +181,9 @@ const RetroDiscussPhase = (props: Props) => {
     organization,
     showTranscription,
     transcription,
-    settings
+    team
   } = meeting
+  const {meetingSettings} = team
   const {reflectionGroup, discussionId} = localStage
   const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
   const title = reflectionGroup?.title ?? ''
@@ -268,7 +271,7 @@ const RetroDiscussPhase = (props: Props) => {
                     <DiscussionThreadListEmptyState
                       allowTasks={true}
                       isReadOnly={allowedThreadables.length === 0}
-                      settingsRef={settings}
+                      settingsRef={meetingSettings}
                       showTranscription={showTranscription}
                     />
                   }

--- a/packages/client/components/RetroMeetingSidebar.tsx
+++ b/packages/client/components/RetroMeetingSidebar.tsx
@@ -37,9 +37,6 @@ const RetroMeetingSidebar = (props: Props) => {
         ...RetroSidebarPhaseListItemChildren_meeting
         ...NewMeetingSidebar_meeting
         showSidebar
-        settings {
-          phaseTypes
-        }
         id
         endedAt
         facilitatorUserId
@@ -75,10 +72,8 @@ const RetroMeetingSidebar = (props: Props) => {
     localPhase,
     localStage,
     phases,
-    settings,
     meetingMembers
   } = meeting
-  const {phaseTypes} = settings
   const localPhaseType = localPhase ? localPhase.phaseType : ''
   const facilitatorStageRes = findStageById(phases, facilitatorStageId)
   const facilitatorPhaseType = facilitatorStageRes ? facilitatorStageRes.phase.phaseType : ''
@@ -93,7 +88,7 @@ const RetroMeetingSidebar = (props: Props) => {
       meeting={meeting}
     >
       <MeetingNavList>
-        {phaseTypes.map((phaseType, index) => {
+        {phases.map(({phaseType}, index) => {
           const itemStage = getSidebarItemStage(phaseType, phases, facilitatorStageId)
           const {
             id: itemStageId = '',
@@ -103,7 +98,7 @@ const RetroMeetingSidebar = (props: Props) => {
           } = itemStage ?? {}
           const canNavigate = isViewerFacilitator ? isNavigableByFacilitator : isNavigable
           const handleClick = () => {
-            const prevPhaseType = phaseTypes[index - 1]
+            const prevPhaseType = phases[index - 1]?.phaseType
             const prevItemStage = prevPhaseType
               ? getSidebarItemStage(prevPhaseType, phases, facilitatorStageId)
               : null

--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -41,9 +41,7 @@ const RetroReflectPhase = (props: Props) => {
           ...RetroReflectPhase_phase @relay(mask: false)
         }
         showSidebar
-        settings {
-          disableAnonymity
-        }
+        disableAnonymity
       }
     `,
     meetingRef
@@ -51,8 +49,7 @@ const RetroReflectPhase = (props: Props) => {
   const [callbackRef, phaseRef] = useCallbackRef()
   const [activeIdx, setActiveIdx] = useState(0)
   const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
-  const {localPhase, endedAt, showSidebar, settings} = meeting
-  const {disableAnonymity} = settings
+  const {disableAnonymity, localPhase, endedAt, showSidebar} = meeting
   if (!localPhase || !localPhase.reflectPrompts) return null
   const reflectPrompts = localPhase!.reflectPrompts
   const focusedPromptId = localPhase!.focusedPromptId

--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -47,10 +47,6 @@ graphql`
           }
         }
       }
-      settings {
-        recallBotId
-        videoMeetingURL
-      }
     }
     team {
       id

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -4383,11 +4383,6 @@ type ActionMeeting implements NewMeeting {
   commentCount: Int!
 
   """
-  The settings that govern the action meeting
-  """
-  settings: ActionMeetingSettings!
-
-  """
   The number of tasks generated in the meeting
   """
   taskCount: Int!
@@ -4633,11 +4628,6 @@ type RetrospectiveMeeting implements NewMeeting {
   The grouped reflections
   """
   reflectionGroups(sortBy: ReflectionGroupSortEnum): [RetroReflectionGroup!]!
-
-  """
-  The settings that govern the retrospective meeting
-  """
-  settings: RetrospectiveMeetingSettings!
 
   """
   The number of tasks generated in the meeting
@@ -5484,11 +5474,6 @@ type PokerMeeting implements NewMeeting {
   The number of stories scored during a meeting
   """
   storyCount: Int!
-
-  """
-  The settings that govern the Poker meeting
-  """
-  settings: PokerMeetingSettings!
 
   """
   A single story created in a Sprint Poker meeting

--- a/packages/server/graphql/types/ActionMeeting.ts
+++ b/packages/server/graphql/types/ActionMeeting.ts
@@ -4,7 +4,6 @@ import {getUserId} from '../../utils/authorization'
 import filterTasksByMeeting from '../../utils/filterTasksByMeeting'
 import {GQLContext} from '../graphql'
 import ActionMeetingMember from './ActionMeetingMember'
-import ActionMeetingSettings from './ActionMeetingSettings'
 import AgendaItem from './AgendaItem'
 import NewMeeting, {newMeetingFields} from './NewMeeting'
 import Task from './Task'
@@ -57,13 +56,6 @@ const ActionMeeting = new GraphQLObjectType<any, GQLContext>({
       description: 'The team members that were active during the time of the meeting',
       resolve: ({id: meetingId}, _args: unknown, {dataLoader}) => {
         return dataLoader.get('meetingMembersByMeetingId').load(meetingId)
-      }
-    },
-    settings: {
-      type: new GraphQLNonNull(ActionMeetingSettings),
-      description: 'The settings that govern the action meeting',
-      resolve: async ({teamId}, _args: unknown, {dataLoader}) => {
-        return await dataLoader.get('meetingSettingsByType').load({teamId, meetingType: 'action'})
       }
     },
     taskCount: {

--- a/packages/server/graphql/types/PokerMeeting.ts
+++ b/packages/server/graphql/types/PokerMeeting.ts
@@ -4,7 +4,6 @@ import {getUserId} from '../../utils/authorization'
 import {GQLContext} from '../graphql'
 import NewMeeting, {newMeetingFields} from './NewMeeting'
 import PokerMeetingMember from './PokerMeetingMember'
-import PokerMeetingSettings from './PokerMeetingSettings'
 import Task from './Task'
 
 const PokerMeeting = new GraphQLObjectType<any, GQLContext>({
@@ -29,13 +28,6 @@ const PokerMeeting = new GraphQLObjectType<any, GQLContext>({
       type: new GraphQLNonNull(GraphQLInt),
       description: 'The number of stories scored during a meeting',
       resolve: ({storyCount}) => storyCount || 0
-    },
-    settings: {
-      type: new GraphQLNonNull(PokerMeetingSettings),
-      description: 'The settings that govern the Poker meeting',
-      resolve: async ({teamId}, _args: unknown, {dataLoader}) => {
-        return dataLoader.get('meetingSettingsByType').load({teamId, meetingType: 'poker'})
-      }
     },
     story: {
       type: Task,

--- a/packages/server/graphql/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/types/RetrospectiveMeeting.ts
@@ -20,7 +20,6 @@ import {resolveForSU} from '../resolvers'
 import NewMeeting, {newMeetingFields} from './NewMeeting'
 import RetroReflectionGroup from './RetroReflectionGroup'
 import RetrospectiveMeetingMember from './RetrospectiveMeetingMember'
-import RetrospectiveMeetingSettings from './RetrospectiveMeetingSettings'
 import Task from './Task'
 import AutogroupReflectionGroup from './AutogroupReflectionGroup'
 
@@ -142,13 +141,6 @@ const RetrospectiveMeeting: GraphQLObjectType<any, GQLContext> = new GraphQLObje
           a.sortOrder < b.sortOrder ? -1 : 1
         )
         return reflectionGroups
-      }
-    },
-    settings: {
-      type: new GraphQLNonNull(RetrospectiveMeetingSettings),
-      description: 'The settings that govern the retrospective meeting',
-      resolve: async ({teamId}, _args: unknown, {dataLoader}) => {
-        return dataLoader.get('meetingSettingsByType').load({teamId, meetingType: 'retrospective'})
       }
     },
     taskCount: {


### PR DESCRIPTION
# Description

Fixes: #8588 

Changing the meeting settings after meeting creation would affect the meeting phases shown, i.e. the icebreaker would show up even if the meeting has none set, or it would be missing, although the meeting has one. Same for team health.

Meeting had a field settings which pointed to the meeting settings for that meeting type. These always pointed to the latest ones and not the ones associated with the current meeting. Because this is misleading, I decided it's safer to remove said field completely.

## Demo

See #8588

## Testing scenarios

- [ ] create a meeting with icebreaker
- [ ] start another meeting of the same type without
- [ ] check that each meeting has a different setting
- [ ] run Poker, Retro and Check-In normally and see switching phases works

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
