### PR TITLE
fix: Add yarn pg:build to deployment steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ yarn dev
 ### Deploy
 
 ```bash
-$ yarn && yarn build && yarn predeploy && yarn start
+$ yarn && yarn pg:build && yarn build && yarn predeploy && yarn start
 ```
 
 - [How to Ship](./docs/deployment.md)


### PR DESCRIPTION
# Description

When not creating the PostgreSQL migrations, the `yarn build` command fails.

Fixes #10496

## Demo

Freshly clone the repo and run `yarn && yarn build`. It will fail. When running `yarn && yarn pg:build && yarn build` the build succeeds.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
