### PR TITLE
fix: React error on forgot password page

### DIFF
--- a/packages/client/components/GenericAuthentication.tsx
+++ b/packages/client/components/GenericAuthentication.tsx
@@ -78,6 +78,16 @@ const GenericAuthentication = (props: Props) => {
   const isMicrosoftAuthEnabled = window.__ACTION__.AUTH_MICROSOFT_ENABLED
   const isInternalAuthEnabled = window.__ACTION__.AUTH_INTERNAL_ENABLED
   const isSSOAuthEnabled = window.__ACTION__.AUTH_SSO_ENABLED
+
+  const isCreate = page === 'create-account'
+  const action = isCreate ? CREATE_ACCOUNT_LABEL : SIGNIN_LABEL
+  const pageTitle = `${action} | Parabol`
+  const metaCopy = isCreate
+    ? 'Give structure to your meetings to get your team talking and moving forward faster. Get started in 44 seconds or less.'
+    : 'Access Parabol to streamline your agile meetings. Collaborate, reflect, and grow with your team in real-time.'
+  useDocumentTitle(pageTitle, action)
+  useMetaTagContent(metaCopy)
+
   if (page === 'forgot-password') {
     return <ForgotPasswordPage goToPage={goToPage} />
   }
@@ -89,17 +99,9 @@ const GenericAuthentication = (props: Props) => {
     }
   }
 
-  const isCreate = page === 'create-account'
-  const action = isCreate ? CREATE_ACCOUNT_LABEL : SIGNIN_LABEL
   const counterAction = isCreate ? SIGNIN_LABEL : CREATE_ACCOUNT_LABEL
   const counterActionSlug = isCreate ? SIGNIN_SLUG : CREATE_ACCOUNT_SLUG
   const actionCopy = isCreate ? 'Already have an account? ' : 'New to Parabol? '
-  const pageTitle = `${action} | Parabol`
-  const metaCopy = isCreate
-    ? 'Give structure to your meetings to get your team talking and moving forward faster. Get started in 44 seconds or less.'
-    : 'Access Parabol to streamline your agile meetings. Collaborate, reflect, and grow with your team in real-time.'
-  useDocumentTitle(pageTitle, action)
-  useMetaTagContent(metaCopy)
   const title = teamName ? `${teamName} is waiting` : action
   const onForgot = () => {
     goToPage('forgot-password', `?email=${emailRef.current?.email()}`)

--- a/packages/client/components/InvitationLinkDialog.tsx
+++ b/packages/client/components/InvitationLinkDialog.tsx
@@ -42,16 +42,20 @@ const InvitationLinkDialog = (props: Props) => {
     return <TeamInvitationErrorNotFound isMassInvite />
   }
   const {errorType, teamName} = massInvitation
+  const pageTitle = teamName ? `${teamName} | Parabol` : 'Join | Parabol'
+  const pageName = teamName ? `Join ${teamName}` : 'Join Parabol'
+  const metaCopy = teamName
+    ? `Join ${teamName} on Parabol, the essential tool for making meetings efficient or replacing them with structured, asynchronous collaboration.`
+    : `Join Parabol, the essential tool for making meetings efficient or replacing them with structured, asynchronous collaboration.`
+  useDocumentTitle(pageTitle, pageName)
+  useMetaTagContent(metaCopy)
+
   switch (errorType) {
     case 'notFound':
       return <TeamInvitationErrorNotFound isMassInvite />
     case 'expired':
       return <InvitationLinkErrorExpired massInvitation={massInvitation} />
   }
-  useDocumentTitle(`${teamName} | Parabol`, `Join ${teamName}`)
-  useMetaTagContent(
-    `Join ${teamName} on Parabol,the essential tool for making meetings efficient or replacing them with structured, asynchronous collaboration.`
-  )
   const {authToken} = atmosphere
   if (authToken) {
     return <TeamInvitationAccept invitationToken={token} />


### PR DESCRIPTION
# Description

Fixes #10716 
We conditionally set the page title, which causes different number of hooks being rendered, which is not allowed.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

- [ ] On the login page press the "forgot password" link

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
