### PR TITLE
chore: update insights flag expiration

### DIFF
--- a/packages/server/postgres/migrations/2025-03-24T18:29:29.969Z_update-insights-expiry.ts
+++ b/packages/server/postgres/migrations/2025-03-24T18:29:29.969Z_update-insights-expiry.ts
@@ -14,7 +14,7 @@ export async function down(db: Kysely<any>): Promise<void> {
   await db
     .updateTable('FeatureFlag')
     .set({
-      expiresAt: '2025-01-31T00:00:00.000Z'
+      expiresAt: '2025-03-31T00:00:00.000Z'
     })
     .where('featureName', '=', 'insights')
     .execute()


### PR DESCRIPTION
Update insights feature flag expiration date as we decide whether to use Pages instead