### PR TITLE
fix: fix in OrgTeamMembers where {teamName} is not a valid HTML

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembers.tsx
@@ -65,7 +65,7 @@ export const OrgTeamMembers = (props: Props) => {
           </Link>
         </Button>
         <div className='text-gray-700 hover:text-gray-900 text-lg font-bold'>
-          {canEditTeam ? <EditableTeamName team={team} /> : {teamName}}
+          {canEditTeam ? <EditableTeamName team={team} /> : teamName}
         </div>
         <div className='ml-auto flex items-center'>
           <InviteTeamMemberAvatar teamId={team.id} teamMembers={teamMembers} />


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/pull/11357#issuecomment-2937629380

## Demo
![2025-06-04 08 47 16](https://github.com/user-attachments/assets/8308a294-457f-441b-ab01-3023a02f0a74)

![2025-06-04 08 46 33](https://github.com/user-attachments/assets/73c473ef-7f54-4563-aeed-c996699b190c)


## Testing scenarios

- [ ] Org admin or team lead
  - Go to `http://localhost:3000/me/organizations` as a team lead or org admin
  - Click into a team's member page
  - Verify you can rename the team

- [ ] Team member
  - Go to `http://localhost:3000/me/organizations` as a team member
  - Click into a team's member page
  - Verify you *cannot* rename the team but can view the team name just fine

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
