### PR TITLE
fix: do not show hyperlink into team members page in OrgTeamsRow if the viewer is not part of the team

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -49,7 +49,7 @@ const OrgTeamsRow = (props: Props) => {
     <tr className='hover:bg-slate-50 border-b border-slate-300'>
       <td className='flex items-center p-3'>
         <td className='flex items-center p-3'>
-          {isMember ? (
+          {isLead || isMember ? (
             <Link
               to={`teams/${teamId}`}
               className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'


### PR DESCRIPTION
Fix [this issue](https://github.com/ParabolInc/parabol/pull/11357#issuecomment-2939451193)