### PR TITLE
fix: always refresh after app update

### DIFF
--- a/packages/client/hooks/useServiceWorkerUpdater.ts
+++ b/packages/client/hooks/useServiceWorkerUpdater.ts
@@ -15,6 +15,9 @@ const useServiceWorkerUpdater = () => {
       isFirstServiceWorkerRef.current = !registration
     }
     const onServiceWorkerChange = () => {
+      // new service worker means new sources
+      sourcesAreDirtyRef.current = true
+
       if (isFirstServiceWorkerRef.current) {
         isFirstServiceWorkerRef.current = false
         return
@@ -31,7 +34,6 @@ const useServiceWorkerUpdater = () => {
           }
         }
       })
-      sourcesAreDirtyRef.current = true
     }
     if ('serviceWorker' in navigator) {
       setFirstServiceWorker().catch(() => {
@@ -49,7 +51,6 @@ const useServiceWorkerUpdater = () => {
     // When the sources are dirty, we want to reload the page as soon as possible without too much interruption for the user.
     // Let's hide it in a navigation event.
     if (sourcesAreDirtyRef.current) {
-      sourcesAreDirtyRef.current = false
       window.location.reload()
     }
   }, [location.pathname])


### PR DESCRIPTION
# Description

Relates to #10602 
Last release the service worker updated for me fine, but it did not trigger the page reload on navigation events. I assume it's because the check for the first service worker is unreliable on Safari, thus I skip it for this use case.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
