### PR TITLE
chore(dependabot): run it only weekly and reduce the max number of PRs to 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
       - "/"
       - "/packages/*"
     schedule:
-      interval: "daily"
+      interval: weekly
+      day: saturday
+    open-pull-requests-limit: 6
     allow:
       - dependency-type: "production"


### PR DESCRIPTION
# Description
This should reduce the number of PRs and also only create PRs on the weekends. It should be easier to work with
