### PR TITLE
fix: max task card width

### DIFF
--- a/packages/client/styles/helpers/cardRootStyles.ts
+++ b/packages/client/styles/helpers/cardRootStyles.ts
@@ -7,6 +7,7 @@ const cardRootStyles = {
   borderRadius: Card.BORDER_RADIUS,
   boxShadow: cardShadow,
   minWidth: 256,
+  maxWidth: 300,
   position: 'relative' as const,
   width: '100%'
 }


### PR DESCRIPTION
# Description

max width needs to be set for things like code blocks inside the task.
can recreate with content like this: https://github.com/ParabolInc/action-devops/issues/265