### PR TITLE
feat: support public pages

### DIFF
--- a/packages/client/hooks/useAuthRoute.ts
+++ b/packages/client/hooks/useAuthRoute.ts
@@ -1,5 +1,5 @@
 import {useEffect} from 'react'
-import type {AuthTokenRole} from '../types/constEnums'
+import {AuthTokenRole, LocalStorageKey} from '../types/constEnums'
 import useAtmosphere from './useAtmosphere'
 import useDeepEqual from './useDeepEqual'
 import useRouter from './useRouter'
@@ -52,13 +52,14 @@ const useAuthRoute = (inOptions: Options = {}) => {
   useEffect(checkAuth, [atmosphere.authObj, history, options])
 
   // Detect changes to the auth token in localStorage (e.g., user signs out from another tab)
-  const token = window.localStorage.getItem('Action:token')
   useEffect(() => {
-    if (!token) {
-      atmosphere.setAuthToken(null)
+    window.addEventListener('storage', (e) => {
+      // this only fires if another tab has changed localStorage
+      if (e.key !== LocalStorageKey.APP_TOKEN_KEY) return
+      atmosphere.setAuthToken(e.newValue)
       checkAuth()
-    }
-  }, [token])
+    })
+  }, [])
 }
 
 export default useAuthRoute

--- a/packages/client/modules/pages/PageAccessCombobox.tsx
+++ b/packages/client/modules/pages/PageAccessCombobox.tsx
@@ -1,4 +1,4 @@
-import {useRef, useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {useUpdatePageAccessMutation} from '~/mutations/useUpdatePageAccessMutation'
 import type {
@@ -9,7 +9,7 @@ import {PageAccessComboboxControl} from './PageAccessComboboxControl'
 import {UnlinkPageDialog} from './UnlinkPageDialog'
 
 interface Props {
-  defaultRole: PageRoleEnum
+  defaultRole: PageRoleEnum | null
   pageId: string
   subjectId: string
   subjectType: PageSubjectEnum
@@ -58,9 +58,24 @@ export const PageAccessCombobox = (props: Props) => {
       }
     })
   }
+  const nullRoleToggledRef = useRef<boolean>(false)
+
+  // If the combobox loads without a role, set the role to viewer
+  // this is for general access switching from restricted to public
+  useEffect(() => {
+    if (defaultRole !== null || nullRoleToggledRef.current) return
+    nullRoleToggledRef.current = true
+    toggleRole('viewer')
+  }, [])
+
+  if (!defaultRole) return null
   return (
     <>
-      <PageAccessComboboxControl onClick={toggleRole} defaultRole={defaultRole} canRemove />
+      <PageAccessComboboxControl
+        onClick={toggleRole}
+        defaultRole={defaultRole}
+        noOwner={subjectId === '*'}
+      />
       {attemptedRole && (
         <UnlinkPageDialog approveUnlink={approveUnlink} closeDialog={closeDialog} />
       )}

--- a/packages/client/modules/pages/PageAccessComboboxControl.tsx
+++ b/packages/client/modules/pages/PageAccessComboboxControl.tsx
@@ -8,6 +8,7 @@ interface Props {
   canRemove?: boolean
   defaultRole: PageRoleEnum
   onClick: (role: PageRoleEnum | null) => void
+  noOwner?: boolean
 }
 
 const pageRoles = [
@@ -32,7 +33,7 @@ const pageRoles = [
 ] as {value: PageRoleEnum; label: string; description?: string}[]
 
 export const PageAccessComboboxControl = (props: Props) => {
-  const {onClick, defaultRole, canRemove} = props
+  const {onClick, defaultRole, canRemove, noOwner} = props
   const roleLabel = pageRoles.find((role) => role.value === defaultRole)!.label
   return (
     <Menu
@@ -41,6 +42,7 @@ export const PageAccessComboboxControl = (props: Props) => {
     >
       <MenuContent align='end' sideOffset={4} className='max-h-80'>
         {pageRoles.map(({value, label, description}) => {
+          if (noOwner && value === 'owner') return null
           return (
             <MenuItem
               key={value}
@@ -49,8 +51,8 @@ export const PageAccessComboboxControl = (props: Props) => {
               }}
             >
               <div className='flex flex-col'>
-                <div>{label}</div>
-                <div>{description}</div>
+                <div className='text-slate-700'>{label}</div>
+                <div className='font-semibold text-slate-600 text-xs'>{description}</div>
               </div>
             </MenuItem>
           )

--- a/packages/client/modules/pages/PageDeletedHeader.tsx
+++ b/packages/client/modules/pages/PageDeletedHeader.tsx
@@ -16,16 +16,19 @@ export const PageDeletedHeader = (props: Props) => {
     graphql`
       fragment PageDeletedHeader_page on Page {
         id
-            deletedAt
-            deletedByUser {
-              preferredName
-            }
+        deletedAt
+        deletedByUser {
+          preferredName
+        }
+        access {
+          viewer
+        }
       }
     `,
     pageRef
   )
-
-  const {id: pageId, deletedByUser, deletedAt} = page
+  const {id: pageId, deletedByUser, deletedAt, access} = page
+  const {viewer: viewerAccess} = access
   const [execute] = useArchivePageMutation()
   const history = useHistory()
   const restorePage = () => {
@@ -52,18 +55,26 @@ export const PageDeletedHeader = (props: Props) => {
   const relativeTime = relativeDate(deletedAt, {smallDiff: 'just now'})
   const {preferredName} = deletedByUser
   return (
-    <div className='flex w-full items-center justify-center bg-tomato-500 font-semibold text-white'>
+    <div className='flex h-10 w-full items-center justify-center bg-tomato-500 font-semibold text-white'>
       <div className='pr-4'>{`${preferredName} moved this page to the trash ${relativeTime}`}</div>
-      <Button
-        variant='outline'
-        onClick={restorePage}
-        className='m-1 text-white hover:bg-tomato-400'
-      >
-        Restore page
-      </Button>
-      <Button variant='outline' onClick={deletePage} className='m-1 text-white hover:bg-tomato-400'>
-        Delete forever
-      </Button>
+      {viewerAccess === 'owner' && (
+        <>
+          <Button
+            variant='outline'
+            onClick={restorePage}
+            className='m-1 text-white hover:bg-tomato-400'
+          >
+            Restore page
+          </Button>
+          <Button
+            variant='outline'
+            onClick={deletePage}
+            className='m-1 text-white hover:bg-tomato-400'
+          >
+            Delete forever
+          </Button>
+        </>
+      )}
     </div>
   )
 }

--- a/packages/client/modules/pages/PageSharingAccessList.tsx
+++ b/packages/client/modules/pages/PageSharingAccessList.tsx
@@ -1,4 +1,3 @@
-import PublicIcon from '@mui/icons-material/Public'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
 import {Link} from 'react-router-dom'
@@ -9,9 +8,11 @@ import TeamAvatar from '../../components/TeamAvatar/TeamAvatar'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import {useUpdatePageParentLinkMutation} from '../../mutations/useUpdatePageParentLinkMutation'
 import {cn} from '../../ui/cn'
+import {PageSharingGeneralAccess} from './PageSharingGeneralAccess'
 
 graphql`
   fragment PageSharingAccessList_pageAccess on Page {
+    ...PageSharingGeneralAccess_page
     id
     isParentLinked
     access {
@@ -181,22 +182,7 @@ export const PageSharingAccessList = (props: Props) => {
             </div>
           )
         })}
-        {access.public && (
-          <div className='flex items-center justify-between'>
-            <div className='flex items-center gap-3 pr-2'>
-              <PublicIcon className='h-8 w-8' />
-              <div className='flex flex-col'>
-                <div className='font-medium text-slate-700 text-sm'>{'Shared Publicly'}</div>
-              </div>
-            </div>
-            <PageAccessCombobox
-              defaultRole={access.public}
-              subjectId={'*'}
-              subjectType='external'
-              pageId={pageId}
-            />
-          </div>
-        )}
+        <PageSharingGeneralAccess pageRef={page} />
       </div>
     </div>
   )

--- a/packages/client/modules/pages/PageSharingGeneralAccess.tsx
+++ b/packages/client/modules/pages/PageSharingGeneralAccess.tsx
@@ -1,0 +1,101 @@
+import LockIcon from '@mui/icons-material/Lock'
+import PublicIcon from '@mui/icons-material/Public'
+import graphql from 'babel-plugin-relay/macro'
+import {useState} from 'react'
+import {useFragment} from 'react-relay'
+import {PageAccessCombobox} from '~/modules/pages/PageAccessCombobox'
+import type {PageSharingGeneralAccess_page$key} from '../../__generated__/PageSharingGeneralAccess_page.graphql'
+import {Menu} from '../../ui/Menu/Menu'
+import {MenuContent} from '../../ui/Menu/MenuContent'
+import {MenuItem} from '../../ui/Menu/MenuItem'
+import {MenuLabelTrigger} from '../../ui/Menu/MenuLabelTrigger'
+
+interface Props {
+  pageRef: PageSharingGeneralAccess_page$key
+}
+
+const gaRoles = [
+  {
+    value: 'restricted',
+    label: 'Restricted',
+    description: 'Only people with access can view',
+    icon: LockIcon
+  },
+  {
+    value: 'public',
+    label: 'Shared publicly',
+    description: 'Anyone with the link can access',
+    icon: PublicIcon
+  }
+] as const
+
+type GAValue = (typeof gaRoles)[number]['value']
+
+export const PageSharingGeneralAccess = (props: Props) => {
+  const {pageRef} = props
+  const page = useFragment(
+    graphql`
+      fragment PageSharingGeneralAccess_page on Page {
+        id
+        access {
+          public
+        }
+      }
+    `,
+    pageRef
+  )
+  const {id: pageId, access} = page
+  const {public: publicAccess} = access
+  const [GAValue, setGAValue] = useState<GAValue>(publicAccess ? 'public' : 'restricted')
+  const GARole = gaRoles.find((r) => r.value === GAValue)!
+  const {icon: AccessIcon, label} = GARole
+  return (
+    <>
+      <div className='pt-2 font-semibold text-slate-700 text-sm'>General access</div>
+      {
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-3 pr-2'>
+            <AccessIcon className='h-8 w-8' />
+            <div className='flex flex-col'>
+              <Menu
+                trigger={
+                  <MenuLabelTrigger labelClassName={'pr-0'}>
+                    <div className='font-medium text-slate-700 text-sm'>{label}</div>
+                  </MenuLabelTrigger>
+                }
+                className='group'
+              >
+                <MenuContent align='end' sideOffset={4} className='max-h-80'>
+                  {gaRoles.map(({value, label, description}) => {
+                    return (
+                      <MenuItem
+                        className='py-1'
+                        key={value}
+                        onClick={() => {
+                          setGAValue(value)
+                        }}
+                      >
+                        <div className='flex flex-col'>
+                          <div className='font-semibold text-slate-700 text-sm'>{label}</div>
+                          <div className='text-md text-slate-600 text-xs'>{description}</div>
+                        </div>
+                      </MenuItem>
+                    )
+                  })}
+                </MenuContent>
+              </Menu>
+            </div>
+          </div>
+          {GAValue === 'public' && (
+            <PageAccessCombobox
+              defaultRole={publicAccess || null}
+              subjectId={'*'}
+              subjectType='external'
+              pageId={pageId}
+            />
+          )}
+        </div>
+      }
+    </>
+  )
+}

--- a/packages/client/mutations/useArchivePageMutation.ts
+++ b/packages/client/mutations/useArchivePageMutation.ts
@@ -10,6 +10,7 @@ graphql`
   fragment useArchivePageMutation_notification on ArchivePagePayload {
     page {
       ...LeftNavPageLink_page @relay(mask: false)
+      ...PageDeletedHeader_page
       id
       deletedAt
       deletedBy

--- a/packages/server/dataloader/pageLoaderMakers.ts
+++ b/packages/server/dataloader/pageLoaderMakers.ts
@@ -1,5 +1,6 @@
 import DataLoader from 'dataloader'
 import type {Selectable} from 'kysely'
+import {PAGE_ROLES} from '../graphql/public/rules/hasPageAccess'
 import {selectPageAccess, selectPageUserSortOrder} from '../postgres/select'
 import type {PageAccess, Pageroleenum} from '../postgres/types/pg'
 import type RootDataLoader from './RootDataLoader'
@@ -7,7 +8,18 @@ import type RootDataLoader from './RootDataLoader'
 export const pageAccessByPageId = (parent: RootDataLoader) => {
   return new DataLoader<number, Selectable<PageAccess>[], number>(
     async (pageIds) => {
-      const res = await selectPageAccess().where('pageId', 'in', pageIds).execute()
+      const res = await selectPageAccess()
+        .where('pageId', 'in', pageIds)
+        .unionAll((eb) =>
+          eb.parens(
+            eb
+              .selectFrom('PageExternalAccess')
+              .select(['pageId', eb.val('*').as('userId'), 'role'])
+              .where('pageId', 'in', pageIds)
+              .where('email', '=', '*')
+          )
+        )
+        .execute()
       return pageIds.map((pageId) => {
         return res.filter((r) => r.pageId === pageId)
       })
@@ -21,6 +33,7 @@ export const pageAccessByPageId = (parent: RootDataLoader) => {
 export const pageAccessByUserId = (parent: RootDataLoader) => {
   return new DataLoader<{pageId: number; userId: string}, Pageroleenum | null, string>(
     async (keys) => {
+      const pageIds = keys.map((k) => k.pageId)
       const res = await selectPageAccess()
         .where(({eb, refTuple, tuple}) =>
           eb(
@@ -29,10 +42,26 @@ export const pageAccessByUserId = (parent: RootDataLoader) => {
             keys.map((key) => tuple(key.pageId, key.userId))
           )
         )
+        .unionAll((eb) =>
+          eb.parens(
+            eb
+              .selectFrom('PageExternalAccess')
+              .select(['pageId', eb.val('*').as('userId'), 'role'])
+              .where('pageId', 'in', pageIds)
+              .where('email', '=', '*')
+          )
+        )
         .execute()
+      const publicRules = res.filter(({userId}) => userId === '*')
       return keys.map((key) => {
         const rule = res.find(({pageId, userId}) => pageId === key.pageId && userId === key.userId)
-        return rule?.role ?? null
+        const userRole = rule?.role ?? null
+        if (userRole === 'owner') return userRole
+        const publicRule = publicRules.find((rule) => rule.pageId === key.pageId)
+        if (!publicRule) return userRole
+        const publicRole = publicRule.role
+        if (!userRole) return publicRole
+        return PAGE_ROLES.indexOf(userRole) < PAGE_ROLES.indexOf(publicRole) ? userRole : publicRole
       })
     },
     {

--- a/packages/server/graphql/public/mutations/archivePage.ts
+++ b/packages/server/graphql/public/mutations/archivePage.ts
@@ -1,10 +1,9 @@
 import {GraphQLError} from 'graphql'
 import {sql} from 'kysely'
-import {SubscriptionChannel} from '../../../../client/types/constEnums'
 import getKysely from '../../../postgres/getKysely'
 import {getUserId} from '../../../utils/authorization'
 import {CipherId} from '../../../utils/CipherId'
-import publish from '../../../utils/publish'
+import {publishPageNotification} from '../../../utils/publishPageNotification'
 import {addCanonicalPageLink} from '../../../utils/tiptap/addCanonicalPageLink'
 import {removeBacklinkedPageLinkBlocks} from '../../../utils/tiptap/hocusPocusHub'
 import {removeCanonicalPageLinkFromPage} from '../../../utils/tiptap/removeCanonicalPageLinkFromPage'
@@ -93,10 +92,7 @@ const archivePage: MutationResolvers['archivePage'] = async (
     }
   }
   const data = {pageId: dbPageId, action}
-  const access = await dataLoader.get('pageAccessByPageId').load(dbPageId)
-  access.forEach(({userId}) => {
-    publish(SubscriptionChannel.NOTIFICATION, userId, 'ArchivePagePayload', data, subOptions)
-  })
+  publishPageNotification(dbPageId, 'ArchivePagePayload', data, subOptions, dataLoader)
   return data
 }
 

--- a/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
+++ b/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
@@ -1,11 +1,10 @@
 import {GraphQLError} from 'graphql'
 import {sql} from 'kysely'
-import {SubscriptionChannel} from '../../../../../client/types/constEnums'
 import {getNewDataLoader} from '../../../../dataloader/getNewDataLoader'
 import getKysely from '../../../../postgres/getKysely'
 import {selectDescendantPages} from '../../../../postgres/select'
 import {updatePageAccessTable} from '../../../../postgres/updatePageAccessTable'
-import publish from '../../../../utils/publish'
+import {publishPageNotification} from '../../../../utils/publishPageNotification'
 import {removeCanonicalPageLinkFromPage} from '../../../../utils/tiptap/removeCanonicalPageLinkFromPage'
 import {validateParentPage} from '../../../../utils/tiptap/validateParentPage'
 
@@ -272,9 +271,6 @@ export const movePageToNewParent = async (
   const operationId = dataLoader.share()
   const subOptions = {operationId, mutatorId: undefined}
   const data = {pageId}
-  const access = await dataLoader.get('pageAccessByPageId').load(pageId)
-  access.forEach(({userId}) => {
-    publish(SubscriptionChannel.NOTIFICATION, userId, 'UpdatePagePayload', data, subOptions)
-  })
+  await publishPageNotification(pageId, 'UpdatePagePayload', data, subOptions, dataLoader)
   dataLoader.dispose()
 }

--- a/packages/server/utils/publishPageNotification.ts
+++ b/packages/server/utils/publishPageNotification.ts
@@ -1,0 +1,38 @@
+import {pack} from 'msgpackr'
+import {SubscriptionChannel} from '../../client/types/constEnums'
+import type {DataLoaderInstance} from '../dataloader/RootDataLoader'
+import type {ResolversTypes} from '../graphql/public/resolverTypes'
+import getRedis from './getRedis'
+import publish from './publish'
+
+export type PublicPageNotificationPayload<T extends keyof ResolversTypes = 'CreatePagePayload'> = {
+  type: T
+  data: ResolversTypes[T]
+  subOptions: {mutatorId?: string; operationId?: string}
+  userIdsToIgnore: string[]
+}
+
+export const publishPageNotification = async (
+  pageId: number,
+  type: string,
+  data: Record<string, any>,
+  subOptions: {mutatorId?: string; operationId?: string},
+  dataLoader: DataLoaderInstance
+) => {
+  const access = await dataLoader.get('pageAccessByPageId').load(pageId)
+  const userIds = access.map((a) => a.userId).filter((userId) => userId !== '*')
+  const isPubliclyAccessible = userIds.length < access.length
+  userIds.forEach((userId) => {
+    publish(SubscriptionChannel.NOTIFICATION, userId, type, data, subOptions)
+  })
+  if (isPubliclyAccessible) {
+    const payload = {
+      type,
+      data,
+      subOptions,
+      userIdsToIgnore: userIds
+    } as PublicPageNotificationPayload
+    const redis = getRedis()
+    await redis.publish(`publicPage:${pageId}`, pack(payload))
+  }
+}

--- a/packages/server/utils/tiptap/createChildPage.ts
+++ b/packages/server/utils/tiptap/createChildPage.ts
@@ -1,10 +1,9 @@
 import {sql} from 'kysely'
-import {SubscriptionChannel} from '../../../client/types/constEnums'
 import {getNewDataLoader} from '../../dataloader/getNewDataLoader'
 import getKysely from '../../postgres/getKysely'
 import {updatePageAccessTable} from '../../postgres/updatePageAccessTable'
 import {analytics} from '../../utils/analytics/analytics'
-import publish from '../publish'
+import {publishPageNotification} from '../publishPageNotification'
 import {validateParentPage} from './validateParentPage'
 
 export const createChildPage = async (parentPageId: number, userId: string) => {
@@ -77,10 +76,7 @@ export const createChildPage = async (parentPageId: number, userId: string) => {
   const operationId = dataLoader.share()
   const subOptions = {operationId, mutatorId: undefined}
   const data = {page}
-  const access = await dataLoader.get('pageAccessByPageId').load(pageId)
-  access.forEach(({userId}) => {
-    publish(SubscriptionChannel.NOTIFICATION, userId, 'CreatePagePayload', data, subOptions)
-  })
+  await publishPageNotification(pageId, 'CreatePagePayload', data, subOptions, dataLoader)
   dataLoader.dispose()
   return page
 }

--- a/packages/server/utils/tiptap/hocusPocusRedisPublisher.ts
+++ b/packages/server/utils/tiptap/hocusPocusRedisPublisher.ts
@@ -1,0 +1,43 @@
+import {
+  type afterLoadDocumentPayload,
+  type afterUnloadDocumentPayload,
+  type Extension
+} from '@hocuspocus/server'
+import {unpack} from 'msgpackr'
+import {SubscriptionChannel} from '../../../client/types/constEnums'
+import {CipherId} from '../CipherId'
+import publish from '../publish'
+import type {PublicPageNotificationPayload} from '../publishPageNotification'
+import RedisInstance from '../RedisInstance'
+
+export class RedisPublisher implements Extension {
+  priority = 1001
+
+  sub: RedisInstance
+
+  public constructor() {
+    this.sub = new RedisInstance('publicPage_sub')
+  }
+
+  private getChannelName(documentName: string) {
+    const [dbId] = CipherId.fromClient(documentName)
+    return `publicPage:${dbId}`
+  }
+  async afterLoadDocument({documentName, document}: afterLoadDocumentPayload) {
+    this.sub.subscribe(this.getChannelName(documentName))
+    this.sub.on('messageBuffer', (_channel, message) => {
+      const payload = unpack(message) as PublicPageNotificationPayload
+      const {data, subOptions, type, userIdsToIgnore} = payload
+      document.connections.forEach(({connection}) => {
+        const {context} = connection
+        const userId = context.userId as string | undefined
+        if (!userId || userIdsToIgnore.includes(userId)) return
+        publish(SubscriptionChannel.NOTIFICATION, userId, type, data, subOptions)
+      })
+    })
+  }
+
+  async afterUnloadDocument({documentName}: afterUnloadDocumentPayload) {
+    await this.sub.unsubscribe(this.getChannelName(documentName))
+  }
+}


### PR DESCRIPTION
# Description

To mark a page as publicly accessible, you set PageExternalAccess.email = '*' in the DB.
Then, when you want to determine if a user has access to a page, just union that with the PageAccess table.

The one gotcha here is how to publish GQL payloads to these public users (e.g. when you change the title).
We need to send a GQL payload to everyone with access to a page as well as everyone who is viewing it publicly.
To do that, we publish a message via redis to each hocus pocus server on a channel just for that pageId. The hocus pocus server iterates through each websocket connection for that page and if the userId isn't on the access list, we know they're viewing it publicly, so we publish the payload to them.

I wanted the UI to have a little more friction for making something public, so made it 2 dropdown boxes. this is what notion does, and they borrowed the idea from google docs.

<img width="464" height="321" alt="Screenshot 2025-08-21 at 6 17 38 PM" src="https://github.com/user-attachments/assets/cd6491d2-0051-4e6e-a890-9150d6a93878" />

<img width="424" height="296" alt="Screenshot 2025-08-21 at 6 16 29 PM" src="https://github.com/user-attachments/assets/979887af-f4bf-4970-9d49-0a1e1724736f" />

