### PR TITLE
chore: speed up teamsWithUserSort query

### DIFF
--- a/packages/server/dataloader/teamLoaderMakers.ts
+++ b/packages/server/dataloader/teamLoaderMakers.ts
@@ -1,5 +1,6 @@
 import DataLoader from 'dataloader'
 import type {Selectable} from 'kysely'
+import TeamMemberId from '../../client/shared/gqlIds/TeamMemberId'
 import getKysely from '../postgres/getKysely'
 import {selectTeams} from '../postgres/select'
 import type {Team} from '../postgres/types'
@@ -21,11 +22,11 @@ export const teamsWithUserSort = (parent: RootDataLoader, dependsOn: RegisterDep
       const res = await selectTeams()
         .innerJoin('TeamMember', 'Team.id', 'TeamMember.teamId')
         .select(['sortOrder', 'userId'])
-        .where(({eb, refTuple, tuple}) =>
+        .where(({eb}) =>
           eb(
-            refTuple('TeamMember.teamId', 'TeamMember.userId'),
+            'TeamMember.id',
             'in',
-            keys.map((key) => tuple(key.teamId, key.userId))
+            keys.map(({teamId, userId}) => TeamMemberId.join(teamId, userId))
           )
         )
         .execute()


### PR DESCRIPTION
The query was slow, up to 3s. Filtering with the primary key of TeamMember speeds this up a lot, although there are indicies on `userId` and `teamId`.

https://app.datadoghq.com/apm/trace/68b1b6e4000000007dfe3afaa86f1e1e?graphType=span_list&shouldShowLegend=true&spanID=6077654895956383861&timeHint=1756477232772.308&traceQuery=

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
