### PR TITLE
chore(nodejs): upgrade to 22.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/ParabolInc/parabol/issues"
   },
   "engines": {
-    "node": "^22.17.1"
+    "node": "^22.19.0"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
# Description

Upgrades node to 22.19.0, last LTS available version

I ran `pnpm i` but nothing got updated in the pnpm-lock.yml. I imagine it's because the last PR upgraded it and it was just some minutes ago. 