### PR TITLE
fix: Allow deleting deleted tasks from Poker scope

### DIFF
--- a/packages/client/components/PokerEstimateHeaderCard.tsx
+++ b/packages/client/components/PokerEstimateHeaderCard.tsx
@@ -94,6 +94,7 @@ const PokerEstimateHeaderCard = (props: Props) => {
     graphql`
       fragment PokerEstimateHeaderCard_stage on EstimateStage {
         meetingId
+        taskId
         task {
           ...PokerEstimateHeaderCardParabol_task
           integrationHash
@@ -151,7 +152,29 @@ const PokerEstimateHeaderCard = (props: Props) => {
   )
   const {meetingId, task} = stage
   if (!task) {
-    return <PokerEstimateHeaderCardError />
+    const {taskId} = stage
+    const onRemove = () => {
+      UpdatePokerScopeMutation(
+        atmosphere,
+        {
+          meetingId,
+          updates: [
+            {
+              service: 'PARABOL',
+              serviceTaskId: taskId,
+              action: 'DELETE'
+            }
+          ]
+        },
+        {
+          onCompleted: () => {},
+          onError: () => {},
+          contents: []
+        }
+      )
+    }
+
+    return <PokerEstimateHeaderCardError onRemove={onRemove} />
   }
 
   const {integrationHash, integration} = task

--- a/packages/client/components/PokerEstimateHeaderCardError.tsx
+++ b/packages/client/components/PokerEstimateHeaderCardError.tsx
@@ -8,16 +8,6 @@ import {Tooltip} from '../ui/Tooltip/Tooltip'
 import {TooltipContent} from '../ui/Tooltip/TooltipContent'
 import {TooltipTrigger} from '../ui/Tooltip/TooltipTrigger'
 
-const ErrorCard = styled('div')({
-  alignItems: 'flex-start',
-  background: PALETTE.WHITE,
-  borderRadius: 4,
-  boxShadow: Elevation.Z1,
-  padding: '12px 8px 12px 16px',
-  maxWidth: 1504, // matches widest dimension column 1600 - padding etc.
-  margin: '0 auto',
-  width: '100%'
-})
 const HeaderCardWrapper = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
   display: 'flex',
   padding: isDesktop ? '0px 16px 4px' : '0px 8px 4px'
@@ -61,22 +51,32 @@ const CardDescription = styled('div')<{isExpanded: boolean}>(({isExpanded}) => (
 
 interface Props {
   service?: string
-  onRemove?: () => void
+  onRemove: () => void
 }
 const PokerEstimateHeaderCardError = (props: Props) => {
   const {onRemove, service} = props
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
-  if (!service || !onRemove) {
+  if (!service) {
     return (
       <HeaderCardWrapper isDesktop={isDesktop}>
-        <ErrorCard>
+        <HeaderCard>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button className='absolute top-2 right-2 cursor-pointer bg-inherit'>
+                <DeleteIcon onClick={() => onRemove()} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side='bottom' align='center' sideOffset={2} className=''>
+              {'Remove from Scope'}
+            </TooltipContent>
+          </Tooltip>
           <CardTitleWrapper>
             <CardTitle>{`That story doesn't exist!`}</CardTitle>
           </CardTitleWrapper>
           <CardDescription isExpanded={false}>
             {`The story was deleted. You can add another story in the Scope phase.`}
           </CardDescription>
-        </ErrorCard>
+        </HeaderCard>
       </HeaderCardWrapper>
     )
   }


### PR DESCRIPTION
# Description

Fixes #10309 
Adding a simple delete button if the task is gone already.

## Demo

<img width="1188" height="266" alt="image" src="https://github.com/user-attachments/assets/3eae2877-3848-49e7-8f75-ec70938c679c" />


## Testing scenarios

- add a parabol task to sprint poker
- delete the task
- refresh poker
- press the new delete button

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
