### PR TITLE
fix: mark jira integrations as inactive if we cannot refresh them

### DIFF
--- a/packages/server/integrations/helpers/authorizeOAuth2.ts
+++ b/packages/server/integrations/helpers/authorizeOAuth2.ts
@@ -72,8 +72,7 @@ export const authorizeOAuth2 = async <
   }
   const tokenJson = (await oauth2Response.json()) as OAuth2Response
   if ('error' in tokenJson) {
-    // Log the detailed error from the OAuth provider
-    console.error(`OAuth2 Error from ${authUrl}:`, tokenJson)
+    // any logging should be performed by the caller
     const errorMessage =
       tokenJson.error_description || tokenJson.error || `Received OAuth2 Error from ${authUrl}`
     return new Error(errorMessage)

--- a/packages/server/postgres/queries/removeAtlassianAuth.ts
+++ b/packages/server/postgres/queries/removeAtlassianAuth.ts
@@ -1,7 +1,0 @@
-import getPg from '../getPg'
-import {removeAtlassianAuthQuery} from './generated/removeAtlassianAuthQuery'
-
-const removeAtlassianAuth = async (userId: string, teamId: string) => {
-  await removeAtlassianAuthQuery.run({userId, teamId}, getPg())
-}
-export default removeAtlassianAuth

--- a/packages/server/postgres/queries/src/removeAtlassianAuthQuery.sql
+++ b/packages/server/postgres/queries/src/removeAtlassianAuthQuery.sql
@@ -1,6 +1,0 @@
-/*
-  @name removeAtlassianAuthQuery
-*/
-UPDATE "AtlassianAuth"
-SET "isActive" = FALSE
-WHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE;


### PR DESCRIPTION
# Description

inactivates jira integrations if the refresh tokens are invalid.

fixes #11849