### PR TITLE
fix: stop calling redis subscribe with 0 args

### DIFF
--- a/packages/server/graphql/public/subscriptions/meetingSubscription.ts
+++ b/packages/server/graphql/public/subscriptions/meetingSubscription.ts
@@ -23,7 +23,7 @@ const meetingSubscription: SubscriptionResolvers['meetingSubscription'] = {
 
     // RESOLUTION
     const channelName = `${SubscriptionChannel.MEETING}.${meetingId}`
-    const iter = getPubSub().subscribe([channelName])
+    const iter = await getPubSub().subscribe([channelName])
     return broadcastSubscription(iter, context)
   }
 }

--- a/packages/server/graphql/public/subscriptions/notificationSubscription.ts
+++ b/packages/server/graphql/public/subscriptions/notificationSubscription.ts
@@ -16,7 +16,7 @@ const notificationSubscription: SubscriptionResolvers['notificationSubscription'
     const viewerId = getUserId(authToken)
     const channelName = `${SubscriptionChannel.NOTIFICATION}.${viewerId}`
 
-    const iter = getPubSub().subscribe([channelName])
+    const iter = await getPubSub().subscribe([channelName])
     return broadcastSubscription(iter, context)
   }
 }

--- a/packages/server/graphql/public/subscriptions/organizationSubscription.ts
+++ b/packages/server/graphql/public/subscriptions/organizationSubscription.ts
@@ -22,7 +22,7 @@ const organizationSubscription: SubscriptionResolvers['organizationSubscription'
 
     // RESOLUTION
     const channelNames = orgIds.map((id) => `${SubscriptionChannel.ORGANIZATION}.${id}`)
-    const iter = getPubSub().subscribe(channelNames)
+    const iter = await getPubSub().subscribe(channelNames)
     return broadcastSubscription(iter, context)
   }
 }

--- a/packages/server/graphql/public/subscriptions/taskSubscription.ts
+++ b/packages/server/graphql/public/subscriptions/taskSubscription.ts
@@ -15,7 +15,7 @@ const taskSubscription: SubscriptionResolvers['taskSubscription'] = {
     // RESOLUTION
     const viewerId = getUserId(authToken)
     const channelName = `${SubscriptionChannel.TASK}.${viewerId}`
-    const iter = getPubSub().subscribe([channelName])
+    const iter = await getPubSub().subscribe([channelName])
     return broadcastSubscription(iter, context)
   }
 }

--- a/packages/server/graphql/public/subscriptions/teamSubscription.ts
+++ b/packages/server/graphql/public/subscriptions/teamSubscription.ts
@@ -14,7 +14,7 @@ const teamSubscription: SubscriptionResolvers['teamSubscription'] = {
     // RESOLUTION
     const {tms: teamIds} = authToken
     const channelNames = teamIds.map((id) => `${SubscriptionChannel.TEAM}.${id}`)
-    const iter = getPubSub().subscribe(channelNames)
+    const iter = await getPubSub().subscribe(channelNames)
     return broadcastSubscription(iter, context)
   }
 }

--- a/packages/server/utils/GraphQLRedisPubSub.ts
+++ b/packages/server/utils/GraphQLRedisPubSub.ts
@@ -28,8 +28,10 @@ export default class GraphQLRedisPubSub {
     return this.publisher.publish(channel, JSON.stringify(payload))
   }
 
-  subscribe = (channels: string[]) => {
-    this.subscriber.subscribe(...channels)
+  subscribe = async (channels: string[]) => {
+    if (channels.length > 0) {
+      await this.subscriber.subscribe(...channels)
+    }
     const onStart = (listener: SubscriptionListener) => {
       channels.forEach((channel) => {
         this.listenersByChannel[channel] = this.listenersByChannel[channel] || []


### PR DESCRIPTION
# Description

fixes #12103 

ensure that we only call redis subscribe if there's at least 1 subject to subscribe to. https://github.com/ParabolInc/parabol/pull/12095/files#diff-069d2665b6892496cdb3b8c9455dfa538f83ac24d61376c410a88728c3770225

I added an await to the subscribe call. I did this so errors propagate properly and don't bubble up to the top where they crash the server.