### PR TITLE
fix: redirect to meeting summary page instead of /new-summary

### DIFF
--- a/packages/client/components/PokerMeetingSidebar.tsx
+++ b/packages/client/components/PokerMeetingSidebar.tsx
@@ -8,6 +8,7 @@ import type {
 import useRouter from '~/hooks/useRouter'
 import useAtmosphere from '../hooks/useAtmosphere'
 import type useGotoStageId from '../hooks/useGotoStageId'
+import {GQLID} from '../utils/GQLID'
 import getSidebarItemStage from '../utils/getSidebarItemStage'
 import findStageById from '../utils/meetings/findStageById'
 import MeetingNavList from './MeetingNavList'
@@ -138,7 +139,7 @@ const PokerMeetingSidebar = (props: Props) => {
             isUnsyncedFacilitatorPhase={false}
             handleClick={() => {
               const summaryURL = summaryPageId
-                ? `/pages/${Number(summaryPageId.split('page:')[1])}`
+                ? `/pages/${GQLID.fromKey(summaryPageId)[0]}`
                 : `/new-summary/${meetingId}`
               history.push(summaryURL)
             }}

--- a/packages/client/components/RetroMeetingSidebar.tsx
+++ b/packages/client/components/RetroMeetingSidebar.tsx
@@ -9,6 +9,7 @@ import useRouter from '~/hooks/useRouter'
 import isDemoRoute from '~/utils/isDemoRoute'
 import useAtmosphere from '../hooks/useAtmosphere'
 import type useGotoStageId from '../hooks/useGotoStageId'
+import {GQLID} from '../utils/GQLID'
 import getSidebarItemStage from '../utils/getSidebarItemStage'
 import findStageById from '../utils/meetings/findStageById'
 import isPhaseComplete from '../utils/meetings/isPhaseComplete'
@@ -169,7 +170,7 @@ const RetroMeetingSidebar = (props: Props) => {
                 history.push('/retrospective-demo-summary')
               } else {
                 const summaryURL = summaryPageId
-                  ? `/pages/${Number(summaryPageId.split('page:')[1])}`
+                  ? `/pages/${GQLID.fromKey(summaryPageId)[0]}`
                   : `/new-summary/${meetingId}`
                 history.push(summaryURL)
               }

--- a/packages/client/components/TimelineEventCompletedActionMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedActionMeeting.tsx
@@ -4,6 +4,7 @@ import {useFragment} from 'react-relay'
 import type {TimelineEventCompletedActionMeeting_timelineEvent$key} from '../__generated__/TimelineEventCompletedActionMeeting_timelineEvent.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import relativeDate from '../utils/date/relativeDate'
+import {GQLID} from '../utils/GQLID'
 import plural from '../utils/plural'
 import SendClientSideEvent from '../utils/SendClientSideEvent'
 import StyledLink from './StyledLink'
@@ -73,7 +74,7 @@ const TimelineEventCompletedActionMeeting = (props: Props) => {
   const {id: orgId, viewerOrganizationUser} = organization
   const canUpgrade = !!viewerOrganizationUser
   const summaryURL = summaryPageId
-    ? `/pages/${Number(summaryPageId.split('page:')[1])}`
+    ? `/pages/${GQLID.fromKey(summaryPageId)[0]}`
     : `/new-summary/${meetingId}`
   const atmosphere = useAtmosphere()
   const onUpgrade = () => {

--- a/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
@@ -3,6 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
 import type {TimelineEventCompletedRetroMeeting_timelineEvent$key} from '../__generated__/TimelineEventCompletedRetroMeeting_timelineEvent.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
+import {GQLID} from '../utils/GQLID'
 import plural from '../utils/plural'
 import SendClientSideEvent from '../utils/SendClientSideEvent'
 import StyledLink from './StyledLink'
@@ -69,7 +70,7 @@ const TimelineEventCompletedRetroMeeting = (props: Props) => {
   const {id: orgId, viewerOrganizationUser} = organization
   const canUpgrade = !!viewerOrganizationUser
   const summaryURL = summaryPageId
-    ? `/pages/${Number(summaryPageId.split('page:')[1])}`
+    ? `/pages/${GQLID.fromKey(summaryPageId)[0]}`
     : `/new-summary/${meetingId}`
   const atmosphere = useAtmosphere()
   const onUpgrade = () => {

--- a/packages/client/components/TimelineEventPokerComplete.tsx
+++ b/packages/client/components/TimelineEventPokerComplete.tsx
@@ -3,6 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
 import type {TimelineEventPokerComplete_timelineEvent$key} from '../__generated__/TimelineEventPokerComplete_timelineEvent.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
+import {GQLID} from '../utils/GQLID'
 import plural from '../utils/plural'
 import SendClientSideEvent from '../utils/SendClientSideEvent'
 import CardsSVG from './CardsSVG'
@@ -84,7 +85,7 @@ const TimelineEventPokerComplete = (props: Props) => {
     })
   }
   const summaryURL = summaryPageId
-    ? `/pages/${Number(summaryPageId.split('page:')[1])}`
+    ? `/pages/${GQLID.fromKey(summaryPageId)[0]}`
     : `/new-summary/${meetingId}`
   return (
     <TimelineEventCard

--- a/packages/client/components/TimelineEventTeamPromptComplete.tsx
+++ b/packages/client/components/TimelineEventTeamPromptComplete.tsx
@@ -3,6 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
 import type {TimelineEventTeamPromptComplete_timelineEvent$key} from '../__generated__/TimelineEventTeamPromptComplete_timelineEvent.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
+import {GQLID} from '../utils/GQLID'
 import plural from '../utils/plural'
 import SendClientSideEvent from '../utils/SendClientSideEvent'
 import StyledLink from './StyledLink'
@@ -74,7 +75,7 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
   const {id: orgId, viewerOrganizationUser} = organization
   const canUpgrade = !!viewerOrganizationUser
   const summaryURL = summaryPageId
-    ? `/pages/${Number(summaryPageId.split('page:')[1])}`
+    ? `/pages/${GQLID.fromKey(summaryPageId)[0]}`
     : `/new-summary/${meetingId}`
   const onUpgrade = () => {
     SendClientSideEvent(atmosphere, 'Upgrade CTA Clicked', {

--- a/packages/client/hooks/useDraggablePage.tsx
+++ b/packages/client/hooks/useDraggablePage.tsx
@@ -13,9 +13,9 @@ import {
 import {__END__, positionAfter, positionBefore, positionBetween} from '../shared/sortOrder'
 import {createPageLinkElement} from '../shared/tiptap/createPageLinkElement'
 import {providerManager} from '../tiptap/providerManager'
+import {GQLID} from '../utils/GQLID'
 import useAtmosphere from './useAtmosphere'
 import useEventCallback from './useEventCallback'
-
 import {makeEditorFromYDoc} from './useTipTapPageEditor'
 
 const makeDragRef = () => ({
@@ -123,7 +123,7 @@ export const useDraggablePage = (
       const provider = providerManager.register(targetParentPageId)
       const {document} = provider
       const frag = document.getXmlFragment('default')
-      const pageCode = Number(pageId.split('page:')[1])
+      const pageCode = GQLID.fromKey(pageId)[0]
       // Yjs doesn't support moves
       // You cannot delete an item and then insert it elsewhere because once an object is deleted it is gone
       // Prosemirror accomplishes moves by swapping the attributes of every item between source and target
@@ -160,7 +160,7 @@ export const useDraggablePage = (
       // when making something a child page, we don't use GraphQL, we use yjs
       // in the future, I hope every user-defined page is a child so this is the only code path
       providerManager.withDoc(targetParentPageId, (doc) => {
-        const pageCode = Number(pageId.split('page:')[1])
+        const pageCode = GQLID.fromKey(pageId)[0]
         const title = source.get(pageId)?.title as string
         const createPageLinkBlock = () => createPageLinkElement(pageCode, title)
         const frag = doc.getXmlFragment('default')
@@ -219,7 +219,7 @@ export const useDraggablePage = (
       // if the source has a parent and it lived under the parent or team, remove the canonical page link. the GQL subscription will propagate the removal
       providerManager.withDoc(sourceParentPageId, (document) => {
         const frag = document.getXmlFragment('default')
-        const pageCode = Number(pageId.split('page:')[1])
+        const pageCode = GQLID.fromKey(pageId)[0]
         const idxToRemove = frag
           .toArray()
           .findIndex(

--- a/packages/client/modules/pages/ArchivedPages.tsx
+++ b/packages/client/modules/pages/ArchivedPages.tsx
@@ -6,6 +6,7 @@ import {type PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import {useHistory} from 'react-router'
 import type {ArchivedPagesQuery} from '../../__generated__/ArchivedPagesQuery.graphql'
 import {useArchivePageMutation} from '../../mutations/useArchivePageMutation'
+import {GQLID} from '../../utils/GQLID'
 import {ArchivedPagesButton} from './ArchivedPagesButton'
 
 interface Props {
@@ -46,8 +47,8 @@ export const ArchivedPages = (props: Props) => {
     })
   }
   const deletePage = (pageId: string) => {
-    const pageCode = pageId.split('page:')[1]!
-    if (location.href.endsWith(pageCode)) {
+    const pageCode = GQLID.fromKey(pageId)[0]
+    if (location.href.endsWith(`${pageCode}`)) {
       history.push('/me')
     }
     execute({

--- a/packages/client/modules/pages/PageDeletedHeader.tsx
+++ b/packages/client/modules/pages/PageDeletedHeader.tsx
@@ -6,6 +6,7 @@ import useAtmosphere from '../../hooks/useAtmosphere'
 import {useArchivePageMutation} from '../../mutations/useArchivePageMutation'
 import {Button} from '../../ui/Button/Button'
 import relativeDate from '../../utils/date/relativeDate'
+import {GQLID} from '../../utils/GQLID'
 
 interface Props {
   pageRef: PageDeletedHeader_page$key
@@ -43,8 +44,8 @@ export const PageDeletedHeader = (props: Props) => {
     })
   }
   const deletePage = () => {
-    const pageCode = pageId.split('page:')[1]!
-    if (location.href.endsWith(pageCode)) {
+    const pageCode = GQLID.fromKey(pageId)[0]
+    if (location.href.endsWith(`${pageCode}`)) {
       history.push('/me')
     }
     execute({

--- a/packages/client/mutations/EndCheckInMutation.ts
+++ b/packages/client/mutations/EndCheckInMutation.ts
@@ -12,6 +12,7 @@ import type {
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
+import {GQLID} from '../utils/GQLID'
 import handleAddTimelineEvent from './handlers/handleAddTimelineEvent'
 import handleRemoveSuggestedActions from './handlers/handleRemoveSuggestedActions'
 import handleRemoveTasks from './handlers/handleRemoveTasks'
@@ -88,7 +89,7 @@ export const endCheckInTeamOnNext: OnNextHandler<
       history.push(`/team/${teamId}`)
       popEndMeetingToast(atmosphere, meetingId)
     } else if (summaryPageId) {
-      const pageCode = Number(summaryPageId.split('page:')[1])
+      const pageCode = GQLID.fromKey(summaryPageId)[0]
       history.push(`/pages/${pageCode}`)
     }
   }

--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -13,6 +13,7 @@ import type {
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
+import {GQLID} from '../utils/GQLID'
 import handleAddTimelineEvent from './handlers/handleAddTimelineEvent'
 import handleRemoveSuggestedActions from './handlers/handleRemoveSuggestedActions'
 import popEndMeetingToast from './toasts/popEndMeetingToast'
@@ -97,7 +98,7 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
       history.push(`/team/${teamId}`)
       popEndMeetingToast(atmosphere, meetingId)
     } else if (summaryPageId) {
-      const pageCode = Number(summaryPageId.split('page:')[1])
+      const pageCode = GQLID.fromKey(summaryPageId)[0]
       history.push(`/pages/${pageCode}`)
     }
   }

--- a/packages/client/mutations/EndSprintPokerMutation.ts
+++ b/packages/client/mutations/EndSprintPokerMutation.ts
@@ -11,6 +11,7 @@ import type {
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
+import {GQLID} from '../utils/GQLID'
 import handleAddTimelineEvent from './handlers/handleAddTimelineEvent'
 import handleRemoveTasks from './handlers/handleRemoveTasks'
 import popEndMeetingToast from './toasts/popEndMeetingToast'
@@ -81,7 +82,7 @@ export const endSprintPokerTeamOnNext: OnNextHandler<
       history.push(`/team/${teamId}`)
       popEndMeetingToast(atmosphere, meetingId)
     } else if (summaryPageId) {
-      const pageCode = Number(summaryPageId.split('page:')[1])
+      const pageCode = GQLID.fromKey(summaryPageId)[0]
       history.push(`/pages/${pageCode}`)
     }
   }

--- a/packages/client/mutations/EndTeamPromptMutation.ts
+++ b/packages/client/mutations/EndTeamPromptMutation.ts
@@ -11,6 +11,7 @@ import type {
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
+import {GQLID} from '../utils/GQLID'
 import handleAddTimelineEvent from './handlers/handleAddTimelineEvent'
 
 graphql`
@@ -69,7 +70,7 @@ export const endTeamPromptTeamOnNext: OnNextHandler<
   const {id: meetingId, summaryPageId} = meeting
   if (onMeetingRoute(window.location.pathname, [meetingId])) {
     if (summaryPageId) {
-      const pageCode = Number(summaryPageId.split('page:')[1])
+      const pageCode = GQLID.fromKey(summaryPageId)[0]
       history.push(`/pages/${pageCode}`)
     }
   }

--- a/packages/client/utils/GQLID.ts
+++ b/packages/client/utils/GQLID.ts
@@ -1,0 +1,8 @@
+export const GQLID = {
+  toKey: (code: number, entity: string) => `${entity}:${code}`,
+  fromKey: (key: string) => {
+    const [entity, codeStr] = key.split(':')
+    const code = Number(codeStr)
+    return [code, entity] as [code: number, entity: string]
+  }
+}


### PR DESCRIPTION
# Description

fixes #12202 

fixes timeline events to go to the Page instead of /new-summary, when available.
Also fixes the "Summary" link in the meeting