### PR TITLE
chore: reduced page invite email for new users

### DIFF
--- a/packages/client/modules/email/components/Button.tsx
+++ b/packages/client/modules/email/components/Button.tsx
@@ -14,10 +14,15 @@ const linkStyle = {
   width: '100%'
 } as React.CSSProperties
 
-const Button = (props: {url: string; width?: number; children: ReactNode}) => {
-  const {url, width = 240} = props
+const Button = (props: {
+  url: string
+  width?: number
+  children: ReactNode
+  style?: React.CSSProperties
+}) => {
+  const {url, width = 240, style = {}} = props
   return (
-    <table style={{...emailTableBase, width}} width={width}>
+    <table style={{...emailTableBase, width, ...style}} width={width}>
       <tbody>
         <tr>
           <td align='center' style={cellStyle}>

--- a/packages/client/modules/email/components/PageSharedInvite.tsx
+++ b/packages/client/modules/email/components/PageSharedInvite.tsx
@@ -53,11 +53,11 @@ export const pageRoles = {
 
 export interface PageSharedInviteProps {
   appOrigin: string
-  ownerName: string
+  ownerName: string | null
   ownerEmail: string
   ownerAvatar: string
   pageLink: string
-  pageName: string
+  pageName: string | null
   role: PageRoleEnum
   corsOptions: CorsOptions
 }
@@ -66,10 +66,11 @@ const PageSharedInvite = (props: PageSharedInviteProps) => {
   const {appOrigin, ownerName, ownerEmail, ownerAvatar, pageLink, pageName, role, corsOptions} =
     props
   const pageAccess = pageRoles[role] || 'view'
+  const owner = ownerName ? ownerName : ownerEmail
   return (
     <Layout maxWidth={544}>
       <EmailBlock innerMaxWidth={innerMaxWidth}>
-        <h1 style={emailHeadingStyle}>{ownerName} shared a page</h1>
+        <h1 style={emailHeadingStyle}>{owner} shared a page</h1>
         <p style={emailCopyStyle}>
           <table style={emailTableBase} width='100%'>
             <tbody>
@@ -84,50 +85,68 @@ const PageSharedInvite = (props: PageSharedInviteProps) => {
                   />
                 </td>
                 <td style={{paddingLeft: '18px'}}>
-                  <span style={boldStyle}>{ownerName}</span>
-                  {' ('}
-                  <a href={`mailto:${ownerEmail}`} style={emailLinkStyle}>
-                    {ownerEmail}
-                  </a>
-                  {') has invited you to '}
+                  {ownerName ? (
+                    <>
+                      <span style={boldStyle}>{ownerName}</span>
+                      {' ('}
+                      <a href={`mailto:${ownerEmail}`} style={emailLinkStyle}>
+                        {ownerEmail}
+                      </a>
+                      {')'}
+                    </>
+                  ) : (
+                    <a href={`mailto:${ownerEmail}`} style={emailLinkStyle}>
+                      {ownerEmail}
+                    </a>
+                  )}
+                  {' has invited you to '}
                   <b>{pageAccess}</b>
-                  {' this page in Parabol.'}
+                  {` ${pageName ? 'this' : 'a'} page in Parabol.`}
                 </td>
               </tr>
             </tbody>
           </table>
-          <table
+          {pageName && (
+            <table
+              style={{
+                border: `2px solid ${PALETTE.SLATE_300}`,
+                borderRadius: '8px',
+                borderCollapse: 'separate',
+                marginTop: '16px',
+                padding: '4px'
+              }}
+              width='100%'
+            >
+              <tbody>
+                <tr>
+                  <td align='center' valign='middle' width='32px'>
+                    <DescriptionIcon
+                      style={{verticalAlign: 'middle', width: '24px', height: '24px'}}
+                    />
+                  </td>
+                  <td
+                    valign='baseline'
+                    style={{
+                      lineHeight: '20px',
+                      padding: '8px 0 6px',
+                      fontWeight: 600,
+                      color: PALETTE.SLATE_900
+                    }}
+                  >
+                    {pageName}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          )}
+          <Button
             style={{
-              border: `2px solid ${PALETTE.SLATE_300}`,
-              borderRadius: '8px',
-              borderCollapse: 'separate',
-              margin: '16px 0',
-              padding: '4px'
+              marginTop: '16px'
             }}
-            width='100%'
+            url={pageLink}
           >
-            <tbody>
-              <tr>
-                <td align='center' valign='middle' width='32px'>
-                  <DescriptionIcon
-                    style={{verticalAlign: 'middle', width: '24px', height: '24px'}}
-                  />
-                </td>
-                <td
-                  valign='baseline'
-                  style={{
-                    lineHeight: '20px',
-                    padding: '8px 0 6px',
-                    fontWeight: 600,
-                    color: PALETTE.SLATE_900
-                  }}
-                >
-                  {pageName}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <Button url={pageLink}>Open Page</Button>
+            Open Page
+          </Button>
         </p>
         <EmptySpace height={24} />
         <p style={emailCopyStyle}>

--- a/packages/server/email/pageSharedEmailCreator.tsx
+++ b/packages/server/email/pageSharedEmailCreator.tsx
@@ -11,8 +11,12 @@ const subjectLine = (ownerName: string): string =>
 const teamInviteText = (props: PageSharedInviteProps) => {
   const {ownerName, ownerEmail, pageName, pageLink, role} = props
   const pageAccess = pageRoles[role] || 'view'
+
+  const owner = ownerName ? `${ownerName} (${ownerEmail})` : ownerEmail
+  const page = pageName ? `this page in Parabol: ${pageName}` : 'a page in Parabol'
+
   return `
-${ownerName} (${ownerEmail}) has invited you to ${pageAccess} this page in Parabol: ${pageName}
+${owner} has invited you to ${pageAccess} ${page}
 
 Open Page here: ${pageLink}
 
@@ -22,7 +26,7 @@ The Parabol Product Team
 }
 
 export default (props: PageSharedInviteProps) => {
-  const subject = subjectLine(props.ownerName)
+  const subject = subjectLine(props.ownerName ?? props.ownerEmail)
   return {
     subject,
     body: teamInviteText(props),

--- a/packages/server/graphql/public/mutations/updatePageAccess.ts
+++ b/packages/server/graphql/public/mutations/updatePageAccess.ts
@@ -1,5 +1,6 @@
 import {GraphQLError} from 'graphql'
 import type {ControlledTransaction} from 'kysely'
+import ms from 'ms'
 import {EMAIL_CORS_OPTIONS} from '../../../../client/types/cors'
 import makeAppURL from '../../../../client/utils/makeAppURL'
 import appOrigin from '../../../appOrigin'
@@ -14,6 +15,7 @@ import {updatePageAccessTable} from '../../../postgres/updatePageAccessTable'
 import {getUserId} from '../../../utils/authorization'
 import {CipherId} from '../../../utils/CipherId'
 import {publishPageNotification} from '../../../utils/publishPageNotification'
+import {DataLoaderWorker} from '../../graphql'
 import type {MutationResolvers, PageRoleEnum, PageSubjectEnum} from '../resolverTypes'
 import {PAGE_ROLES} from '../rules/hasPageAccess'
 import publishNotification from './helpers/publishNotification'
@@ -22,6 +24,33 @@ const utmParams = {
   utm_source: 'shared page email',
   utm_medium: 'email',
   utm_campaign: 'invitations'
+}
+
+const isTrustworthy = async (dataLoader: DataLoaderWorker, userId: string) => {
+  const [viewer, highestTier] = await Promise.all([
+    dataLoader.get('users').loadNonNull(userId),
+    dataLoader.get('highestTierForUserId').load(userId)
+  ])
+  if (!highestTier) return false
+  if (highestTier !== 'starter') return true
+
+  if (viewer.createdAt < new Date(Date.now() - ms('30d'))) return false
+
+  const meetingMembers = await dataLoader.get('meetingMembersByUserId').load(userId)
+  if (meetingMembers.length < 3) return false
+
+  const pg = getKysely()
+  const colleagues = await pg
+    .selectFrom('TeamMember as ut')
+    .innerJoin('TeamMember as ot', 'ut.teamId', 'ot.teamId')
+    .where('ut.userId', '=', userId)
+    .where('ot.userId', '!=', userId)
+    .select('ot.userId')
+    .distinct()
+    .execute()
+  if (colleagues.length < 4) return false
+
+  return true
 }
 
 const getNextIsPrivate = async (
@@ -246,6 +275,7 @@ const updatePageAccess: MutationResolvers['updatePageAccess'] = async (
     }
     if (invitationEmail) {
       const viewer = await dataLoader.get('users').loadNonNull(viewerId)
+      const trustworthy = await isTrustworthy(dataLoader, viewerId)
       const pageLink = makeAppURL(appOrigin, `pages/${pageSlug}`, {
         searchParams: {
           ...utmParams,
@@ -254,10 +284,10 @@ const updatePageAccess: MutationResolvers['updatePageAccess'] = async (
       })
       const {html, subject, body} = pageSharedEmailCreator({
         appOrigin,
-        ownerName: viewer.preferredName,
+        ownerName: trustworthy ? viewer.preferredName : null,
         ownerEmail: viewer.email,
         ownerAvatar: viewer.picture,
-        pageName: page.title ?? 'Untitled',
+        pageName: trustworthy ? (page.title ?? 'Untitled') : null,
         pageLink,
         role,
         corsOptions: EMAIL_CORS_OPTIONS


### PR DESCRIPTION
# Description

If a user just signed up and directly shares a page via email, we reduce the email content to not include any user content (i.e. page title and preferred name).


## Demo

<img width="573" height="507" alt="image" src="https://github.com/user-attachments/assets/0dc6cdb2-f1a8-44f1-8e8c-86c9b0e1381f" />

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
