### PR TITLE
feat: add pnpm-lock to ironbank zip

### DIFF
--- a/.github/workflows/ironbank.yml
+++ b/.github/workflows/ironbank.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           docker cp temp-container:/home/node/parabol/dist ./dist
           docker cp temp-container:/home/node/parabol/build ./build
+          docker cp temp-container:/home/node/parabol/pnpm-lock.yaml ./pnpm-lock.yaml
           docker cp temp-container:/home/node/tools/ip-to-server_id ./ip-to-server_id
 
       - name: Zip the files


### PR DESCRIPTION
# Description

previously we were using something called build_dependencies.zip, which had an ancient pnpm-lock.yaml in it.
Now, we include the up to date one, which should include all recent vulns.