### PR TITLE
feat: add h1, h2, h3, bullet slash shortcuts

### DIFF
--- a/packages/client/tiptap/extensions/slashCommand/slashCommands.ts
+++ b/packages/client/tiptap/extensions/slashCommand/slashCommands.ts
@@ -60,7 +60,7 @@ export const slashCommands = [
       {
         title: 'Heading 1',
         description: 'Big section heading',
-        searchTerms: ['title', 'big', 'large', 'heading'],
+        searchTerms: ['title', 'big', 'large', 'heading', 'h1'],
         icon: TitleIcon,
         action: (editor: Editor) => {
           editor.chain().focus().setNode('heading', {level: 1}).run()
@@ -69,7 +69,7 @@ export const slashCommands = [
       {
         title: 'Heading 2',
         description: 'Medium section heading',
-        searchTerms: ['subtitle', 'medium', 'heading'],
+        searchTerms: ['subtitle', 'medium', 'heading', 'h2'],
         icon: TitleIcon,
         action: (editor: Editor) => {
           editor.chain().focus().setNode('heading', {level: 2}).run()
@@ -78,7 +78,7 @@ export const slashCommands = [
       {
         title: 'Heading 3',
         description: 'Small section heading',
-        searchTerms: ['subtitle', 'small', 'heading'],
+        searchTerms: ['subtitle', 'small', 'heading', 'h3'],
         icon: TitleIcon,
         action: (editor: Editor) => {
           editor.chain().focus().setNode('heading', {level: 3}).run()
@@ -87,7 +87,7 @@ export const slashCommands = [
       {
         title: 'Bullet list',
         description: 'Create a simple bullet list',
-        searchTerms: ['unordered', 'point', 'list'],
+        searchTerms: ['unordered', 'point', 'list', 'bullet'],
         icon: FormatListBulletedIcon,
         action: (editor: Editor) => {
           editor.chain().focus().toggleBulletList().run()


### PR DESCRIPTION
# Description

Trivial change to add some additional Page slash command shortcuts. It was breaking my flow to not be able to `/h2`,  for example.

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] `/h1` – should create H1 header
- [ ] `/h2` – should create H2 header
- [ ] `/h3` – should create H3 header
- [ ] `/bullet` – should create bullet list


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ x I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
