### PR TITLE
feat: page adoption

### DIFF
--- a/packages/server/graphql/public/permissions.ts
+++ b/packages/server/graphql/public/permissions.ts
@@ -71,7 +71,7 @@ const permissionMap: PermissionMap<Resolvers> = {
     updatePageParentLink: hasPageAccess<'Mutation.updatePageParentLink'>('args.pageId', 'owner'),
     archivePage: hasPageAccess<'Mutation.archivePage'>('args.pageId', 'owner'),
     updatePageAccess: and(
-      hasPageAccess<'Mutation.updatePageAccess'>('args.pageId', 'owner'),
+      hasPageAccess<'Mutation.updatePageAccess'>('args.pageId', 'viewer'),
       // limit looking up users by email
       rateLimit({perMinute: 50, perHour: 100})
     ),


### PR DESCRIPTION
# Description

fixes #12223

Allows orphan pages to get adopted.
- We don't wanna auto-assign all orphans because that's just rude to the team leader or page editor or whoever. No surprises!
- The only time someone cares if a page is an orphan is when they want to share it (or move it) & they can't. That's literally the only thing ownership gets you. And if they try to share it, where will they look? That's right, the "Share menu" So, I stuck a banner in the share menu
https://www.loom.com/share/71aaa61822d446adab3971ff2a08ceed