### PR TITLE
fix: sanitize querymap before persisting

### DIFF
--- a/scripts/RelayPersistServer.ts
+++ b/scripts/RelayPersistServer.ts
@@ -68,7 +68,11 @@ export default class RelayPersistServer {
       return
     }
     const id = this.makeHash(text)
-    this.queryMap[id] = text.replace(/\n|\r/g, '').replace(/\s{2,}/g, ' ')
+    this.queryMap[id] = text
+      .replace(/\n|\r/g, '')
+      .replace(/\s{2,}/g, ' ')
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: disallow null char
+      .replace(/\u0000/g, '')
     fs.writeFileSync(this.queryMapPath, JSON.stringify(this.queryMap))
     res.writeHead(200, {
       'Content-Type': 'application/json'


### PR DESCRIPTION
# Description

for the first time ever PG has been complaining about null chars existing in our QueryMap query.
Since we've only pushed 1 new query in the last week, we know which one is probably the culprit, but I couldn't find the null char in it.

Just to be safe, we're sanitizing our inputs in case we don't get utf-8 from the relay persist server.
https://app.datadoghq.com/error-tracking?query=env%3Aproduction&refresh_mode=paused&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22750a6686-b68b-11f0-b051-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1761765064000&to_ts=1761937864000&live=false