### PR TITLE
fix: remove newlines from story titles when creating table

### DIFF
--- a/packages/server/graphql/mutations/helpers/summaryPage/getPokerTable.ts
+++ b/packages/server/graphql/mutations/helpers/summaryPage/getPokerTable.ts
@@ -15,7 +15,11 @@ function extractTitleOrSummary(obj: Record<string, any>): string | undefined {
   // Look for 'title' or 'summary' at the current level
   for (const key of ['title', 'summary']) {
     if (key in obj && typeof obj[key] === 'string') {
-      return obj[key]
+      const story = obj[key]
+      return story
+        .slice(0, 256)
+        .replace(/\n|\r/g, '')
+        .replace(/\s{2,}/g, ' ')
     }
   }
 


### PR DESCRIPTION
# Description

fixes #12123

replaces \n with spaces so story titles don't go off the rails