### PR TITLE
fix: ensure ext is at the end for assets in dev

### DIFF
--- a/scripts/webpack/dev.client.config.js
+++ b/scripts/webpack/dev.client.config.js
@@ -93,7 +93,7 @@ module.exports = {
     filename: '[name].js',
     chunkFilename: '[name].chunk.js',
     publicPath: '/',
-    assetModuleFilename: '[name][ext][query]-[hash]'
+    assetModuleFilename: '[name]-[hash][query][ext]'
   },
   resolve: {
     alias: {


### PR DESCRIPTION
# Description

assets lost their MIME type when they ended with a hash