### PR TITLE
fix: jira issue search results not returning correct order

### DIFF
--- a/packages/server/graphql/public/types/AtlassianIntegration.ts
+++ b/packages/server/graphql/public/types/AtlassianIntegration.ts
@@ -82,9 +82,9 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
           }
         })
 
-        const edges = nodes.map((node, idx) => ({
+        const edges = nodes.map((node) => ({
           node,
-          cursor: `${idx}`
+          cursor: node.issueKey
         }))
 
         return {
@@ -99,10 +99,7 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
       })
     )
 
-    const combinedEdges = cloudResults
-      .flatMap((result) => result.edges)
-      .filter(Boolean)
-      .sort((a, b) => (a.cursor < b.cursor ? -1 : 1))
+    const combinedEdges = cloudResults.flatMap((result) => result.edges).filter(Boolean)
     const combinedError = cloudResults.find((result) => result.error)
     return {
       edges: combinedEdges.slice(0, first),


### PR DESCRIPTION
# Description

followup of #12172

A customer wrote in saying the jira issue order is not the same in Parabol as it is in Jira when running a JQL query.
I'm not sure what could be causing this, even the sort by idx should not affect this if there is only a single cloudId, however I'm removing that just in case so we can make future debugging easier