### PR TITLE
fix(server): uncorked writes

### DIFF
--- a/packages/server/ICSHandler.ts
+++ b/packages/server/ICSHandler.ts
@@ -8,10 +8,12 @@ const ICSHandler = (res: HttpResponse, req: HttpRequest) => {
   const startDate = new Date(Number(createdAt))
   if (typeof meetingUrl !== 'string' || typeof teamName !== 'string') return
   const icsText = createICS(startDate, meetingUrl, teamName)
-  res
-    .writeHeader('content-type', 'text/calendar')
-    .writeHeader('content-disposition', 'attachment; filename=Parabol Check-in Meeting.ics')
-    .end(icsText)
+  res.cork(() => {
+    res
+      .writeHeader('content-type', 'text/calendar')
+      .writeHeader('content-disposition', 'attachment; filename=Parabol Check-in Meeting.ics')
+      .end(icsText)
+  })
 }
 
 export default ICSHandler

--- a/packages/server/PWAHandler.ts
+++ b/packages/server/PWAHandler.ts
@@ -4,7 +4,9 @@ import serveStatic from './utils/serveStatic'
 
 const PWAHandler = (res: HttpResponse, req: HttpRequest) => {
   if (!serveStatic(res, req.getUrl().slice(1), acceptsBrotli(req))) {
-    res.writeStatus('404').end()
+    res.cork(() => {
+      res.writeStatus('404').end()
+    })
   }
 }
 export default PWAHandler

--- a/packages/server/jiraImagesHandler.ts
+++ b/packages/server/jiraImagesHandler.ts
@@ -38,7 +38,9 @@ const servePlaceholderImage = async (res: HttpResponse) => {
       Logger.error('Jira Placeholder image could not be fetched', e)
     }
   }
-  res.writeStatus('200').writeHeader('Content-Type', 'image/png').end(jiraPlaceholderBuffer)
+  res.cork(() => {
+    res.writeStatus('200').writeHeader('Content-Type', 'image/png').end(jiraPlaceholderBuffer)
+  })
 }
 
 const jiraImagesHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpRequest) => {
@@ -54,10 +56,12 @@ const jiraImagesHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpReq
     return
   }
 
-  res
-    .writeStatus('200')
-    .writeHeader('Content-Type', cachedImage.contentType)
-    .end(cachedImage.imageBuffer)
+  res.cork(() => {
+    res
+      .writeStatus('200')
+      .writeHeader('Content-Type', cachedImage.contentType)
+      .end(cachedImage.imageBuffer)
+  })
 })
 
 export default jiraImagesHandler

--- a/packages/server/metricsHandler.ts
+++ b/packages/server/metricsHandler.ts
@@ -169,8 +169,10 @@ export const metricsHandler = async (res: HttpResponse) => {
 
   if (process.env.ENABLE_METRICS !== 'true') {
     if (!aborted) {
-      res.writeStatus('404 Not Found')
-      res.end()
+      res.cork(() => {
+        res.writeStatus('404 Not Found')
+        res.end()
+      })
     }
     return
   }

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -82,14 +82,18 @@ if (ENABLE_STATIC_FILE_HANDLER) {
   app.get('/static/*', createStaticFileHandler('/static/'))
 } else {
   app.get('/static/*', (res) => {
-    res.writeStatus('404 Not Found').end()
+    res.cork(() => {
+      res.writeStatus('404 Not Found').end()
+    })
   })
 }
 if (ENABLE_MATTERMOST_FILE_HANDLER) {
   app.get('/components/*', createStaticFileHandler('/components/'))
 } else {
   app.get('/components/*', (res) => {
-    res.writeStatus('404 Not Found').end()
+    res.cork(() => {
+      res.writeStatus('404 Not Found').end()
+    })
   })
 }
 
@@ -98,9 +102,11 @@ if (ENABLE_METRICS) {
     .App()
     .get('/metrics', metricsHandler)
     .get('/health', (res) => {
-      res.writeStatus('200 OK')
-      res.writeHeader('Content-Type', 'text/plain')
-      res.end('OK')
+      res.cork(() => {
+        res.writeStatus('200 OK')
+        res.writeHeader('Content-Type', 'text/plain')
+        res.end('OK')
+      })
     })
     .listen(METRICS_PORT, (socket) => {
       if (socket) {

--- a/packages/server/staticFileHandler.ts
+++ b/packages/server/staticFileHandler.ts
@@ -16,7 +16,9 @@ export const createStaticFileHandler = (route: string) => {
     const fileName = req.getUrl().slice(route.length)
     const servedStatic = serveStatic(res, fileName, acceptsBrotli(req))
     if (servedStatic) return
-    res.writeStatus('404').end()
+    res.cork(() => {
+      res.writeStatus('404').end()
+    })
     return
   }
 }


### PR DESCRIPTION
# Description

When I was developing #12391 I was getting some warnings about uncorked uws writes. I had to fix up my code to avoid these warnings. I had a look elsewhere in the code base and found that we weren't always "corking" our writes when we returned data from the webserver.

Most of the time, this isn't an issue. "Corking" is uws's jargon of buffering up multiple write operations to be packed into as few network operations as possible (ultimately in order to maximize the amount of data shoved into a TCP packet) in order to increase server performance.

I've fixed up the various places in the server where we forgot to cork to be consistent.

## Ye olde checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ c I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [c] I have performed a self-review of my code, the same way I'd do it for any other team member
- [c] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] PR title is human readable and could be used in changelog
