### PR TITLE
fix: standardize adding meetingSummaryId to all meeting objects before publish

### DIFF
--- a/packages/server/graphql/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/mutations/endSprintPoker.ts
@@ -10,6 +10,7 @@ import {analytics} from '../../utils/analytics/analytics'
 import {getUserId, isSuperUser, isTeamMember} from '../../utils/authorization'
 import getPhase from '../../utils/getPhase'
 import getRedis from '../../utils/getRedis'
+import {Logger} from '../../utils/Logger'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import type {GQLContext} from '../graphql'
@@ -119,8 +120,6 @@ export default {
         .get('meetingTemplates')
         .loadNonNull(templateId)
     ])
-    IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId)
-    analytics.sprintPokerEnd(completedMeeting, meetingMembers, template, dataLoader)
     const isKill = !!(phase && phase.phaseType !== 'ESTIMATE')
     const events = teamMembers.map(
       (teamMember) =>
@@ -134,7 +133,7 @@ export default {
     const pg = getKysely()
     await pg.insertInto('TimelineEvent').values(events).execute()
     const page = await publishSummaryPage(meetingId, context, info)
-    sendSummaryEmailV2(meetingId, page.id, context, info)
+    meeting.summaryPageId = page.id
     const data = {
       meetingId,
       teamId,
@@ -142,7 +141,11 @@ export default {
       removedTaskIds
     }
     publish(SubscriptionChannel.TEAM, teamId, 'EndSprintPokerSuccess', data, subOptions)
-
+    sendSummaryEmailV2(meetingId, page.id, context, info).catch(Logger.log)
+    IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId).catch(Logger.log)
+    analytics
+      .sprintPokerEnd(completedMeeting, meetingMembers, template, dataLoader)
+      .catch(Logger.log)
     return data
   }
 }

--- a/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
@@ -125,8 +125,7 @@ const safeEndRetrospective = async ({
   await pg.insertInto('TimelineEvent').values(events).execute()
   // the promise only creates the initial page, the page blocks are generated and sent after resolving
   const page = await publishSummaryPage(meetingId, context, info)
-  dataLoader.get('newMeetings').clearAll()
-  analytics.retrospectiveEnd(completedRetrospective, meetingMembers, template, dataLoader)
+  meeting.summaryPageId = page.id
   if (team.isOnboardTeam) {
     const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId)
     const teamLead = teamMembers.find((teamMember) => teamMember.isLead)!
@@ -155,6 +154,10 @@ const safeEndRetrospective = async ({
   summarizeRetroMeeting(completedRetrospective, context).catch(Logger.log)
   // do not await sending the email
   sendSummaryEmailV2(meetingId, page.id, context, info).catch(Logger.log)
+  analytics
+    .retrospectiveEnd(completedRetrospective, meetingMembers, template, dataLoader)
+    .catch(Logger.log)
+
   return data
 }
 

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -8,6 +8,7 @@ import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTe
 import type {TeamPromptMeeting} from '../../../postgres/types/Meeting'
 import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId} from '../../../utils/authorization'
+import {Logger} from '../../../utils/Logger'
 import publish from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
 import type {InternalContext} from '../../graphql'
@@ -91,14 +92,14 @@ const safeEndTeamPrompt = async ({
   summarizeTeamPrompt(meeting, context)
   analytics.teamPromptEnd(completedTeamPrompt, meetingMembers, responses, dataLoader)
   const page = await publishSummaryPage(meetingId, context, info)
-  // do not await sending the email
-  sendSummaryEmailV2(meetingId, page.id, context, info)
-  dataLoader.get('newMeetings').clear(meetingId)
+  meeting.summaryPageId = page.id
   const data = {
     meetingId,
     teamId
   }
   publish(SubscriptionChannel.TEAM, teamId, 'EndTeamPromptSuccess', data, subOptions)
+  // do not await sending the email
+  sendSummaryEmailV2(meetingId, page.id, context, info).catch(Logger.log)
   return data
 }
 


### PR DESCRIPTION
# Description

`meeting.summaryPageId = page.id` for all meeting types