### PR TITLE
fix: Asset Migration v2

### DIFF
--- a/packages/server/postgres/migrations/2025-11-20T19:13:58.950Z_replace-pic-urls.ts
+++ b/packages/server/postgres/migrations/2025-11-20T19:13:58.950Z_replace-pic-urls.ts
@@ -118,6 +118,8 @@ export async function up(db: Kysely<any>): Promise<void> {
       const fullPath = fileManager.prependPath(previousMove.to)
       const publicPath = fileManager.getPublicFileLocation(fullPath)
       try {
+        // sleep to make sure the file has been pushed & is available
+        await new Promise((res) => setTimeout(res, 200))
         const fileRes = await fetch(publicPath)
         const fileResBuffer = await fileRes.arrayBuffer()
         await fileManager.putUserFile(fileResBuffer, to)


### PR DESCRIPTION
# Description

supersedes #12421
handle same image being referenced in the same page and different pages. tested working in dev