### PR TITLE
feat: support tab and shift+tab in pages

### DIFF
--- a/packages/client/hooks/useTipTapPageEditor.ts
+++ b/packages/client/hooks/useTipTapPageEditor.ts
@@ -20,6 +20,7 @@ import {LoomExtension} from '../components/promptResponse/loomExtension'
 import {TiptapLinkExtension} from '../components/promptResponse/TiptapLinkExtension'
 import {themeBackgroundColors} from '../shared/themeBackgroundColors'
 import {mentionConfig} from '../shared/tiptap/serverTipTapExtensions'
+import {IndentHandler} from '../tiptap/extensions/IndentHandler'
 import ImageBlock from '../tiptap/extensions/imageBlock/ImageBlock'
 import {ImageUpload} from '../tiptap/extensions/imageUpload/ImageUpload'
 import {InsightsBlock} from '../tiptap/extensions/insightsBlock/InsightsBlock'
@@ -108,6 +109,7 @@ export const useTipTapPageEditor = (
           assetScope: 'Page'
         }),
         ImageBlock,
+        IndentHandler,
         LoomExtension,
         PageDragHandle.configure({pageId, atmosphere}),
         Placeholder.configure({

--- a/packages/client/tiptap/extensions/IndentHandler.ts
+++ b/packages/client/tiptap/extensions/IndentHandler.ts
@@ -1,0 +1,67 @@
+// https://github.com/ueberdosis/tiptap/issues/457#issuecomment-2285456957
+import {Extension} from '@tiptap/core'
+
+const TAB_CHAR = '\u0009'
+
+export const IndentHandler = Extension.create({
+  name: 'indentHandler',
+  addKeyboardShortcuts() {
+    return {
+      Tab: ({editor}) => {
+        const {selection} = editor.state
+        const {$from} = selection
+
+        // Check if we're at the start of a list item
+        if (editor.isActive('listItem') && $from.parentOffset === 0) {
+          // Attempt to sink the list item
+          const sinkResult = editor.chain().sinkListItem('listItem').run()
+
+          // If sinking was successful, return true
+          if (sinkResult) {
+            return true
+          }
+          // If sinking failed, we'll fall through to inserting a tab
+        }
+
+        // Insert a tab character
+        editor
+          .chain()
+          .command(({tr}) => {
+            tr.insertText(TAB_CHAR)
+            return true
+          })
+          .run()
+
+        // Prevent default behavior (losing focus)
+        return true
+      },
+      'Shift-Tab': ({editor}) => {
+        const {selection, doc} = editor.state
+        const {$from} = selection
+        const pos = $from.pos
+
+        // Check if we're at the start of a list item
+        if (editor.isActive('listItem') && $from.parentOffset === 0) {
+          // If so, lift the list item
+          return editor.chain().liftListItem('listItem').run()
+        }
+
+        // Check if the previous character is a tab
+        if (doc.textBetween(pos - 1, pos) === TAB_CHAR) {
+          // If so, delete it
+          editor
+            .chain()
+            .command(({tr}) => {
+              tr.delete(pos - 1, pos)
+              return true
+            })
+            .run()
+          return true
+        }
+
+        // Prevent default behavior (losing focus)
+        return true
+      }
+    }
+  }
+})


### PR DESCRIPTION
# Description

Now we can hit tab in a Page & it'll indent. Works for lists like todo-lists, bullet lists, numbered lists, code blocks, etc.