### PR TITLE
feat: bump nodejs to v22.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/ParabolInc/parabol/issues"
   },
   "engines": {
-    "node": "^22.20.0"
+    "node": "^22.21.1"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
# Description

bumps to latest nodejs available in ironbank.
there is a v24 now available for alpine, but i'll try to stick on debian as long as we can so we don't have to change the DOCKERFILE