### PR TITLE
fix: signout when done impersonating

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -304,8 +304,7 @@ export default class Atmosphere extends Environment {
 
     const anotherTabIsOpen = await isAnotherParabolTabOpen()
     if (anotherTabIsOpen || justOpened) return
-    // since this is async, useAuthRoute will have already run
-    window.location.href = '/'
+    this.invalidateSession('Removing impersonate token')
   }
 
   private setAuthToken = async (authToken: string | null | undefined) => {


### PR DESCRIPTION
# Description

prevents the infinite loop of redirecting to / while still holding onto a cookie