### PR TITLE
fix: check for isNotRemoved after querying the `teamMembers` dataloader

### DIFF
--- a/packages/client/components/MeetingSelector.tsx
+++ b/packages/client/components/MeetingSelector.tsx
@@ -54,9 +54,7 @@ const MeetingSelector = (props: Props) => {
       <Redirect
         to={{
           pathname: `/invitation-required`,
-          search: `?redirectTo=${encodeURIComponent(
-            window.location.pathname
-          )}&meetingId=${meetingId}`
+          search: `?redirectTo=${window.location.pathname}&meetingId=${meetingId}`
         }}
       />
     )

--- a/packages/client/components/MeetingSeriesRedirector.tsx
+++ b/packages/client/components/MeetingSeriesRedirector.tsx
@@ -38,7 +38,7 @@ const MeetingSeriesRedirector = (props: Props) => {
     return (
       <Redirect
         to={{
-          pathname: `/invitation-required`,
+          pathname: `/  `,
           search: `?redirectTo=${encodeURIComponent(
             window.location.pathname
           )}&meetingId=${meetingId}`

--- a/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
+++ b/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
@@ -52,7 +52,7 @@ const TeamContainer = (props: Props) => {
     if (!canAccessTeam) {
       history.replace({
         pathname: `/invitation-required`,
-        search: `?redirectTo=${encodeURIComponent(pathname)}&teamId=${teamId}`
+        search: `?redirectTo=${pathname}&teamId=${teamId}`
       })
     }
   }, [canAccessTeam])

--- a/packages/server/dataloader/pageLoaderMakers.ts
+++ b/packages/server/dataloader/pageLoaderMakers.ts
@@ -87,7 +87,7 @@ export const pageUserSection = (parent: RootDataLoader) => {
           if (teamId) {
             const teamMemberId = TeamMemberId.join(teamId, userId)
             const teamMember = await parent.get('teamMembers').load(teamMemberId)
-            return teamMember ? 'team' : 'shared'
+            return teamMember?.isNotRemoved ? 'team' : 'shared'
           }
           // if the page has a parent, it will be a subpage unless it doesn't have access to that parent
           if (parentPageId) {

--- a/packages/server/graphql/mutations/archiveTeam.ts
+++ b/packages/server/graphql/mutations/archiveTeam.ts
@@ -40,7 +40,7 @@ export default {
       dataLoader.get('users').loadNonNull(viewerId),
       dataLoader.get('teams').loadNonNull(teamId)
     ])
-    const isTeamLead = teamMember?.isLead
+    const isTeamLead = teamMember?.isNotRemoved && teamMember?.isLead
     const isOrgAdmin = await isUserOrgAdmin(viewerId, teamToArchive.orgId, dataLoader)
     if (!isTeamLead && !isSuperUser(authToken) && !isOrgAdmin) {
       return standardError(new Error('Not team lead or org admin'), {

--- a/packages/server/graphql/mutations/removeTeamMember.ts
+++ b/packages/server/graphql/mutations/removeTeamMember.ts
@@ -36,7 +36,7 @@ export default {
       isUserOrgAdmin(viewerId, team.orgId, dataLoader),
       dataLoader.get('teamMembers').load(TeamMemberId.join(teamId, viewerId))
     ])
-    const isViewerTeamLead = teamMember?.isLead
+    const isViewerTeamLead = teamMember?.isNotRemoved && teamMember?.isLead
     const isSelf = viewerId === userId
     if (!isSelf) {
       if (!isOrgAdmin && !isViewerTeamLead) {

--- a/packages/server/graphql/mutations/startSprintPoker.ts
+++ b/packages/server/graphql/mutations/startSprintPoker.ts
@@ -170,6 +170,9 @@ export default {
 
     const teamMemberId = toTeamMemberId(teamId, viewerId)
     const teamMember = await dataLoader.get('teamMembers').loadNonNull(teamMemberId)
+    if (!teamMember.isNotRemoved) {
+      return {error: {message: 'Team member was removed'}}
+    }
     const meetingMember = createMeetingMember(meeting, teamMember)
     await pg
       .with('MeetingMemberInsert', (qb) => qb.insertInto('MeetingMember').values(meetingMember))

--- a/packages/server/graphql/public/fields/pageInsights.ts
+++ b/packages/server/graphql/public/fields/pageInsights.ts
@@ -39,7 +39,9 @@ export const pageInsights: NonNullable<UserResolvers['pageInsights']> = async (
   const meetings = (await dataLoader.get('newMeetings').loadMany(meetingIds)).filter(isValid)
   const teamIds = [...new Set(meetings.map(({teamId}) => teamId))]
   const teamMemberIds = teamIds.map((teamId) => TeamMemberId.join(teamId, viewerId))
-  const teamMembers = (await dataLoader.get('teamMembers').loadMany(teamMemberIds)).filter(isValid)
+  const teamMembers = (await dataLoader.get('teamMembers').loadMany(teamMemberIds))
+    .filter(isValid)
+    .filter((tm) => tm.isNotRemoved)
   if (teamMembers.length < teamIds.length) {
     throw new GraphQLError('You must be a member of the team for each requested meetingId')
   }

--- a/packages/server/graphql/public/mutations/toggleFeatureFlag.ts
+++ b/packages/server/graphql/public/mutations/toggleFeatureFlag.ts
@@ -27,6 +27,9 @@ const toggleFeatureFlag: MutationResolvers['toggleFeatureFlag'] = async (
   if (teamId) {
     const teamMemberId = toTeamMemberId(teamId, viewerId)
     const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
+    if (!teamMember?.isNotRemoved) {
+      return standardError(new Error('Not a member of the team anymore'))
+    }
     if (!teamMember) {
       return standardError(new Error('Not a member of the team'))
     }

--- a/packages/server/graphql/public/mutations/toggleTeamPrivacy.ts
+++ b/packages/server/graphql/public/mutations/toggleTeamPrivacy.ts
@@ -19,7 +19,9 @@ const toggleTeamPrivacy: MutationResolvers['toggleTeamPrivacy'] = async (
   if (!teamMember) {
     return standardError(new Error('Not a member of the team'))
   }
-
+  if (!teamMember.isNotRemoved) {
+    return standardError(new Error('Not a member of the team anymore'))
+  }
   const team = await dataLoader.get('teams').load(teamId)
   if (!team) {
     return standardError(new Error('Team not found'))

--- a/packages/server/graphql/public/rules/isViewerOnTeam.ts
+++ b/packages/server/graphql/public/rules/isViewerOnTeam.ts
@@ -15,6 +15,7 @@ const isViewerOnTeam = (getTeamId: GetTeamId) =>
       const teamMemberId = TeamMemberId.join(teamId, viewerId)
       const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
       if (!teamMember) return new Error('Viewer is not on team')
+      if (!teamMember.isNotRemoved) return new Error('Viewer is not on team anymore')
       return true
     }
   )

--- a/packages/server/graphql/public/rules/isViewerTeamLead.ts
+++ b/packages/server/graphql/public/rules/isViewerTeamLead.ts
@@ -12,6 +12,7 @@ export const isViewerTeamLead = <T>(teamIdDotPath: ResolverDotPath<T>) =>
       const teamMemberId = TeamMemberId.join(teamId, viewerId)
       const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
       if (!teamMember?.isLead) return new Error('User is not team lead')
+      if (!teamMember?.isNotRemoved) return new Error('User is not team lead anymore')
       return true
     }
   )

--- a/packages/server/graphql/public/types/DomainJoinRequest.ts
+++ b/packages/server/graphql/public/types/DomainJoinRequest.ts
@@ -30,6 +30,7 @@ const DomainJoinRequest: DomainJoinRequestResolvers = {
     const teamMemberIds = teamIds.map((teamId) => TeamMemberId.join(teamId, viewerId))
     const leadTeamMembers = (await dataLoader.get('teamMembers').loadMany(teamMemberIds))
       .filter(isValid)
+      .filter(({isNotRemoved}) => isNotRemoved)
       .filter(({isLead}) => isLead)
 
     const leadTeamIds = leadTeamMembers.map((teamMember) => teamMember.teamId)

--- a/packages/server/graphql/public/types/PagePartial.ts
+++ b/packages/server/graphql/public/types/PagePartial.ts
@@ -16,9 +16,10 @@ const PagePartial: ReqResolvers<'PagePartial'> = {
       dataLoader.get('teams').load(teamId)
     ])
     if (!team) return null
+    const isOnTeam = teamMember?.isNotRemoved
     return {
       ...team,
-      __typename: teamMember ? 'Team' : 'TeamPreview'
+      __typename: isOnTeam ? 'Team' : 'TeamPreview'
     }
   }
 }

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -600,7 +600,7 @@ const User: ReqResolvers<'User'> = {
     const teamMember = teamId
       ? await dataLoader.get('teamMembers').load(TeamMemberId.join(teamId, viewerId))
       : null
-    if (teamMember) return {isOnTeam: true}
+    if (teamMember?.isNotRemoved) return {isOnTeam: true}
     const teamInvitations = teamId
       ? await dataLoader.get('teamInvitationsByTeamId').load(teamId)
       : null

--- a/packages/server/graphql/types/Team.ts
+++ b/packages/server/graphql/types/Team.ts
@@ -91,7 +91,7 @@ const Team: GraphQLObjectType = new GraphQLObjectType<ITeam, GQLContext>({
         const viewerId = getUserId(authToken)
         const teamMemberId = toTeamMemberId(teamId, viewerId)
         const teamMember = await dataLoader.get('teamMembers').loadNonNull(teamMemberId)
-        return !!teamMember.isLead
+        return teamMember.isLead && teamMember.isNotRemoved
       }
     },
     meetingSettings: {


### PR DESCRIPTION
# Description

fix [#12381](https://github.com/ParabolInc/parabol/issues/12381)

checks `TeamMember.isNotRemoved` after querying `dataLoader.get('teamMembers')`.
Should probably have the dataloader only fetch active team members, but we can save that for another PR.

also deleted some unused functions