### PR TITLE
feat: clone external pictures when added to a page

### DIFF
--- a/packages/client/styles/theme/global.css
+++ b/packages/client/styles/theme/global.css
@@ -191,6 +191,15 @@
     }
   }
 
+  --animate-shimmer: shimmer 2.5s infinite;
+  @keyframes shimmer {
+    from {
+      mask-position: right;
+    }
+    to {
+      mask-position: left;
+    }
+  }
 }
 
 :root {

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlockView.tsx
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlockView.tsx
@@ -1,9 +1,29 @@
 import {type NodeViewProps, NodeViewWrapper} from '@tiptap/react'
-import {useCallback, useRef, useState} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
+import type {AssetScopeEnum} from '~/__generated__/useEmbedUserAssetMutation.graphql'
+import useAtmosphere from '~/hooks/useAtmosphere'
+import {useEmbedUserAsset} from '~/mutations/useEmbedUserAsset'
+import {GQLID} from '~/utils/GQLID'
 import {useBlockResizer} from '../../../hooks/useBlockResizer'
 import {cn} from '../../../ui/cn'
 import {BlockResizer} from './BlockResizer'
 import {ImageBlockBubbleMenu} from './ImageBlockBubbleMenu'
+
+const getRelativeSrc = (src: string) => {
+  if (src.startsWith('/')) return src
+  try {
+    const url = new URL(src)
+    return url.pathname
+  } catch {
+    return ''
+  }
+}
+const getIsHosted = (src: string, scopeKey: string, assetScope: AssetScopeEnum) => {
+  const relativeSrc = getRelativeSrc(src)
+  const scopeCode = assetScope === 'Page' ? GQLID.fromKey(scopeKey)[0] : scopeKey
+  const hostedPath = `/assets/${assetScope}/${scopeCode}`
+  return relativeSrc.startsWith(hostedPath)
+}
 export const ImageBlockView = (props: NodeViewProps) => {
   const {editor, getPos, node, updateAttributes} = props
   const imageWrapperRef = useRef<HTMLDivElement>(null)
@@ -11,7 +31,8 @@ export const ImageBlockView = (props: NodeViewProps) => {
   const {src, align, height, width} = attrs
   const alignClass =
     align === 'left' ? 'justify-start' : align === 'right' ? 'justify-end' : 'justify-center'
-
+  const {scopeKey, assetScope} = editor.extensionStorage.imageUpload
+  const isHosted = getIsHosted(src, scopeKey, assetScope)
   const onClick = useCallback(() => {
     const pos = getPos()
     if (!pos) return
@@ -32,13 +53,41 @@ export const ImageBlockView = (props: NodeViewProps) => {
   )
   const onMouseDownLeft = onMouseDown('left')
   const onMouseDownRight = onMouseDown('right')
+  const atmosphere = useAtmosphere()
+  const [commit] = useEmbedUserAsset()
+  useEffect(() => {
+    if (isHosted) return
+    commit({
+      variables: {url: src, scope: assetScope, scopeKey},
+      onCompleted: (res, error) => {
+        const {embedUserAsset} = res
+        if (!embedUserAsset) {
+          // Since this is triggered without user input, we log it silently
+          console.error(error?.[0]?.message)
+          return
+        }
+        const {url} = embedUserAsset
+        const message = embedUserAsset?.error?.message
+        if (message) {
+          atmosphere.eventEmitter.emit('addSnackbar', {
+            key: 'errorEmbeddingAsset',
+            message,
+            autoDismiss: 5
+          })
+          return
+        }
+        updateAttributes({src: url})
+      }
+    })
+  }, [isHosted])
   return (
     <NodeViewWrapper>
       <div className={cn('flex', alignClass)}>
         <div contentEditable={false} ref={imageWrapperRef} className='group relative w-fit'>
           <img
             draggable={false}
-            className='block'
+            data-uploading={isHosted ? undefined : ''}
+            className='block data-uploading:animate-shimmer data-uploading:[mask:linear-gradient(-60deg,#000_30%,#0005,#000_70%)_right/350%_100%]'
             src={src}
             alt=''
             onClick={onClick}

--- a/packages/server/fileStorage/FileStoreManager.ts
+++ b/packages/server/fileStorage/FileStoreManager.ts
@@ -26,6 +26,7 @@ export default abstract class FileStoreManager {
     partialPath: string
   ): Promise<string>
 
+  abstract copyFile(oldKey: PartialPath, newKey: PartialPath): Promise<string>
   abstract moveFile(oldKey: PartialPath, newKey: PartialPath): Promise<void>
   abstract presignUrl(partialPath: PartialPath): Promise<string>
   async putUserFile(file: ArrayBufferLike | Buffer<ArrayBufferLike>, partialPath: PartialPath) {

--- a/packages/server/fileStorage/LocalFileStoreManager.ts
+++ b/packages/server/fileStorage/LocalFileStoreManager.ts
@@ -29,6 +29,13 @@ export default class LocalFileStoreManager extends FileStoreManager {
     return makeAppURL(appOrigin, fullPath)
   }
 
+  async copyFile(oldKey: PartialPath, newKey: PartialPath) {
+    const oldFullPath = this.prependPath(oldKey)
+    const newFullPath = this.prependPath(newKey)
+    await fs.promises.copyFile(oldFullPath, newFullPath)
+    return makeAppURL(appOrigin, newFullPath)
+  }
+
   async moveFile(oldKey: PartialPath, newKey: PartialPath): Promise<void> {
     const oldFullPath = this.prependPath(oldKey)
     const newFullPath = this.prependPath(newKey)

--- a/packages/server/fileStorage/S3FileStoreManager.ts
+++ b/packages/server/fileStorage/S3FileStoreManager.ts
@@ -10,7 +10,9 @@ import {getSignedUrl} from '@aws-sdk/s3-request-presigner'
 import type {RetryErrorInfo, StandardRetryToken} from '@smithy/types'
 import {StandardRetryStrategy} from '@smithy/util-retry'
 import mime from 'mime-types'
+import makeAppURL from 'parabol-client/utils/makeAppURL'
 import path from 'path'
+import appOrigin from '../appOrigin'
 import {Logger} from '../utils/Logger'
 import FileStoreManager, {type FileAssetDir, type PartialPath} from './FileStoreManager'
 
@@ -122,7 +124,7 @@ export default class S3Manager extends FileStoreManager {
     return true
   }
 
-  async moveFile(oldPartialPath: PartialPath, newPartialPath: PartialPath) {
+  async copyFile(oldPartialPath: PartialPath, newPartialPath: PartialPath) {
     const oldFullPath = decodeURI(this.prependPath(oldPartialPath))
     const newFullPath = decodeURI(this.prependPath(newPartialPath))
 
@@ -133,6 +135,12 @@ export default class S3Manager extends FileStoreManager {
         Key: newFullPath
       })
     )
+    return makeAppURL(appOrigin, `/assets/${newPartialPath}`)
+  }
+
+  async moveFile(oldPartialPath: PartialPath, newPartialPath: PartialPath) {
+    const oldFullPath = decodeURI(this.prependPath(oldPartialPath))
+    await this.copyFile(oldPartialPath, newPartialPath)
     await this.s3.send(
       new DeleteObjectCommand({
         Bucket: this.bucket,


### PR DESCRIPTION
# Description

https://www.loom.com/share/6078b61c39d5436d8a5d56943e7fafee

When pasting a picture into a Page, it checks to make sure that picture belongs to the page. If it doesn't, it copies it.
Cloning means we will have the same image just under multiple names, but that's probably for the best in case we support editing photos, etc. Storage is cheap

