### PR TITLE
chore: mark organization feature flags as public explicitly

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
@@ -50,7 +50,7 @@ interface Props {
 const OrgFeatureFlags = (props: Props) => {
   const {organizationRef} = props
   const atmosphere = useAtmosphere()
-  const {onError, onCompleted} = useMutationProps()
+  const {onError, onCompleted, error} = useMutationProps()
   const organization = useFragment(
     graphql`
       fragment OrgFeatureFlags_organization on Organization {
@@ -96,6 +96,9 @@ const OrgFeatureFlags = (props: Props) => {
             <Toggle active={!!feature.enabled} onClick={() => handleToggle(feature.featureName)} />
           </FeatureRow>
         ))}
+        {error && (
+          <div className='mt-2 pr-4 font-semibold text-tomato-500 text-xs'>{error.message}</div>
+        )}
       </PanelRow>
     </StyledPanel>
   )

--- a/packages/server/graphql/public/mutations/toggleFeatureFlag.ts
+++ b/packages/server/graphql/public/mutations/toggleFeatureFlag.ts
@@ -52,6 +52,9 @@ const toggleFeatureFlag: MutationResolvers['toggleFeatureFlag'] = async (
   if (!featureFlag) {
     return standardError(new Error('Feature flag not found or expired'))
   }
+  if (!featureFlag.isPublic) {
+    return standardError(new Error('Contact love@parabol.co to enable this feature flag'))
+  }
 
   const scope = orgId ? 'Organization' : teamId ? 'Team' : 'User'
   if (featureFlag.scope !== scope) {

--- a/packages/server/graphql/public/types/Organization.ts
+++ b/packages/server/graphql/public/types/Organization.ts
@@ -118,7 +118,10 @@ const Organization: OrganizationResolvers = {
   },
   integrationProviders: ({id: orgId}) => ({orgId}),
   orgFeatureFlags: async ({id: orgId}, _args, {dataLoader}) => {
-    return dataLoader.get('allFeatureFlagsByOwner').load({ownerId: orgId, scope: 'Organization'})
+    const orgFeatureFlags = await dataLoader
+      .get('allFeatureFlagsByOwner')
+      .load({ownerId: orgId, scope: 'Organization'})
+    return orgFeatureFlags.filter((flag) => flag.isPublic)
   }
 }
 

--- a/packages/server/postgres/migrations/2026-01-12T12:24:54.650Z_publicFeatureFlagFlag.ts
+++ b/packages/server/postgres/migrations/2026-01-12T12:24:54.650Z_publicFeatureFlagFlag.ts
@@ -1,0 +1,18 @@
+import type {Kysely} from 'kysely'
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function up(db: Kysely<any>): Promise<void> {
+  db.schema
+    .alterTable('FeatureFlag')
+    .addColumn('isPublic', 'boolean', (col) => col.notNull().defaultTo(false))
+    .execute()
+  db.updateTable('FeatureFlag')
+    .set({isPublic: true})
+    .where('featureName', '=', 'Databases')
+    .execute()
+}
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function down(db: Kysely<any>): Promise<void> {
+  db.schema.alterTable('FeatureFlag').dropColumn('isPublic').execute()
+}


### PR DESCRIPTION
Do not expose all organization feature flags to enterprise users, only those which are marked `isPublic` explicitly.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
