### PR TITLE
fix: fail when generating vendorsDll fails

### DIFF
--- a/scripts/buildDll.js
+++ b/scripts/buildDll.js
@@ -11,7 +11,7 @@ const DLL_ROOT = path.join(PROJECT_ROOT, 'dev', 'dll')
 const CACHE_HASH = path.join(DLL_ROOT, 'pnpm-lock.yaml.md5')
 
 const buildDll = async () => {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let cacheHash
     try {
       cacheHash = fs.readFileSync(CACHE_HASH, 'utf8')
@@ -26,7 +26,12 @@ const buildDll = async () => {
         fs.mkdirSync(DLL_ROOT, {recursive: true})
       }
       fs.writeFileSync(CACHE_HASH, hash)
-      webpack(config, () => {
+      webpack(config, (error) => {
+        if (error) {
+          console.error(`📘 DLL failed\n`, error.message)
+          reject(new Error(error))
+          return
+        }
         console.log(`📘 DLL created`)
         resolve()
       })

--- a/scripts/webpack/dev.clientdll.config.js
+++ b/scripts/webpack/dev.clientdll.config.js
@@ -43,7 +43,6 @@ module.exports = {
       '@emotion/core',
       '@emotion/react',
       '@emotion/styled',
-      '@floating-ui/dom',
       '@graphiql/toolkit',
       '@mattkrick/sanitize-svg',
       '@mui/base',


### PR DESCRIPTION
# Description

A duplicate entry caused the generation of vendors.json to fail silently.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

```
rm -r dev/dll ; pnpm node ./scripts/buildDll.js ; ls dev/dll
```
will not generate `vendors.json` on master, but will after this PR.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
