### PR TITLE
fix: rename persistentUserId to persistentNameId

### DIFF
--- a/packages/server/database/types/User.ts
+++ b/packages/server/database/types/User.ts
@@ -18,7 +18,7 @@ interface Input {
   pseudoId?: string | null
   sendSummaryEmail?: boolean
   tms?: string[]
-  persistentUserId?: string
+  persistentNameId?: string
 }
 
 export default class User {
@@ -41,7 +41,7 @@ export default class User {
   tms: string[]
   reasonRemoved?: string
   rol?: AuthTokenRole.SUPER_USER
-  persistentUserId: string | null
+  persistentNameId: string | null
   constructor(input: Input) {
     const {
       tms,
@@ -58,7 +58,7 @@ export default class User {
       preferredName,
       pseudoId,
       sendSummaryEmail,
-      persistentUserId
+      persistentNameId
     } = input
     const now = new Date()
     this.id = id ?? `local|${generateUID()}`
@@ -75,6 +75,6 @@ export default class User {
     this.preferredName = preferredName.trim().slice(0, USER_PREFERRED_NAME_LIMIT)
     this.pseudoId = pseudoId ?? undefined
     this.sendSummaryEmail = sendSummaryEmail ?? true
-    this.persistentUserId = persistentUserId ?? null
+    this.persistentNameId = persistentNameId ?? null
   }
 }

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -17,7 +17,7 @@ import createTeamAndLeader from './createTeamAndLeader'
 const bootstrapNewUser = async (
   newUser: Pick<
     User,
-    'id' | 'createdAt' | 'preferredName' | 'email' | 'identities' | 'picture' | 'persistentUserId'
+    'id' | 'createdAt' | 'preferredName' | 'email' | 'identities' | 'picture' | 'persistentNameId'
   > & {
     pseudoId?: string
   },

--- a/packages/server/postgres/migrations/2026-02-03T01:19:30.621Z_persistentnameid.ts
+++ b/packages/server/postgres/migrations/2026-02-03T01:19:30.621Z_persistentnameid.ts
@@ -1,0 +1,9 @@
+import type {Kysely} from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema.alterTable('User').renameColumn('persistentUserId', 'persistentNameId').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.alterTable('User').renameColumn('persistentNameId', 'persistentUserId').execute()
+}


### PR DESCRIPTION
# Description

rename, but still catch the old name in the SAML message