### PR TITLE
fix: use contextFactory for all contexts

### DIFF
--- a/packages/server/email/requestFromYoga.ts
+++ b/packages/server/email/requestFromYoga.ts
@@ -8,13 +8,16 @@ export const requestFromYoga = async (
 ) => {
   // using require until this file is not required by any file that is used to create the schema (ie we move away from object-first GraphQL)
   const {getPersistedOperation, yoga} = require('../yoga')
-  const {schema, execute, parse} = yoga.getEnveloped()
-  const query = await getPersistedOperation(docId)
+  const {schema, execute, parse, contextFactory} = yoga.getEnveloped()
+  const [query, envelopedContext] = await Promise.all([
+    getPersistedOperation(docId),
+    contextFactory()
+  ])
   const res = await execute({
     document: parse(query),
     variableValues: variables,
     schema,
-    contextValue: context
+    contextValue: {...envelopedContext, ...context}
   })
   // yoga creates objects using a null prototype. Relay incorrectly uses `{}.hasOwnProperty`
   // As a quick hack, we recate the objects using an Object prototype here

--- a/packages/server/utils/callGQL.ts
+++ b/packages/server/utils/callGQL.ts
@@ -8,12 +8,13 @@ import {yoga} from '../yoga'
 export const callGQL = async <TData>(query: string, variables?: Record<string, any>) => {
   const authToken = new ServerAuthToken()
   const dataLoader = getNewDataLoader('callGQL')
-  const {execute, parse} = yoga.getEnveloped()
+  const {execute, parse, contextFactory} = yoga.getEnveloped()
+  const envelopedContext = await contextFactory()
   const result = await execute({
     document: parse(query),
     variableValues: variables,
     schema: privateSchema,
-    contextValue: {dataLoader, authToken}
+    contextValue: {...envelopedContext, dataLoader, authToken}
   })
   dataLoader.dispose()
   return result as ExecutionResult<TData>


### PR DESCRIPTION
# Description

oneOf requires a Symbol in the context, so we have to use the contextFactory in all places where we pass context into execute.

From: 

```
Plugin has not been properly set up. The 'contextFactory' function is not invoked and the result has not been passed to 'execute'.
```