### PR TITLE
fix: new user infinite loop on accept team invitation

### DIFF
--- a/packages/client/components/InvitationLinkDialog.tsx
+++ b/packages/client/components/InvitationLinkDialog.tsx
@@ -1,7 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
-import {useEffect} from 'react'
+import {useEffect, useRef} from 'react'
 import {useFragment} from 'react-relay'
-import {type RouteComponentProps, withRouter} from 'react-router'
 import type {InvitationLinkDialog_massInvitation$key} from '../__generated__/InvitationLinkDialog_massInvitation.graphql'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useMetaTagContent from '../hooks/useMetaTagContent'
@@ -13,12 +12,14 @@ import {useIsAuthenticated} from './IsAuthenticatedProvider'
 import TeamInvitationAccept from './TeamInvitationAccept'
 import TeamInvitationErrorNotFound from './TeamInvitationErrorNotFound'
 
-interface Props extends RouteComponentProps<{token: string}> {
+interface Props {
   massInvitation: InvitationLinkDialog_massInvitation$key
 }
 
 const InvitationLinkDialog = (props: Props) => {
   const isLoggedIn = useIsAuthenticated()
+  // if they log in, then accepting team invite will get triggered via login flow
+  const isInitiallyLoggedInRef = useRef(isLoggedIn)
   const {match} = useRouter<{token: string}>()
   const {params} = match
   const {token} = params
@@ -58,10 +59,10 @@ const InvitationLinkDialog = (props: Props) => {
     case 'expired':
       return <InvitationLinkErrorExpired massInvitation={massInvitation} />
   }
-  if (isLoggedIn) {
+  if (isInitiallyLoggedInRef.current) {
     return <TeamInvitationAccept invitationToken={token} />
   }
   return <InvitationLinkAuthentication teamName={teamName!} invitationToken={token} />
 }
 
-export default withRouter(InvitationLinkDialog)
+export default InvitationLinkDialog

--- a/packages/client/utils/loginSSO.ts
+++ b/packages/client/utils/loginSSO.ts
@@ -24,11 +24,11 @@ const loginSSO = (url: string, top?: number): ReturnType | Promise<ReturnType> =
       // an extension posted to the opener
       if (typeof event.data !== 'object') return
       const {error, userId} = event.data
-      if (!userId || event.origin !== window.location.origin) return
+      if (event.origin !== window.location.origin) return
 
       const params = new URLSearchParams(popup.location.search)
       if (userId !== params.get('userId')) {
-        resolve({error: 'Error logging in.'})
+        resolve({error: error || 'Error logging in.'})
         return
       }
       const isNewUser = params.get('isNewUser') === 'true'

--- a/packages/server/graphql/mutations/deleteUser.ts
+++ b/packages/server/graphql/mutations/deleteUser.ts
@@ -16,13 +16,16 @@ const markUserSoftDeleted = async (
   deletedUserEmail: string,
   validReason: string
 ) => {
-  const update = {
-    isRemoved: true,
-    email: deletedUserEmail,
-    reasonRemoved: validReason,
-    updatedAt: new Date()
-  }
-  await updateUser(update, userIdToDelete)
+  await updateUser(
+    {
+      isRemoved: true,
+      email: deletedUserEmail,
+      reasonRemoved: validReason,
+      persistentNameId: null,
+      updatedAt: new Date()
+    },
+    userIdToDelete
+  )
 }
 
 export default {

--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -172,7 +172,7 @@ const loginSAML: MutationResolvers['loginSAML'] = async (
   if (!email) {
     return standardError(
       new Error(
-        `Email attribute is missing from the SAML response. The following attributes were included: ${Object.keys(attributes).join(', ')}`
+        `Email attribute is missing from the SAML response. The following attributes were included: ${Object.keys(attributes).join(', ') || '<None>'}`
       ),
       {extras: {attributes}}
     )

--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -7,6 +7,7 @@ import {
 import AuthToken from '../../../database/types/AuthToken'
 import acceptTeamInvitationSafe from '../../../safeMutations/acceptTeamInvitation'
 import {analytics} from '../../../utils/analytics/analytics'
+import {setAuthCookie} from '../../../utils/authCookie'
 import {getUserId, isTeamMember} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import RedisLock from '../../../utils/RedisLock'
@@ -120,7 +121,8 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
   })
   // This is to triage https://github.com/ParabolInc/parabol/issues/11167. We know it worked if we don't see it again
   context.authToken = nextAuthToken
-
+  // if this gets called without a websocket, we need to set it: https://github.com/ParabolInc/parabol/issues/12610
+  setAuthCookie(context, nextAuthToken)
   // Send the new team member a welcome & a new token
   publish(SubscriptionChannel.NOTIFICATION, viewerId, 'AuthTokenPayload', {
     tms


### PR DESCRIPTION
# Description

fixes #11878 

also prevents 2 `acceptTeamInvitation` calls from getting sent, which was the source of the rate limit getting hit.
passes through the error message when SSO fails.

@Dschoordsch the acceptTeamInvitation loop that has plagued us is finally squashed 😅 