### PR TITLE
feat: Add reflection group color dots to retro sidebar

### DIFF
--- a/packages/client/components/ReflectionCard/ColorBadge.tsx
+++ b/packages/client/components/ReflectionCard/ColorBadge.tsx
@@ -3,8 +3,9 @@ import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
 import type {NewMeetingPhaseTypeEnum} from '~/__generated__/ActionMeeting_meeting.graphql'
 import type {ColorBadge_reflection$key} from '~/__generated__/ColorBadge_reflection.graphql'
-import {MenuPosition} from '~/hooks/useCoords'
-import useTooltip from '~/hooks/useTooltip'
+import {Tooltip} from '~/ui/Tooltip/Tooltip'
+import {TooltipContent} from '~/ui/Tooltip/TooltipContent'
+import {TooltipTrigger} from '~/ui/Tooltip/TooltipTrigger'
 
 const DROP_SIZE = 32
 const DROP_SIZE_HALF = DROP_SIZE / 2
@@ -50,20 +51,16 @@ const ColorBadge = (props: Props) => {
   )
   const {prompt} = reflection
   const {question, groupColor} = prompt
-  const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
-    MenuPosition.LOWER_LEFT,
-    {
-      disabled: phaseType !== 'discuss'
-    }
-  )
   if (phaseType === 'reflect') return null
   return (
-    <>
-      <BadgeWrapper onMouseEnter={openTooltip} onMouseLeave={closeTooltip} ref={originRef}>
-        <ColorDrop groupColor={groupColor} />
-      </BadgeWrapper>
-      {tooltipPortal(question)}
-    </>
+    <Tooltip disableHoverableContent={phaseType !== 'discuss'}>
+      <TooltipTrigger asChild>
+        <BadgeWrapper>
+          <ColorDrop groupColor={groupColor} />
+        </BadgeWrapper>
+      </TooltipTrigger>
+      <TooltipContent>{question}</TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/packages/client/components/RetroSidebarDiscussSection.tsx
+++ b/packages/client/components/RetroSidebarDiscussSection.tsx
@@ -140,7 +140,15 @@ const RetroSidebarDiscussSection = (props: Props) => {
                 {stages.map((stage, idx) => {
                   const {reflectionGroup} = stage
                   if (!reflectionGroup) return null
-                  const {title, voteCount} = reflectionGroup
+                  const {title, voteCount, reflections} = reflectionGroup
+                  const reflectionColors = reflections.map(({prompt}) => prompt.groupColor)
+                  const colors = [...new Set(reflectionColors)]
+                    .sort(
+                      (a, b) =>
+                        reflectionColors.filter((v) => v === b).length -
+                        reflectionColors.filter((v) => v === a).length
+                    )
+                    .slice(0, 3)
                   // the local user is at another stage than the facilitator stage
                   const isUnsyncedFacilitatorStage = !inSync && stage.id === facilitatorStageId
                   const voteMeta = (
@@ -175,7 +183,38 @@ const RetroSidebarDiscussSection = (props: Props) => {
                               isDisabled={!stage.isNavigable}
                               isUnsyncedFacilitatorStage={isUnsyncedFacilitatorStage}
                             >
-                              {title!}
+                              <div className='flex w-full items-center space-x-0.5'>
+                                <div>
+                                  {colors.map((color, idx) => {
+                                    const DOT_SIZE = 8
+                                    const TOTAL_HEIGHT = 18
+                                    const DESIRED_VISIBLE = 4 // how much of each lower dot shows
+
+                                    const visible =
+                                      colors.length > 1
+                                        ? Math.min(
+                                            DESIRED_VISIBLE,
+                                            (TOTAL_HEIGHT - DOT_SIZE) / (colors.length - 1)
+                                          )
+                                        : 0
+
+                                    const overlap = DOT_SIZE - visible
+
+                                    return (
+                                      <div
+                                        key={idx}
+                                        style={{
+                                          backgroundColor: color,
+                                          marginTop: idx === 0 ? 0 : -overlap,
+                                          zIndex: colors.length - idx
+                                        }}
+                                        className='relative h-2 w-2 rounded-full'
+                                      />
+                                    )
+                                  })}
+                                </div>
+                                <div>{title!}</div>
+                              </div>
                             </MeetingSubnavItem>
                           </DraggableMeetingSubnavItem>
                         )
@@ -203,6 +242,11 @@ graphql`
       reflectionGroup {
         title
         voteCount
+        reflections {
+          prompt {
+            groupColor
+          }
+        }
       }
       sortOrder
     }


### PR DESCRIPTION
# Description

A customer said they like to keep all reflections in the same columns.
Then, after they vote, they like to discuss all the items in the first column, then all the items in the second column, etc.
In other words, it's a 2-tiered sort: they first sort by column, then they sort by number of votes.

While more than 1 customer may do this, it's a pattern that could get messy.
I suggested we put the column color next to the discussion topic. that way, then can manually drag & drop to achieve their desired sort. By having the colors next to the title, it'll go faster because they don't have to perform a manual O(nlogn) sort by clicking into each topic, seeing what color it contains, and then dragging it.

in case a topic has more than 1 prompt in it, i picked the top 3.
I also group by color instead of prompt ID so if they have 2 columns with the same color, then they can group like that, too.

<img width="251" height="377" alt="Screenshot 2026-02-17 at 7 16 46 PM" src="https://github.com/user-attachments/assets/de7bfc69-a75b-467f-a0e3-61780f58366c" />
