### PR TITLE
fix: broken page removal on team member removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,5 +208,5 @@
     "y-protocols": "^1.0.7",
     "yjs": "^13.6.29"
   },
-  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
+  "packageManager": "pnpm@10.30.0+sha512.2b5753de015d480eeb88f5b5b61e0051f05b4301808a82ec8b840c9d2adf7748eb352c83f5c1593ca703ff1017295bc3fdd3119abb9686efc96b9fcb18200937"
 }

--- a/packages/client/components/TeamAvatar/TeamAvatar.tsx
+++ b/packages/client/components/TeamAvatar/TeamAvatar.tsx
@@ -43,7 +43,7 @@ export const TeamAvatar: React.FC<TeamAvatarProps> = ({teamName, teamId, classNa
   return (
     <div
       className={cn(
-        'mr-2 flex h-6 w-6 shrink-0 items-center justify-center rounded-full font-light font-sans text-[10px] text-white text-xs uppercase',
+        'pointer-cursor mr-2 flex h-6 w-6 shrink-0 select-none items-center justify-center rounded-full font-light font-sans text-[10px] text-white text-xs uppercase',
         className
       )}
       style={{backgroundColor: `#${backgroundColor}`}}

--- a/packages/client/utils/getMassInvitationUrl.ts
+++ b/packages/client/utils/getMassInvitationUrl.ts
@@ -2,7 +2,7 @@ import makeHref from './makeHref'
 
 const getMassInvitationUrl = (token: string) => {
   const {prblIn} = window.__ACTION__
-  const protocol = prblIn?.startsWith('localhost') ? 'http:' : 'https:'
+  const {protocol} = window.location
   return prblIn ? `${protocol}//${prblIn}/${token}` : makeHref(`/invitation-link/${token}`)
 }
 

--- a/packages/server/postgres/migrations/2026-02-19T20:30:29.922Z_remove-page-access-team.ts
+++ b/packages/server/postgres/migrations/2026-02-19T20:30:29.922Z_remove-page-access-team.ts
@@ -1,0 +1,43 @@
+import {type Kysely, sql} from 'kysely'
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+CREATE OR REPLACE FUNCTION "removePageAccessOnTeamArchive"() RETURNS TRIGGER AS $$
+DECLARE
+  "_pageIds" INT[];
+  "_userIds" VARCHAR[];
+BEGIN
+  -- 1. Only run if isArchived flipped from False to True
+  IF NEW."isArchived" = TRUE AND OLD."isArchived" = FALSE THEN
+
+    WITH "deleted" AS (
+      DELETE FROM "PageTeamAccess"
+      WHERE "teamId" = NEW."id"
+      RETURNING "pageId"
+    )
+    SELECT ARRAY(SELECT "pageId" FROM "deleted") INTO "_pageIds";
+
+    "_userIds" := ARRAY(
+      SELECT "userId" FROM "TeamMember" WHERE "teamId" = NEW."id"
+    );
+
+    -- 3. Only perform the update if there is actually work to do
+    -- This prevents passing empty/null arrays to your sub-function
+    IF array_length("_pageIds", 1) > 0 AND array_length("_userIds", 1) > 0 THEN
+      PERFORM "updatePageAccess"("_userIds", "_pageIds");
+    END IF;
+
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+	`.execute(db)
+}
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function down(db: Kysely<any>): Promise<void> {
+  // down migration code goes here...
+  // note: down migrations are optional. you can safely delete this function.
+  // For more info, see: https://kysely.dev/docs/migrations
+}


### PR DESCRIPTION
# Description

when deleting a team, i kept hitting a bug caused by the trigger function.
replacing it fixed removing the team and now if a page is shared with that team & a user leaves the org, it works correctly.

fix #12619