### PR TITLE
fix: prevent moving and dragging of Meeting Summaries pages

### DIFF
--- a/packages/client/components/DashNavList/LeftNavPageLink.tsx
+++ b/packages/client/components/DashNavList/LeftNavPageLink.tsx
@@ -65,6 +65,7 @@ export const LeftNavPageLink = (props: Props) => {
         userSortOrder
         sortOrder # used implicityly in store traversal by useDraggingPage
         isDatabase
+        isMeetingTOC
       }
     `,
     pageRef
@@ -79,7 +80,8 @@ export const LeftNavPageLink = (props: Props) => {
     teamId,
     isPrivate,
     currentPageAncestorDepth,
-    isDatabase
+    isDatabase,
+    isMeetingTOC
   } = page
   const {viewer: viewerAccess} = access
 
@@ -123,7 +125,12 @@ export const LeftNavPageLink = (props: Props) => {
     isDropBelowReorder || (isViewerOwnerOfDraggingPage && isEditorOfDroppingSection)
 
   const canDropIn =
-    draggingPageId && !isSourceDragParent && !isSelf && !isDraggingLastChild && hasDragDropInAccess
+    draggingPageId &&
+    !isSourceDragParent &&
+    !isSelf &&
+    !isDraggingLastChild &&
+    hasDragDropInAccess &&
+    !isMeetingTOC
   const hasDragDropInOrBelow = showChildren ? hasDragDropInAccess : hasDragDropBelowAccess
 
   const canDropBelow =

--- a/packages/client/hooks/useDraggablePage.tsx
+++ b/packages/client/hooks/useDraggablePage.tsx
@@ -169,7 +169,15 @@ export const rawOnPointerUp =
           console.warn('Page not found in Relay')
           return
         }
-        const {title, isDatabase} = pageGQLRecord
+        const {title, isDatabase, isMeetingTOC} = pageGQLRecord
+        if (isMeetingTOC) {
+          atmosphere.eventEmitter.emit('addSnackbar', {
+            key: 'useDraggablePage:noDropAccess',
+            message: 'Cannot move Meeting Summaries',
+            autoDismiss: 5
+          })
+          return
+        }
         const children = getPageLinks(document, true)
         const idx = dropIdx === null ? -1 : dropIdx
         const dropTarget = children.at(idx) as Y.XmlElement
@@ -217,6 +225,16 @@ export const rawOnPointerUp =
           teamId: targetTeamId
         },
         onError: snackOnError(atmosphere, 'updatePageErr'),
+        onCompleted: (_res, errors) => {
+          const firstError = errors?.[0]
+          if (firstError) {
+            atmosphere.eventEmitter.emit('addSnackbar', {
+              message: firstError.message,
+              autoDismiss: 10,
+              key: 'dragPageError'
+            })
+          }
+        },
         sourceTeamId,
         sourceParentPageId,
         sourceConnectionKey,

--- a/packages/client/tiptap/extensions/PageDragHandle.ts
+++ b/packages/client/tiptap/extensions/PageDragHandle.ts
@@ -15,6 +15,7 @@ const queryNode = graphql`
         isPrivate
         title
         isDatabase
+        isMeetingTOC
         access {
           viewer
         }

--- a/packages/server/graphql/public/mutations/updatePage.ts
+++ b/packages/server/graphql/public/mutations/updatePage.ts
@@ -30,9 +30,13 @@ const updatePage: MutationResolvers['updatePage'] = async (
   const page = await dataLoader.get('pages').load(dbPageId)
   dataLoader.get('pages').clearAll()
   if (!page) throw new GraphQLError('Invalid pageId')
-  if (page.isMeetingTOC) throw new GraphQLError('Meeting Summaries pages cannot be moved')
-  const isReorder = sourceSection === targetSection && (!teamId || teamId === page.teamId)
+
+  const isReorder =
+    sourceSection === targetSection && ((!teamId && !page.teamId) || teamId === page.teamId)
   if (!isReorder) {
+    if (page.isMeetingTOC) {
+      throw new GraphQLError('Meeting Summaries pages cannot be moved')
+    }
     // changing parents will change permissions.
     const userRole = await dataLoader
       .get('pageAccessByPageIdUserId')

--- a/packages/server/graphql/public/typeDefs/Page.graphql
+++ b/packages/server/graphql/public/typeDefs/Page.graphql
@@ -21,4 +21,5 @@ type Page implements PagePartial {
   deletedByUser: User
   ancestorIds: [ID!]!
   ancestors: [PagePartial!]!
+  isMeetingTOC: Boolean!
 }

--- a/packages/server/postgres/migrations/2026-02-20T19:53:26.000Z_meetingTOCPage.ts
+++ b/packages/server/postgres/migrations/2026-02-20T19:53:26.000Z_meetingTOCPage.ts
@@ -144,7 +144,7 @@ export async function up(db: Kysely<any>): Promise<void> {
             isPrivate: false,
             title: 'Meeting Summaries',
             yDoc,
-            sortOrder: '!',
+            sortOrder: ' !',
             isParentLinked: true
           })
           .returning('id')

--- a/packages/server/utils/tiptap/movePageToNewParent.ts
+++ b/packages/server/utils/tiptap/movePageToNewParent.ts
@@ -18,12 +18,15 @@ export const movePageToNewParent = async (
   const pg = getKysely()
   const childPage = await pg
     .selectFrom('Page')
-    .select(['parentPageId', 'deletedAt'])
+    .select(['parentPageId', 'deletedAt', 'isMeetingTOC'])
     .where('id', '=', pageId)
     .executeTakeFirstOrThrow()
   if (childPage.parentPageId === parentPageId) {
     // the child page will already have the correct parent if we created a PageLink on the parent doc
     if (!childPage.deletedAt) return
+  }
+  if (childPage.isMeetingTOC) {
+    throw new GraphQLError(`Cannot move Meeting Summaries`)
   }
 
   const [viewerAccess] = await pageAccessByUserIdBatchFn([{pageId, userId: viewerId}])


### PR DESCRIPTION
# Description

prevents dropping items into the Meeting Summaries TOC.
We can fix the dragging later, but that'll be more involved, so popping a toast works for now