### PR TITLE
Fix: #12683 push integration tasks

### DIFF
--- a/packages/server/graphql/public/mutations/createTask.ts
+++ b/packages/server/graphql/public/mutations/createTask.ts
@@ -1,4 +1,5 @@
 import {generateText} from '@tiptap/core'
+import type {GraphQLResolveInfo} from 'graphql'
 import type {Insertable} from 'kysely'
 import MeetingMemberId from 'parabol-client/shared/gqlIds/MeetingMemberId'
 import {getAllNodesAttributesByType} from 'parabol-client/shared/tiptap/getAllNodesAttributesByType'
@@ -133,7 +134,8 @@ const handleAddTaskNotifications = async (
 const createTask: MutationResolvers['createTask'] = async (
   _source,
   {newTask, area: _area},
-  context
+  context,
+  info: GraphQLResolveInfo
 ) => {
   const {authToken, dataLoader, socketId: mutatorId} = context
   const pg = getKysely()
@@ -174,10 +176,8 @@ const createTask: MutationResolvers['createTask'] = async (
     content,
     viewerId,
     teamId,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    context as any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    {} as any // info is not easily available in SDL resolvers without extra effort, but createTaskInService might not need full info
+    context,
+    info
   )
   if (integrationRes.error) {
     return {error: {message: integrationRes.error.message}}

--- a/packages/server/graphql/public/mutations/createTaskIntegration.ts
+++ b/packages/server/graphql/public/mutations/createTaskIntegration.ts
@@ -1,3 +1,4 @@
+import type {GraphQLResolveInfo} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import makeAppURL from 'parabol-client/utils/makeAppURL'
 import appOrigin from '../../../appOrigin'
@@ -12,7 +13,8 @@ import type {MutationResolvers} from '../resolverTypes'
 const createTaskIntegration: MutationResolvers['createTaskIntegration'] = async (
   _source,
   {integrationProviderService, integrationRepoId, taskId},
-  context
+  context,
+  info: GraphQLResolveInfo
 ) => {
   const {authToken, dataLoader, socketId: mutatorId} = context
   const pg = getKysely()
@@ -46,10 +48,8 @@ const createTaskIntegration: MutationResolvers['createTaskIntegration'] = async 
           teamId: teamId,
           userId: viewerId
         },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        context as any,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        {} as any // info is not easily available
+        context,
+        info
       ),
       userId
         ? TaskIntegrationManagerFactory.initManager(
@@ -59,10 +59,8 @@ const createTaskIntegration: MutationResolvers['createTaskIntegration'] = async 
               teamId: teamId,
               userId
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            context as any,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            {} as any
+            context,
+            info
           )
         : null,
       dataLoader.get('teams').loadNonNull(teamId),


### PR DESCRIPTION
# Description

Fixes #12683

The SDL-first migration dropped the info parameter and passed {} as any instead, which breaks any integration that called i`nfo.schema.getType()` (specifically GitHub, Linear, GitLab).

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [x] Can push tasks!
