### PR TITLE
fix(embedder): abort pending drought promise on graceful shutdown

### DIFF
--- a/packages/embedder/EmbeddingsJobQueueStream.ts
+++ b/packages/embedder/EmbeddingsJobQueueStream.ts
@@ -99,6 +99,10 @@ export class EmbeddingsJobQueueStream implements AsyncIterableIterator<Embedding
   }
   return() {
     this.done = true
+    if (this.resolveDrought) {
+      this.resolveDrought()
+      this.resolveDrought = undefined
+    }
     return Promise.resolve({done: true as const, value: undefined})
   }
   throw(error: any) {


### PR DESCRIPTION
# Description

> **This is AI generated but tested. It's working and it's executing the graceful shutdown as I expect**

This PR fixes an issue where the `EmbeddingsJobQueueStream` would hang indefinitely during a graceful shutdown if no jobs were actively being processing.

**Root Cause:**
When a worker is idle, it waits on a promise (`resolveDrought`) that is only resolved when a new job arrives via Redis pub/sub. During a `SIGTERM` or `SIGINT`, the `.return()` method is called on the iterator, but it failed to reject or resolve this pending drought promise. As a result, the generator remained suspended, causing the `for await` loop in `embedder.ts` to hang forever and preventing `process.exit()` from running.

**Fix:**
Updated the `.return()` method in `EmbeddingsJobQueueStream.ts` to check for and invoke `resolveDrought` if it exists, ensuring the promise resolves and the iterator can complete its cycle, allowing the process to exit gracefully.

## Demo

https://www.loom.com/share/1a84891cf0d94be3964b0c278a797285

## Testing scenarios

- Using master, send the SIGTERM to the Embedder when it is not embedding anything and observe how it hangs forever. In Kubernetes this end abruptly after the termination period (default 60s) with a SIGKILL and exits with an error code.

- Using this branch, send the SIGTERM to the Embedder when it is not embedding anything and observe how it quickly ends gracefully

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
