### PR TITLE
fix: log out client if auth token is rejected

### DIFF
--- a/packages/client/utils/createWSClient.ts
+++ b/packages/client/utils/createWSClient.ts
@@ -118,6 +118,11 @@ export function createWSClient(atmosphere: Atmosphere) {
           setConnectedStatus(atmosphere, true)
         },
         closed: (event) => {
+          if ((event as CloseEvent).code === 1006) {
+            // closed abnormally, this happens if we reject with 401 from the server
+            atmosphere.invalidateSession('Connection rejected')
+          }
+
           if (!hasConnected) {
             console.error('Could not connect via WebSocket', event)
             reject(event)

--- a/packages/server/wsHandler.ts
+++ b/packages/server/wsHandler.ts
@@ -303,12 +303,13 @@ wsHandler.upgrade = async (res, req, context) => {
     const authToken = getVerifiedAuthToken(token)
     const {sub: viewerId, iat} = authToken
     const [isBlacklistedJWT, user] = await Promise.all([
-      checkBlacklistJWT(viewerId, iat),
-      getKysely()
-        .selectFrom('User')
-        .select(['id', 'inactive', 'lastSeenAt', 'email', 'tms'])
-        .where('id', '=', viewerId)
-        .executeTakeFirst()
+      !viewerId || checkBlacklistJWT(viewerId, iat),
+      viewerId &&
+        getKysely()
+          .selectFrom('User')
+          .select(['id', 'inactive', 'lastSeenAt', 'email', 'tms'])
+          .where('id', '=', viewerId)
+          .executeTakeFirst()
     ])
 
     if (isAborted) {


### PR DESCRIPTION
It's not the cleanest solution because the browser does not report 401 from upgrade back to the websocket client, but at least it's something.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
