### PR TITLE
fix: properly notify client if AuthToken is unauthorized

### DIFF
--- a/packages/client/utils/createWSClient.ts
+++ b/packages/client/utils/createWSClient.ts
@@ -118,11 +118,6 @@ export function createWSClient(atmosphere: Atmosphere) {
           setConnectedStatus(atmosphere, true)
         },
         closed: (event) => {
-          if ((event as CloseEvent).code === 1006) {
-            // closed abnormally, this happens if we reject with 401 from the server
-            atmosphere.invalidateSession('Connection rejected')
-          }
-
           if (!hasConnected) {
             console.error('Could not connect via WebSocket', event)
             reject(event)


### PR DESCRIPTION
Responding to a websocket upgrade request with 401 or similar will be swallowed by the browser and reported as just a generic connection error to the client. This is not helpful to initiate a logout. So let the client establish the websocket connection first and then reject them.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
