### PR TITLE
fix: Update `refUpdatedAt` on conflict when renaming meeting templates.

### DIFF
--- a/packages/server/graphql/public/mutations/renameMeetingTemplate.ts
+++ b/packages/server/graphql/public/mutations/renameMeetingTemplate.ts
@@ -54,6 +54,11 @@ const renameMeetingTemplate: MutationResolvers['renameMeetingTemplate'] = async 
         refUpdatedAt: sql`CURRENT_TIMESTAMP`,
         teamId
       })
+      .onConflict((oc) =>
+        oc.columns(['refId', 'objectType']).doUpdateSet((eb) => ({
+          refUpdatedAt: eb.ref('excluded.refUpdatedAt')
+        }))
+      )
       .returning('id')
       .executeTakeFirstOrThrow(),
     pg


### PR DESCRIPTION
# Description

fixed yesterday's regression.