### PR TITLE
chore: fail staging and prod deployments properly and restrict PR creation

### DIFF
--- a/.github/workflows/release-to-prod.yml
+++ b/.github/workflows/release-to-prod.yml
@@ -37,14 +37,20 @@ jobs:
             JOB_ID_DONE=$(echo $RES | jq '.id // empty')
             [ -z "$JOB_ID_DONE" ] && exit 1 || exit 0
       - name: Poll Production Release
-        uses: artiz/poll-endpoint@1.0.2
-        with:
-          url: https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/jobs/${{ env.JOB_ID }}?access_token=${{ secrets.GITLAB_DEPLOYMENT_ACCESS_TOKEN }}
-          method: GET
-          expect-status: 200
-          expect-response-regex: '"status":"success"'
-          timeout: 120000
-          interval: 3000
+        timeout-minutes: 30
+        run: |
+          while true; do
+            STATUS=$(curl -s "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/jobs/${{ env.JOB_ID }}" --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_DEPLOYMENT_ACCESS_TOKEN }}' | jq -r '.status')
+            echo "Current status: $STATUS"
+            if [ "$STATUS" == "success" ]; then
+              echo "Job completed successfully."
+              exit 0
+            elif [[ "$STATUS" == "failed" || "$STATUS" == "canceled" ]]; then
+              echo "Job failed or was canceled."
+              exit 1
+            fi
+            sleep 15
+          done
 
       - name: Report Status
         if: failure()

--- a/.github/workflows/release-to-staging.yml
+++ b/.github/workflows/release-to-staging.yml
@@ -91,6 +91,21 @@ jobs:
             echo $RES
             JOB_ID_DONE=$(echo $RES | jq '.id // empty')
             [ -z "$JOB_ID_DONE" ] && exit 1 || exit 0
+      - name: Poll Staging Release
+        timeout-minutes: 30
+        run: |
+          while true; do
+            STATUS=$(curl -s "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/jobs/${{ env.JOB_ID }}" --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_DEPLOYMENT_ACCESS_TOKEN }}' | jq -r '.status')
+            echo "Current status: $STATUS"
+            if [ "$STATUS" == "success" ]; then
+              echo "Job completed successfully."
+              exit 0
+            elif [[ "$STATUS" == "failed" || "$STATUS" == "canceled" ]]; then
+              echo "Job failed or was canceled."
+              exit 1
+            fi
+            sleep 15
+          done
       - name: Open PR to Push to Prod
         env:
           GH_TOKEN: ${{ github.token }}
@@ -112,15 +127,6 @@ jobs:
             --head release/v${{ env.ACTION_VERSION }} \
             --title "chore(release): Test and deploy to Production v${{ env.ACTION_VERSION }}" \
             --body "$BODY"
-      - name: Poll Staging Release
-        uses: artiz/poll-endpoint@1.0.2
-        with:
-          url: https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/jobs/${{ env.JOB_ID }}?access_token=${{ secrets.GITLAB_DEPLOYMENT_ACCESS_TOKEN }}
-          method: GET
-          expect-status: 200
-          expect-response-regex: '"status":"success"'
-          timeout: 120000
-          interval: 3000
 
       - name: Report Status
         if: failure()


### PR DESCRIPTION


# Description
Ensure GitHub Action workflows handle failing GitLab deployments appropriately and prevent automated PRs to Production when the Staging deployment fails.

## Changes Included
- **Accurate Deployment Polling:** Swapped out the `artiz/poll-endpoint` GitHub Action for a simple bash script to poll the status of our GitLab deployment jobs in both Staging and Prod.
- **Immediate Failure Triggers:** The polling script now explicitly checks for `failed` or `canceled` GitLab job states and fails the GitHub Action step immediately, effectively preventing timeout-based ambiguity.
- **Fail-Fast Staging Release Checks:** Reordered the `release-to-staging.yml` workflow so that we only open a Pull Request for Production *after* making sure the Staging environment deployment reported a successful exit code status from GitLab.