### PR TITLE
fix: Tab/S+Tab indention for details, tasks

### DIFF
--- a/packages/client/hooks/useTipTapPageEditor.ts
+++ b/packages/client/hooks/useTipTapPageEditor.ts
@@ -149,8 +149,14 @@ export const useTipTapPageEditor = (
                 return "Press '/' for commands"
               case 'detailsSummary':
                 return 'New summary'
-              case 'detailsContent':
-                return 'Add details, use / to add blocks'
+              case 'detailsContent': {
+                const isDefaultEmpty =
+                  node.childCount === 0 ||
+                  (node.childCount === 1 &&
+                    node.firstChild?.type.name === 'paragraph' &&
+                    node.firstChild.content.size === 0)
+                return isDefaultEmpty ? 'Add details, use / to add blocks' : ''
+              }
               case 'bulletList':
               case 'listItem':
               case 'orderedList':

--- a/packages/client/tiptap/extensions/IndentHandler.ts
+++ b/packages/client/tiptap/extensions/IndentHandler.ts
@@ -1,65 +1,141 @@
-// https://github.com/ueberdosis/tiptap/issues/457#issuecomment-2285456957
+import type {Editor} from '@tiptap/core'
 import {Extension} from '@tiptap/core'
+import {TextSelection} from '@tiptap/pm/state'
 
-const TAB_CHAR = '\u0009'
+// See also: https://github.com/ueberdosis/tiptap/issues/457#issuecomment-2285456957
+// TipTap has troble receiving the Tab input in certain contexts
+
+// Move a details block into the previous sibling's detailsContent
+function sinkDetails(editor: Editor): boolean {
+  const {state} = editor
+  const {$from} = state.selection
+
+  // Find the nearest details ancestor
+  let detailsDepth = -1
+  for (let d = $from.depth; d > 0; d--) {
+    if ($from.node(d).type.name === 'details') {
+      detailsDepth = d
+      break
+    }
+  }
+  if (detailsDepth < 1) return true
+
+  const detailsNode = $from.node(detailsDepth)
+  const detailsStart = $from.before(detailsDepth)
+  const detailsEnd = $from.after(detailsDepth)
+  const cursorOffset = $from.pos - detailsStart
+
+  // Need a previous sibling that is also a details block
+  const parentNode = $from.node(detailsDepth - 1)
+  const indexInParent = $from.index(detailsDepth - 1)
+  if (indexInParent === 0) return true
+
+  const prevSibling = parentNode.child(indexInParent - 1)
+  if (prevSibling.type.name !== 'details') return true
+
+  // Find the insertion point: end of the previous sibling's detailsContent
+  const prevSiblingStart = detailsStart - prevSibling.nodeSize
+  let contentEndOffset = -1
+  prevSibling.forEach((child, offset) => {
+    if (child.type.name === 'detailsContent') {
+      contentEndOffset = offset + 1 + child.content.size
+    }
+  })
+  if (contentEndOffset === -1) return true
+
+  // Absolute position at the end of prev sibling's detailsContent content
+  const insertPos = prevSiblingStart + 1 + contentEndOffset
+
+  // Delete first (higher position), then insert (lower position) — avoids position shifts
+  const tr = state.tr
+  tr.delete(detailsStart, detailsEnd)
+  tr.insert(insertPos, detailsNode)
+
+  // Restore cursor inside the moved node
+  try {
+    tr.setSelection(TextSelection.create(tr.doc, insertPos + cursorOffset))
+  } catch {
+    tr.setSelection(TextSelection.create(tr.doc, insertPos + 2))
+  }
+  tr.scrollIntoView()
+
+  editor.view.dispatch(tr)
+  return true
+}
+
+// Lift a details block out of its parent detailsContent into the grandparent.
+function liftDetails(editor: Editor): boolean {
+  const {state} = editor
+  const {$from} = state.selection
+
+  // Find the nearest details ancestor
+  let detailsDepth = -1
+  for (let d = $from.depth; d > 0; d--) {
+    if ($from.node(d).type.name === 'details') {
+      detailsDepth = d
+      break
+    }
+  }
+  if (detailsDepth < 2) return true
+
+  // Must be nested: details > detailsContent > details (current)
+  if ($from.node(detailsDepth - 1).type.name !== 'detailsContent') return true
+  if ($from.node(detailsDepth - 2).type.name !== 'details') return true
+
+  const detailsNode = $from.node(detailsDepth)
+  const detailsStart = $from.before(detailsDepth)
+  const detailsEnd = $from.after(detailsDepth)
+  const cursorOffset = $from.pos - detailsStart
+  const grandparentEnd = $from.after(detailsDepth - 2)
+
+  // Insert after grandparent (higher position) first, then delete original (lower position)
+  const tr = state.tr
+  tr.insert(grandparentEnd, detailsNode)
+  tr.delete(detailsStart, detailsEnd)
+
+  // The moved node now starts at: grandparentEnd - deletedSize
+  const newDetailsStart = grandparentEnd - (detailsEnd - detailsStart)
+  try {
+    tr.setSelection(TextSelection.create(tr.doc, newDetailsStart + cursorOffset))
+  } catch {
+    tr.setSelection(TextSelection.create(tr.doc, newDetailsStart + 2))
+  }
+  tr.scrollIntoView()
+
+  editor.view.dispatch(tr)
+  return true
+}
 
 export const IndentHandler = Extension.create({
   name: 'indentHandler',
   addKeyboardShortcuts() {
     return {
       Tab: ({editor}) => {
-        const {selection} = editor.state
-        const {$from} = selection
-
-        // Check if we're at the start of a list item
-        if (editor.isActive('listItem') && $from.parentOffset === 0) {
-          // Attempt to sink the list item
-          const sinkResult = editor.chain().sinkListItem('listItem').run()
-
-          // If sinking was successful, return true
-          if (sinkResult) {
-            return true
-          }
-          // If sinking failed, we'll fall through to inserting a tab
+        if (editor.isActive('listItem')) {
+          editor.chain().sinkListItem('listItem').run()
+          return true
         }
-
-        // Insert a tab character
-        editor
-          .chain()
-          .command(({tr}) => {
-            tr.insertText(TAB_CHAR)
-            return true
-          })
-          .run()
-
-        // Prevent default behavior (losing focus)
+        if (editor.isActive('taskItem')) {
+          editor.chain().sinkListItem('taskItem').run()
+          return true
+        }
+        if (editor.isActive('detailsSummary')) {
+          return sinkDetails(editor)
+        }
         return true
       },
       'Shift-Tab': ({editor}) => {
-        const {selection, doc} = editor.state
-        const {$from} = selection
-        const pos = $from.pos
-
-        // Check if we're at the start of a list item
-        if (editor.isActive('listItem') && $from.parentOffset === 0) {
-          // If so, lift the list item
-          return editor.chain().liftListItem('listItem').run()
-        }
-
-        // Check if the previous character is a tab
-        if (doc.textBetween(pos - 1, pos) === TAB_CHAR) {
-          // If so, delete it
-          editor
-            .chain()
-            .command(({tr}) => {
-              tr.delete(pos - 1, pos)
-              return true
-            })
-            .run()
+        if (editor.isActive('listItem')) {
+          editor.chain().liftListItem('listItem').run()
           return true
         }
-
-        // Prevent default behavior (losing focus)
+        if (editor.isActive('taskItem')) {
+          editor.chain().liftListItem('taskItem').run()
+          return true
+        }
+        if (editor.isActive('detailsSummary')) {
+          return liftDetails(editor)
+        }
         return true
       }
     }


### PR DESCRIPTION
# Description

While looking at DnD on Pages, I noticed that I couldn't easily indent or de-indent a task list or details list. This rectifies that.

Also, a little fix for these conflicting placeholders:

<img width="290" height="79" alt="mess1" src="https://github.com/user-attachments/assets/7d1c06db-6512-4c52-828b-96e98c112c73" />

## Demo

Loom: https://www.loom.com/share/0bdc608d0c63472ab101d9680517e714

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Put cursor on first item, hit tab: no indention!
- [ ] Create second item, hit tab, indention!
- [ ] Hit shift+tab, de-indention!

