### PR TITLE
chore: react 18 migration PR 2, migrate from `React.FC` types

### DIFF
--- a/docs/react-v18-migration.md
+++ b/docs/react-v18-migration.md
@@ -114,7 +114,7 @@ packages/client/components/NullableTask/NullableTask.tsx
 
 ---
 
-### PR 2 — Fix `React.FC` types and explicit `children` typing
+### PR 2 — Fix `React.FC` types and explicit `children` typing - DONE
 
 **~50 lines changed | Risk: LOW**
 

--- a/packages/client/components/TeamAvatar/TeamAvatar.tsx
+++ b/packages/client/components/TeamAvatar/TeamAvatar.tsx
@@ -1,4 +1,3 @@
-import type React from 'react'
 import {themeBackgroundColors} from '../../shared/themeBackgroundColors'
 import {cn} from '../../ui/cn'
 
@@ -37,7 +36,7 @@ const selectColor = (seed: string): string => {
   return themeBackgroundColors[idx]!
 }
 
-export const TeamAvatar: React.FC<TeamAvatarProps> = ({teamName, teamId, className}) => {
+export const TeamAvatar = ({teamName, teamId, className}: TeamAvatarProps) => {
   const initials = getInitials(teamName)
   const backgroundColor = selectColor(teamId)
   return (

--- a/packages/client/ui/Menu/Menu.tsx
+++ b/packages/client/ui/Menu/Menu.tsx
@@ -6,7 +6,7 @@ interface MenuProps extends DropdownMenu.DropdownMenuProps {
   trigger: React.ReactNode
 }
 
-export const Menu: React.FC<MenuProps> = ({trigger, children, ...props}) => {
+export const Menu = ({trigger, children, ...props}: MenuProps) => {
   return (
     <DropdownMenu.Root {...props}>
       <DropdownMenu.Trigger asChild>{trigger}</DropdownMenu.Trigger>


### PR DESCRIPTION
# Description

Part 2 of 18 or so to migrate to React v18. This one is trivial, so I will merge directly.
