### PR TITLE
chore: convert class components to functional, batch 1

### DIFF
--- a/docs/react-v18-migration.md
+++ b/docs/react-v18-migration.md
@@ -139,7 +139,7 @@ export const TeamAvatar = ({teamName, teamId, className}: TeamAvatarProps) => {
 
 ---
 
-### PR 3 — Convert class components to functional (batch 1: simple)
+### PR 3 — Convert class components to functional (batch 1: simple) - DONE
 
 **~400 lines changed | Risk: LOW**
 

--- a/packages/client/components/AddTeamMemberModalSuccess.tsx
+++ b/packages/client/components/AddTeamMemberModalSuccess.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import {Component} from 'react'
+import {useEffect} from 'react'
 import DialogContainer from './DialogContainer'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
@@ -23,38 +23,34 @@ const LI = styled('li')({
   lineHeight: '1.5rem'
 })
 
-class AddTeamMemberModalSuccess extends Component<Props> {
-  exitTimeoutId: number | undefined
+const AddTeamMemberModalSuccess = (props: Props) => {
+  const {closePortal, successfulInvitations} = props
 
-  componentDidMount() {
-    this.exitTimeoutId = window.setTimeout(() => {
-      this.props.closePortal()
+  useEffect(() => {
+    const exitTimeoutId = window.setTimeout(() => {
+      closePortal()
     }, 5000)
-  }
+    return () => {
+      clearTimeout(exitTimeoutId)
+    }
+  }, [closePortal])
 
-  componentWillUnmount() {
-    clearTimeout(this.exitTimeoutId)
-  }
-
-  render() {
-    const {successfulInvitations} = this.props
-    return (
-      <StyledDialogContainer>
-        <DialogTitle>Success!</DialogTitle>
-        <DialogContent>
-          <span>An invitation has been sent to</span>
-          {successfulInvitations.length === 1 ? <span> {successfulInvitations[0]}.</span> : ':'}
-          {successfulInvitations.length > 1 && (
-            <UL>
-              {successfulInvitations.map((email) => {
-                return <LI key={email}>{email}</LI>
-              })}
-            </UL>
-          )}
-        </DialogContent>
-      </StyledDialogContainer>
-    )
-  }
+  return (
+    <StyledDialogContainer>
+      <DialogTitle>Success!</DialogTitle>
+      <DialogContent>
+        <span>An invitation has been sent to</span>
+        {successfulInvitations.length === 1 ? <span> {successfulInvitations[0]}.</span> : ':'}
+        {successfulInvitations.length > 1 && (
+          <UL>
+            {successfulInvitations.map((email) => {
+              return <LI key={email}>{email}</LI>
+            })}
+          </UL>
+        )}
+      </DialogContent>
+    </StyledDialogContainer>
+  )
 }
 
 export default AddTeamMemberModalSuccess

--- a/packages/client/components/AvatarInput.tsx
+++ b/packages/client/components/AvatarInput.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled'
-import * as React from 'react'
-import {Component, lazy, Suspense} from 'react'
+import {type ChangeEvent, type FormEvent, lazy, Suspense, useRef} from 'react'
 import RaisedButton from './RaisedButton'
 import StyledError from './StyledError'
 
@@ -23,47 +22,39 @@ interface Props {
 
 const Confetti = lazy(() => import(/* webpackChunkName: 'Confetti' */ './Confetti'))
 
-class AvatarInput extends Component<Props> {
-  inputRef = React.createRef<HTMLInputElement>()
-  onClick = () => {
-    if (this.inputRef.current) {
-      this.inputRef.current.click()
-    }
+const AvatarInput = (props: Props) => {
+  const {error, onSubmit} = props
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const onClick = () => {
+    inputRef.current?.click()
   }
-  onChange = (e: React.ChangeEvent<HTMLInputElement> | React.FormEvent<HTMLFormElement>) => {
-    const {onSubmit} = this.props
+
+  const onChange = (e: ChangeEvent<HTMLInputElement> | FormEvent<HTMLFormElement>) => {
     const {files} = e.currentTarget
     const imageToUpload = files ? files[0] : null
     if (!imageToUpload) return
     onSubmit(imageToUpload)
   }
 
-  render() {
-    const {error} = this.props
-    const isHack = error === 'xss'
-    const errorStr = isHack ? 'You hacked us!' : error
-    return (
-      <div>
-        <Control>
-          <RaisedButton size='small' onClick={this.onClick} palette='gray' type='button'>
-            {'Choose File'}
-          </RaisedButton>
-          <form onSubmit={this.onChange}>
-            <HiddenInput
-              accept='image/*'
-              onChange={this.onChange}
-              type='file'
-              ref={this.inputRef}
-            />
-          </form>
-        </Control>
-        <Suspense fallback={''}>
-          <Confetti active={isHack} />
-        </Suspense>
-        {error && <StyledError>{errorStr}</StyledError>}
-      </div>
-    )
-  }
+  const isHack = error === 'xss'
+  const errorStr = isHack ? 'You hacked us!' : error
+  return (
+    <div>
+      <Control>
+        <RaisedButton size='small' onClick={onClick} palette='gray' type='button'>
+          {'Choose File'}
+        </RaisedButton>
+        <form onSubmit={onChange}>
+          <HiddenInput accept='image/*' onChange={onChange} type='file' ref={inputRef} />
+        </form>
+      </Control>
+      <Suspense fallback={''}>
+        <Confetti active={isHack} />
+      </Suspense>
+      {error && <StyledError>{errorStr}</StyledError>}
+    </div>
+  )
 }
 
 export default AvatarInput

--- a/packages/client/components/DelayUnmount.tsx
+++ b/packages/client/components/DelayUnmount.tsx
@@ -1,15 +1,10 @@
-import {Component, type ComponentClass, type ReactNode} from 'react'
+import {type ComponentType, type ReactNode, useEffect, useRef, useState} from 'react'
 import DelayUnmountShrinkAndScale from './DelayUnmountShrinkAndScale'
 
 enum TransitionState {
   Entered,
   Exiting,
   Exited
-}
-
-interface State {
-  exitingChildren: ReactNode
-  transitionState: TransitionState
 }
 
 interface PassthroughProps {
@@ -19,61 +14,52 @@ interface PassthroughProps {
 
 interface Props {
   children: ReactNode
-  Animator?: ComponentClass<PassthroughProps>
+  Animator?: ComponentType<PassthroughProps>
   unmountAfter: number
 }
 
-class DelayUnmount extends Component<Props, State> {
-  exitTimerId: number | undefined
-  state = {
-    exitingChildren: null,
-    transitionState: TransitionState.Entered
+const DelayUnmount = (props: Props) => {
+  const {Animator = DelayUnmountShrinkAndScale, children, unmountAfter} = props
+  const [transitionState, setTransitionState] = useState(
+    children !== null ? TransitionState.Entered : TransitionState.Exited
+  )
+  const exitingChildrenRef = useRef(children)
+  const exitTimerRef = useRef<number | undefined>(undefined)
+
+  // Synchronous state derivation (replaces getDerivedStateFromProps)
+  if (children !== null) {
+    exitingChildrenRef.current = children
+    if (transitionState !== TransitionState.Entered) {
+      setTransitionState(TransitionState.Entered)
+    }
+  } else if (transitionState === TransitionState.Entered) {
+    setTransitionState(TransitionState.Exiting)
   }
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): Partial<State> | null {
-    const {children} = nextProps
-    if (children !== null) {
-      return {
-        exitingChildren: nextProps.children,
-        transitionState: TransitionState.Entered
-      }
-    } else if (prevState.transitionState < TransitionState.Exiting) {
-      return {
-        transitionState: TransitionState.Exiting
+  // Start exit timer when entering Exiting state
+  useEffect(() => {
+    if (transitionState === TransitionState.Exiting) {
+      exitTimerRef.current = window.setTimeout(() => {
+        exitTimerRef.current = undefined
+        setTransitionState(TransitionState.Exited)
+      }, unmountAfter)
+      return () => {
+        if (exitTimerRef.current !== undefined) {
+          clearTimeout(exitTimerRef.current)
+          exitTimerRef.current = undefined
+        }
       }
     }
-    return null
-  }
+    return undefined
+  }, [transitionState, unmountAfter])
 
-  componentDidUpdate(_prevProps: Props, prevState: State) {
-    if (
-      prevState.transitionState !== TransitionState.Exiting &&
-      this.state.transitionState === TransitionState.Exiting
-    ) {
-      this.exitTimerId = window.setTimeout(() => {
-        this.exitTimerId = undefined
-        this.setState({
-          transitionState: TransitionState.Exited
-        })
-      }, this.props.unmountAfter)
-    }
-  }
-
-  componentWillUnmount() {
-    clearTimeout(this.exitTimerId)
-  }
-
-  render() {
-    const {Animator = DelayUnmountShrinkAndScale, children, unmountAfter} = this.props
-    const {exitingChildren, transitionState} = this.state
-    if (transitionState === TransitionState.Exited) return null
-    const isExiting = transitionState === TransitionState.Exiting
-    return (
-      <Animator isExiting={isExiting} duration={unmountAfter}>
-        {isExiting ? exitingChildren : children}
-      </Animator>
-    )
-  }
+  if (transitionState === TransitionState.Exited) return null
+  const isExiting = transitionState === TransitionState.Exiting
+  return (
+    <Animator isExiting={isExiting} duration={unmountAfter}>
+      {isExiting ? exitingChildrenRef.current : children}
+    </Animator>
+  )
 }
 
 export default DelayUnmount

--- a/packages/client/components/Radio/Radio.tsx
+++ b/packages/client/components/Radio/Radio.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled'
 import type * as React from 'react'
-import {Component} from 'react'
 import {PALETTE} from '../../styles/paletteV3'
 import ui from '../../styles/ui'
 
@@ -32,17 +31,15 @@ interface Props {
   value: string
 }
 
-class Radio extends Component<Props> {
-  render() {
-    // foce checked to a boolean again because of react bug
-    const {checked, name, onChange, label, value} = this.props
-    return (
-      <Base>
-        <Input name={name} type='radio' checked={!!checked} value={value} onChange={onChange} />
-        <Label>{label}</Label>
-      </Base>
-    )
-  }
+const Radio = (props: Props) => {
+  // force checked to a boolean again because of react bug
+  const {checked, name, onChange, label, value} = props
+  return (
+    <Base>
+      <Input name={name} type='radio' checked={!!checked} value={value} onChange={onChange} />
+      <Label>{label}</Label>
+    </Base>
+  )
 }
 
 export default Radio

--- a/packages/client/components/Tabs/Tabs.tsx
+++ b/packages/client/components/Tabs/Tabs.tsx
@@ -1,5 +1,13 @@
 import styled from '@emotion/styled'
-import {Children, Component, cloneElement, type ReactElement, type ReactNode} from 'react'
+import {
+  Children,
+  cloneElement,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useRef,
+  useState
+} from 'react'
 import {PALETTE} from '../../styles/paletteV3'
 import getBBox from '../RetroReflectPhase/getBBox'
 
@@ -34,54 +42,48 @@ const TabHeaders = styled('div')({
   width: '100%'
 })
 
-class Tabs extends Component<Props> {
-  activeChildRef?: HTMLDivElement
-  parentRef?: HTMLDivElement | null
+const Tabs = (props: Props) => {
+  const {activeIdx, children, className} = props
+  const [transform, setTransform] = useState('scaleX(0)')
+  const activeChildRef = useRef<HTMLElement | null>(null)
+  const parentRef = useRef<HTMLElement | null>(null)
 
-  state = {
-    transform: `scaleX(0)`
-  }
-  setChildRef = (c: HTMLDivElement | undefined) => {
-    if (c && c !== this.activeChildRef) {
-      this.moveInkBar(this.parentRef, c)
-    }
-    this.activeChildRef = c
-  }
-
-  setParentRef = (c: HTMLDivElement | null) => {
-    if (c && c !== this.parentRef) {
-      this.moveInkBar(c, this.activeChildRef)
-    }
-    this.parentRef = c
-  }
-
-  moveInkBar = (parent: HTMLDivElement | undefined | null, child: HTMLDivElement | undefined) => {
+  const moveInkBar = (parent: HTMLElement | null, child: HTMLElement | null) => {
     const childBBox = child && getBBox(child)
     const parentBBox = parent && getBBox(parent)
     if (!childBBox || !parentBBox) return
     const left = childBBox.left - parentBBox.left
-    this.setState({
-      transform: `translate3d(${left}px, 0, 0)scaleX(${childBBox.width / 1000})`
-    })
+    setTransform(`translate3d(${left}px, 0, 0)scaleX(${childBBox.width / 1000})`)
   }
 
-  render() {
-    const {activeIdx, children, className} = this.props
-    const {transform} = this.state
-    const properChildren = Children.map(children, (child, idx) => {
-      const isActive = idx === activeIdx
-      return cloneElement(child as ReactElement<any>, {
-        isActive,
-        ref: isActive ? this.setChildRef : null
-      })
+  const setChildRef = useCallback((c: HTMLElement | null) => {
+    if (c && c !== activeChildRef.current) {
+      moveInkBar(parentRef.current, c)
+    }
+    activeChildRef.current = c
+  }, [])
+
+  const setParentRef = useCallback((c: HTMLElement | null) => {
+    if (c && c !== parentRef.current) {
+      moveInkBar(c, activeChildRef.current)
+    }
+    parentRef.current = c
+  }, [])
+
+  const properChildren = Children.map(children, (child, idx) => {
+    const isActive = idx === activeIdx
+    return cloneElement(child as ReactElement<any>, {
+      isActive,
+      ref: isActive ? setChildRef : null
     })
-    return (
-      <TabsAndBar className={className} ref={this.setParentRef}>
-        <TabHeaders>{properChildren}</TabHeaders>
-        <InkBar style={{transform}} />
-      </TabsAndBar>
-    )
-  }
+  })
+
+  return (
+    <TabsAndBar className={className} ref={setParentRef}>
+      <TabHeaders>{properChildren}</TabHeaders>
+      <InkBar style={{transform}} />
+    </TabsAndBar>
+  )
 }
 
 export default Tabs

--- a/packages/client/components/TimelineEventDate.tsx
+++ b/packages/client/components/TimelineEventDate.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import ms from 'ms'
-import {Component} from 'react'
+import {useEffect, useState} from 'react'
 import {PALETTE} from '../styles/paletteV3'
 import absoluteDate from '../utils/date/absoluteDate'
 import relativeDate from '../utils/date/relativeDate'
@@ -12,43 +12,29 @@ const StyledSpan = styled('span')({
   lineHeight: '16px'
 })
 
-interface State {
-  fromNow: string
-}
-
 interface Props {
   createdAt: string | Date
 }
 
-class TimelineEventDate extends Component<Props, State> {
-  state = {
-    fromNow: relativeDate(this.props.createdAt)
-  }
-  intervalId?: number
+const TimelineEventDate = (props: Props) => {
+  const {createdAt} = props
+  const [fromNow, setFromNow] = useState(() => relativeDate(createdAt))
 
-  componentDidMount() {
-    this.intervalId = window.setInterval(() => {
-      const fromNow = relativeDate(this.props.createdAt)
-      if (fromNow !== this.state.fromNow) {
-        this.setState({
-          fromNow
-        })
-      }
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      const next = relativeDate(createdAt)
+      setFromNow((prev) => (prev === next ? prev : next))
     }, ms('1m'))
-  }
+    return () => {
+      clearInterval(intervalId)
+    }
+  }, [createdAt])
 
-  componentWillUnmount(): void {
-    clearInterval(this.intervalId)
-  }
-
-  render() {
-    const {fromNow} = this.state
-    return (
-      <StyledSpan>
-        <SimpleTooltip text={absoluteDate(this.props.createdAt)}>{fromNow}</SimpleTooltip>
-      </StyledSpan>
-    )
-  }
+  return (
+    <StyledSpan>
+      <SimpleTooltip text={absoluteDate(createdAt)}>{fromNow}</SimpleTooltip>
+    </StyledSpan>
+  )
 }
 
 export default TimelineEventDate


### PR DESCRIPTION
# Description

Step 3 of 18 of the React 18 migration.

React 18 deprecates several class component lifecycle methods and assumes functional components with hooks as the primary pattern. This is the first batch. The components touched in this PR are all simple.

Will skip maintainer review and merge back to the migration branch.


