### PR TITLE
fix: sign out on not signed in error

### DIFF
--- a/packages/client/components/ErrorBoundary.tsx
+++ b/packages/client/components/ErrorBoundary.tsx
@@ -3,7 +3,7 @@ import {Component, type ErrorInfo, type ReactNode} from 'react'
 import type Atmosphere from '~/Atmosphere'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import SendClientSideEvent from '~/utils/SendClientSideEvent'
-import {isIgnoredError} from '../utils/errorFilters'
+import {isIgnoredError, isNotSignedInError} from '../utils/errorFilters'
 import ErrorComponent from './ErrorComponent/ErrorComponent'
 
 interface Props {
@@ -35,6 +35,9 @@ class ErrorBoundary extends Component<Props & {atmosphere: Atmosphere}, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     const {atmosphere} = this.props
+    if (isNotSignedInError(error)) {
+      atmosphere.invalidateSession('Not signed in')
+    }
     const {viewerId} = atmosphere
     const store = atmosphere.getStore()
     const email = (store?.getSource?.().get?.(viewerId) as any)?.email ?? ''

--- a/packages/client/utils/errorFilters.ts
+++ b/packages/client/utils/errorFilters.ts
@@ -14,3 +14,7 @@ export const isExtensionError = ({name, stack}: Error) => {
 export const isIgnoredError = (error: Error) => {
   return isNetworkError(error) || isOldBrowserError(error) || isExtensionError(error)
 }
+
+export const isNotSignedInError = ({message}: Error) => {
+  return message.includes('Not signed in')
+}


### PR DESCRIPTION
Don't show an error message if the error was "Not signed in", instead sign the user out.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
