### PR TITLE
chore:  migrate to React v18 `createRoot` API

### DIFF
--- a/docs/react-v18-migration.md
+++ b/docs/react-v18-migration.md
@@ -299,7 +299,7 @@ Now that React 18 is installed, upgrade `@hello-pangea/dnd` from `^16.6.0` (the 
 
 ---
 
-### PR 9 — Migrate to `createRoot` API
+### PR 9 — Migrate to `createRoot` API — DONE
 
 **~15 lines changed | Risk: LOW**
 
@@ -682,7 +682,7 @@ The Mattermost plugin is an independent package with its own webpack config and 
 | 6 | Pre-work | Update minor dependencies | ~30 | LOW | **DONE** |
 | 7 | Version Bump | React 17 → 18 + fix compilation | ~120 | **HIGH** | **DONE** |
 | 8 | Version Bump | Bump `@hello-pangea/dnd` v16 → v18 | ~10 | LOW | **DONE** |
-| 9 | Version Bump | `ReactDOM.render` → `createRoot` | ~15 | LOW | |
+| 9 | Version Bump | `ReactDOM.render` → `createRoot` | ~15 | LOW | **DONE** |
 | 10 | Version Bump | Verify email SSR | ~20 | LOW | |
 | 11 | Router | Upgrade to v6, core route definitions | ~500 | **HIGH** | |
 | 12 | Router | Nested route trees | ~400 | MEDIUM | |

--- a/packages/client/client.tsx
+++ b/packages/client/client.tsx
@@ -1,8 +1,9 @@
-import {render} from 'react-dom'
+import {createRoot} from 'react-dom/client'
 import Root from './Root'
 import './scrollIntoViewIfNeeded'
 
-render(<Root />, document.getElementById('root'))
+const container = document.getElementById('root')!
+createRoot(container).render(<Root />)
 if (__PRODUCTION__ && 'serviceWorker' in navigator) {
   window.addEventListener('load', async () => {
     navigator.serviceWorker.register('/sw.js', {scope: '/'}).catch(console.error)


### PR DESCRIPTION
# Description

Another trivial PR: moving to the React `createRoot` API.
