### PR TITLE
chore: replace the custom `useRouter` with standard React Router v5 hooks, batch 1

### DIFF
--- a/docs/react-v18-migration.md
+++ b/docs/react-v18-migration.md
@@ -409,11 +409,20 @@ Removed all 9 `withRouter` usages from the codebase and replaced with direct hoo
 
 ---
 
-### PR 12 — Replace custom `useRouter` hook — batch 1 (components/)
+### PR 12 — Replace custom `useRouter` hook — batch 1 (components/) — DONE
 
-**~500 lines changed | Risk: LOW**
+**61 files changed, 133 insertions, 160 deletions | Risk: LOW**
 
-Replace the custom `useRouter` hook with standard React Router v5 hooks (`useHistory`, `useLocation`, `useParams`) in the first batch of files (components/ directory).
+Replaced the custom `useRouter` hook with standard React Router v5 hooks (`useHistory`, `useLocation`, `useParams`) in all 61 components/ files. This is pre-work that runs on v5.
+
+**Breakdown by pattern:**
+
+| Pattern | Files | Replacement |
+|---|---|---|
+| `{history}` only | 43 | `useHistory()` |
+| `{location}` only | 4 | `useLocation()` |
+| `{history, location}` | 3 | `useHistory()` + `useLocation()` |
+| `{match}` (params access) | 11 | `useParams<T>()` |
 
 ---
 
@@ -514,7 +523,7 @@ The Mattermost plugin is an independent package with its own webpack config and 
 | 9 | Version Bump | `ReactDOM.render` → `createRoot` | ~15 | LOW | **DONE** |
 | 10 | Version Bump | Verify email SSR | ~60 | LOW | **DONE** |
 | 11 | Router Pre-work | Remove `withRouter` HOC → use hooks directly | ~250 | LOW | **DONE** |
-| 12 | Router Pre-work | Replace custom `useRouter` hook — batch 1 (components/) | ~500 | LOW | |
+| 12 | Router Pre-work | Replace custom `useRouter` hook — batch 1 (components/) | ~300 | LOW | **DONE** |
 | 13 | Router Pre-work | Replace custom `useRouter` hook — batch 2 + delete hook + remaining `RouteComponentProps` | ~500 | LOW | |
 | 14 | Router Pre-work | Convert navigation infrastructure from `history` object to `navigate` function | ~500 | MEDIUM | |
 | 15 | Router Flip | Upgrade to react-router v6 — convert ALL remaining v5 APIs | ~900 | **HIGH** | |

--- a/packages/client/components/ActionMeetingLastCall.tsx
+++ b/packages/client/components/ActionMeetingLastCall.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import EndCheckInMutation from '~/mutations/EndCheckInMutation'
 import type {ActionMeetingLastCall_meeting$key} from '../__generated__/ActionMeetingLastCall_meeting.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import AgendaShortcutHint from '../modules/meeting/components/AgendaShortcutHint/AgendaShortcutHint'
 import MeetingCopy from '../modules/meeting/components/MeetingCopy/MeetingCopy'
 import MeetingFacilitationHint from '../modules/meeting/components/MeetingFacilitationHint/MeetingFacilitationHint'
@@ -59,7 +59,7 @@ const ActionMeetingLastCall = (props: Props) => {
     meetingRef
   )
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const {submitting, onError, onCompleted, submitMutation} = useMutationProps()
   const {viewerId} = atmosphere
   const {endedAt, facilitator, facilitatorUserId, id: meetingId, phases, showSidebar} = meeting

--- a/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetailsRoute.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetailsRoute.tsx
@@ -1,17 +1,14 @@
 import {Suspense} from 'react'
-import {Redirect} from 'react-router'
+import {Redirect, useParams} from 'react-router'
 import activityDetailsQuery, {
   type ActivityDetailsQuery
 } from '~/__generated__/ActivityDetailsQuery.graphql'
 import useQueryLoaderNow from '../../../hooks/useQueryLoaderNow'
-import useRouter from '../../../hooks/useRouter'
 import {Loader} from '../../../utils/relay/renderLoader'
 import ActivityDetails from './ActivityDetails'
 
 const ActivityDetailsRoute = () => {
-  const {match} = useRouter<{activityId: string}>()
-  const {params} = match
-  const {activityId} = params
+  const {activityId} = useParams<{activityId: string}>()
 
   const queryRef = useQueryLoaderNow<ActivityDetailsQuery>(activityDetailsQuery, {activityId})
 

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -8,7 +8,7 @@ import {
   usePreloadedQuery,
   useRefetchableFragment
 } from 'react-relay'
-import {Redirect} from 'react-router'
+import {Redirect, useParams} from 'react-router'
 import {Link} from 'react-router-dom'
 import type {ActivityLibrary_template$data} from '~/__generated__/ActivityLibrary_template.graphql'
 import type {ActivityLibrary_templateSearchDocument$data} from '~/__generated__/ActivityLibrary_templateSearchDocument.graphql'
@@ -17,7 +17,6 @@ import type {ActivityLibraryTemplateSearch_query$key} from '~/__generated__/Acti
 import type {ActivityLibraryTemplateSearchRefetchQuery} from '~/__generated__/ActivityLibraryTemplateSearchRefetchQuery.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import {useDebouncedSearch} from '../../hooks/useDebouncedSearch'
-import useRouter from '../../hooks/useRouter'
 import useSearchFilter from '../../hooks/useSearchFilter'
 import logoMarkPurple from '../../styles/theme/images/brand/mark-color.svg'
 import {cn} from '../../ui/cn'
@@ -281,10 +280,7 @@ export const ActivityLibrary = (props: Props) => {
     }
   }, [debouncedSearchQuery])
 
-  const {match} = useRouter<{categoryId?: string}>()
-  const {
-    params: {categoryId}
-  } = match
+  const {categoryId} = useParams<{categoryId?: string}>()
 
   const templatesToRender = useMemo(() => {
     if (searchQuery.length > 0) {

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -3,7 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import type * as React from 'react'
 import {type ComponentPropsWithoutRef, useState} from 'react'
 import {type PreloadedQuery, usePreloadedQuery} from 'react-relay'
-import {useHistory} from 'react-router'
+import {useHistory, useParams} from 'react-router'
 import {Link} from 'react-router-dom'
 import type {CreateNewActivityQuery} from '~/__generated__/CreateNewActivityQuery.graphql'
 import estimatedEffortTemplate from '../../../../../static/images/illustrations/estimatedEffortTemplate.png'
@@ -12,7 +12,6 @@ import type {AddPokerTemplateMutation$data} from '../../../__generated__/AddPoke
 import type {AddReflectTemplateMutation$data} from '../../../__generated__/AddReflectTemplateMutation.graphql'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useMutationProps from '../../../hooks/useMutationProps'
-import useRouter from '../../../hooks/useRouter'
 import AddPokerTemplateMutation from '../../../mutations/AddPokerTemplateMutation'
 import AddReflectTemplateMutation from '../../../mutations/AddReflectTemplateMutation'
 import {cn} from '../../../ui/cn'
@@ -125,13 +124,11 @@ export const CreateNewActivity = (props: Props) => {
   const atmosphere = useAtmosphere()
   const data = usePreloadedQuery<CreateNewActivityQuery>(query, queryRef)
 
-  const {match} = useRouter<{categoryId?: string}>()
-  const {params} = match
+  const {categoryId} = useParams<{categoryId?: string}>()
 
   const [selectedActivity, setSelectedActivity] = useState(() => {
     const defaultActivity = SUPPORTED_CUSTOM_ACTIVITIES[0]!
-    const categoryId = params.categoryId
-    if (!params.categoryId) return defaultActivity
+    if (!categoryId) return defaultActivity
 
     const selectedActivity = SUPPORTED_CUSTOM_ACTIVITIES.find((activity) =>
       activity.includedCategories.includes(categoryId as CategoryID)
@@ -171,7 +168,7 @@ export const CreateNewActivity = (props: Props) => {
           const templateId = res.addReflectTemplate?.reflectTemplate?.id
           if (templateId) {
             history.push(`/activity-library/details/${templateId}`, {
-              prevCategory: params.categoryId,
+              prevCategory: categoryId,
               edit: true
             })
           }
@@ -196,7 +193,7 @@ export const CreateNewActivity = (props: Props) => {
           const templateId = res.addPokerTemplate?.pokerTemplate?.id
           if (templateId) {
             history.push(`/activity-library/details/${templateId}`, {
-              prevCategory: params.categoryId,
+              prevCategory: categoryId,
               edit: true
             })
           }

--- a/packages/client/components/AddTeamDialog.tsx
+++ b/packages/client/components/AddTeamDialog.tsx
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useState} from 'react'
 import {type PreloadedQuery, useFragment, usePreloadedQuery} from 'react-relay'
-import useRouter from '~/hooks/useRouter'
+import {useHistory} from 'react-router'
 import AddTeamMutation from '~/mutations/AddTeamMutation'
 import getGraphQLError from '~/utils/relay/getGraphQLError'
 import SendClientSideEvent from '~/utils/SendClientSideEvent'
@@ -53,7 +53,7 @@ const query = graphql`
 const AddTeamDialog = (props: Props) => {
   const {isOpen, onClose, queryRef, onTeamAdded} = props
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
 
   const {submitting, onCompleted, onError, error, submitMutation} = useMutationProps()
 

--- a/packages/client/components/AuthenticationPage.tsx
+++ b/packages/client/components/AuthenticationPage.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
+import {useHistory} from 'react-router'
 import useCanonical from '~/hooks/useCanonical'
 import useAtmosphere from '../hooks/useAtmosphere'
-import useRouter from '../hooks/useRouter'
 import getValidRedirectParam from '../utils/getValidRedirectParam'
 import {AUTH_DIALOG_WIDTH} from './AuthenticationDialog'
 import GenericAuthentication, {type AuthPageSlug, type GotoAuthPage} from './GenericAuthentication'
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const AuthenticationPage = (props: Props) => {
-  const {history} = useRouter()
+  const history = useHistory()
   const {page} = props
   const {authObj} = useAtmosphere()
   useCanonical(page)

--- a/packages/client/components/DashTopBar.tsx
+++ b/packages/client/components/DashTopBar.tsx
@@ -2,8 +2,8 @@ import styled from '@emotion/styled'
 import {Menu} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {DashTopBar_query$key} from '~/__generated__/DashTopBar_query.graphql'
-import useRouter from '~/hooks/useRouter'
 import {PALETTE} from '~/styles/paletteV3'
 import {ICON_SIZE} from '~/styles/typographyV2'
 import {AppBar, Breakpoint, Layout, NavSidebar} from '~/types/constEnums'
@@ -93,7 +93,7 @@ const DashTopBar = (props: Props) => {
     `,
     queryRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const gotoHome = () => {
     history.push('/meetings')
   }

--- a/packages/client/components/DeleteTeamDialog.tsx
+++ b/packages/client/components/DeleteTeamDialog.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react'
+import {useHistory} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import ArchiveTeamMutation from '../mutations/ArchiveTeamMutation'
 import {Dialog} from '../ui/Dialog/Dialog'
 import {DialogActions} from '../ui/Dialog/DialogActions'
@@ -22,7 +22,7 @@ interface Props {
 
 const DeleteTeamDialog = (props: Props) => {
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const {isOpen, onClose, teamId, teamName, teamOrgId, onDeleteTeam} = props
 
   const {submitting, onCompleted, onError, error, submitMutation} = useMutationProps()

--- a/packages/client/components/DiscussionMentioned.tsx
+++ b/packages/client/components/DiscussionMentioned.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import NotificationAction from '~/components/NotificationAction'
 import type {DiscussionMentioned_notification$key} from '../__generated__/DiscussionMentioned_notification.graphql'
-import useRouter from '../hooks/useRouter'
 import {useTipTapCommentEditor} from '../hooks/useTipTapCommentEditor'
 import anonymousAvatar from '../styles/theme/images/anonymous-avatar.svg'
 import fromStageIdToUrl from '../utils/meetings/fromStageIdToUrl'
@@ -46,7 +46,7 @@ const DiscussionMentioned = (props: Props) => {
     `,
     notificationRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const {meeting, author, comment, discussion} = notification
   const authorPicture = author ? author.picture : anonymousAvatar
   const authorName = author ? author.preferredName : 'Anonymous'

--- a/packages/client/components/EmailPasswordAuthForm.tsx
+++ b/packages/client/components/EmailPasswordAuthForm.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
 import type * as React from 'react'
 import {forwardRef, useEffect, useImperativeHandle, useState} from 'react'
+import {useHistory, useLocation} from 'react-router'
 import {commitLocalUpdate} from 'relay-runtime'
 import type Atmosphere from '../Atmosphere'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useForm from '../hooks/useForm'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import LoginWithPasswordMutation from '../mutations/LoginWithPasswordMutation'
 import SignUpWithPasswordMutation from '../mutations/SignUpWithPasswordMutation'
@@ -96,7 +96,7 @@ const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
   const isSingleTenantSSO =
     isSSOAuthEnabled && !isGoogleAuthEnabled && !isMicrosoftAuthEnabled && !isInternalAuthEnabled
   const {getOffsetTop, isPrimary, isSignin, invitationToken, email, goToPage} = props
-  const {location} = useRouter()
+  const location = useLocation()
   const params = new URLSearchParams(location.search)
   const isSSODefault = isSSOAuthEnabled && Boolean(params.get('sso'))
   const signInWithSSOOnly = isSSOAuthEnabled && !isInternalAuthEnabled
@@ -106,7 +106,7 @@ const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
   const [ssoDomain, setSSODomain] = useState<string>()
   const {submitMutation, onCompleted, submitting, error, onError} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const {fields, onChange, setDirtyField, validateField} = useForm({
     email: {
       getDefault: () => email,

--- a/packages/client/components/EndMeetingButton.tsx
+++ b/packages/client/components/EndMeetingButton.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import {Flag} from '@mui/icons-material'
 import {forwardRef, type Ref} from 'react'
+import {useHistory} from 'react-router'
 import type {TransitionStatus} from '~/hooks/useTransition'
 import EndCheckInMutation from '~/mutations/EndCheckInMutation'
 import EndRetrospectiveMutation from '~/mutations/EndRetrospectiveMutation'
@@ -8,7 +9,6 @@ import {PALETTE} from '~/styles/paletteV3'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuPosition} from '../hooks/useCoords'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import useTooltip from '../hooks/useTooltip'
 import EndSprintPokerMutation from '../mutations/EndSprintPokerMutation'
 import {ElementWidth, Times} from '../types/constEnums'
@@ -47,7 +47,7 @@ const EndMeetingButton = forwardRef((props: Props, ref: Ref<HTMLButtonElement>) 
     onTransitionEnd
   } = props
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const {submitMutation, onCompleted, onError, submitting} = useMutationProps()
   const {openTooltip, tooltipPortal, originRef} = useTooltip<HTMLDivElement>(
     MenuPosition.UPPER_CENTER,

--- a/packages/client/components/ForgotPasswordPage.tsx
+++ b/packages/client/components/ForgotPasswordPage.tsx
@@ -4,10 +4,10 @@
  */
 import styled from '@emotion/styled'
 import type * as React from 'react'
+import {useHistory} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useForm from '../hooks/useForm'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import EmailPasswordResetMutation from '../mutations/EmailPasswordResetMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {AuthenticationError} from '../types/constEnums'
@@ -95,7 +95,7 @@ const ForgotPasswordPage = (props: Props) => {
       validate: validateEmail
     }
   })
-  const {history} = useRouter()
+  const history = useHistory()
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const {name} = e.target

--- a/packages/client/components/GenericAuthentication.tsx
+++ b/packages/client/components/GenericAuthentication.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled'
 import {useRef} from 'react'
+import {useLocation} from 'react-router'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useMetaTagContent from '../hooks/useMetaTagContent'
-import useRouter from '../hooks/useRouter'
 import {ForgotPasswordResType} from '../mutations/EmailPasswordResetMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {
@@ -69,7 +69,7 @@ const DialogSubTitle = styled('div')({
 const GenericAuthentication = (props: Props) => {
   const {goToPage, invitationToken, page, teamName} = props
   const emailRef = useRef<{email: () => string}>()
-  const {location} = useRouter()
+  const location = useLocation()
   const params = new URLSearchParams(location.search)
   const email = params.get('email')
   const authDialogRef = useRef<HTMLDivElement>(null)

--- a/packages/client/components/GoogleOAuthButtonBlock.tsx
+++ b/packages/client/components/GoogleOAuthButtonBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
+import {useHistory, useLocation} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import logo from '../styles/theme/images/graphics/google.svg'
 import {cn} from '../ui/cn'
 import GoogleClientManager from '../utils/GoogleClientManager'
@@ -33,7 +33,8 @@ const GoogleOAuthButtonBlock = (props: Props) => {
   const {invitationToken, isCreate, loginHint, getOffsetTop} = props
   const {onError, error, submitting, onCompleted, submitMutation} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const {history, location} = useRouter()
+  const history = useHistory()
+  const location = useLocation()
   const label = isCreate ? 'Sign up with Google' : 'Sign in with Google'
   const openOAuth = () => {
     const mutationProps = {onError, onCompleted, submitMutation, submitting}

--- a/packages/client/components/InvitationLinkDialog.tsx
+++ b/packages/client/components/InvitationLinkDialog.tsx
@@ -1,10 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect, useRef} from 'react'
 import {useFragment} from 'react-relay'
+import {useParams} from 'react-router'
 import type {InvitationLinkDialog_massInvitation$key} from '../__generated__/InvitationLinkDialog_massInvitation.graphql'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useMetaTagContent from '../hooks/useMetaTagContent'
-import useRouter from '../hooks/useRouter'
 import {LocalStorageKey} from '../types/constEnums'
 import InvitationLinkAuthentication from './InvitationLinkAuthentication'
 import InvitationLinkErrorExpired from './InvitationLinkErrorExpired'
@@ -20,9 +20,7 @@ const InvitationLinkDialog = (props: Props) => {
   const isLoggedIn = useIsAuthenticated()
   // if they log in, then accepting team invite will get triggered via login flow
   const isInitiallyLoggedInRef = useRef(isLoggedIn)
-  const {match} = useRouter<{token: string}>()
-  const {params} = match
-  const {token} = params
+  const {token} = useParams<{token: string}>()
   useEffect(() => {
     window.localStorage.setItem(LocalStorageKey.INVITATION_TOKEN, token)
   }, [token])

--- a/packages/client/components/InvitationLinkErrorExpired.tsx
+++ b/packages/client/components/InvitationLinkErrorExpired.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {InvitationLinkErrorExpired_massInvitation$key} from '../__generated__/InvitationLinkErrorExpired_massInvitation.graphql'
 import useDocumentTitle from '../hooks/useDocumentTitle'
-import useRouter from '../hooks/useRouter'
 import hasToken from '../utils/hasToken'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
@@ -40,7 +40,7 @@ const InvitationLinkErrorExpired = (props: Props) => {
   const {teamName} = massInvitation
   useDocumentTitle(`Token Expired | Invitation Link`, 'Invitation Link')
 
-  const {history} = useRouter()
+  const history = useHistory()
 
   return (
     <InviteDialog>

--- a/packages/client/components/JiraExportUpgradeModal.tsx
+++ b/packages/client/components/JiraExportUpgradeModal.tsx
@@ -1,5 +1,5 @@
+import {useHistory} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
-import useRouter from '../hooks/useRouter'
 import {Dialog} from '../ui/Dialog/Dialog'
 import {DialogActions} from '../ui/Dialog/DialogActions'
 import {DialogContent} from '../ui/Dialog/DialogContent'
@@ -19,7 +19,7 @@ interface Props {
 const JiraExportUpgradeModal = (props: Props) => {
   const {isOpen, exportCount, isHardBlock, orgId, onClose} = props
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const goToUpgrade = () => {
     SendClientSideEvent(atmosphere, 'Upgrade CTA Clicked', {
       upgradeCTALocation: 'jiraExportLimitModal'

--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -7,9 +7,9 @@ import {
 } from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import {type PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import {useHistory} from 'react-router'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
-import useRouter from '~/hooks/useRouter'
 import type {MeetingCardOptionsMenuQuery} from '../__generated__/MeetingCardOptionsMenuQuery.graphql'
 import type {MenuProps} from '../hooks/useMenu'
 import {PALETTE} from '../styles/paletteV3'
@@ -89,7 +89,7 @@ const MeetingCardOptionsMenu = (props: Props) => {
   const canEndMeeting = meetingType === 'teamPrompt' || isViewerFacilitator
   const atmosphere = useAtmosphere()
   const {onCompleted, onError} = useMutationProps()
-  const {history} = useRouter()
+  const history = useHistory()
 
   const hasRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt
 

--- a/packages/client/components/MeetingLockedOverlay.tsx
+++ b/packages/client/components/MeetingLockedOverlay.tsx
@@ -3,9 +3,9 @@ import {Lock} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import {lazy, Suspense, useEffect} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {MeetingLockedOverlay_meeting$key} from '~/__generated__/MeetingLockedOverlay_meeting.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
-import useRouter from '../hooks/useRouter'
 import {modalShadow} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
 import {Radius} from '../types/constEnums'
@@ -109,7 +109,7 @@ const MeetingLockedOverlay = (props: Props) => {
   const canUpgrade = !!viewerOrganizationUser
 
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   useEffect(() => {
     if (locked) {
       SendClientSideEvent(atmosphere, 'Upgrade CTA Viewed', {

--- a/packages/client/components/MeetingRoot.tsx
+++ b/packages/client/components/MeetingRoot.tsx
@@ -1,15 +1,14 @@
 import {Suspense, useEffect} from 'react'
+import {useHistory, useParams} from 'react-router'
 import meetingSelectorQuery, {
   type MeetingSelectorQuery
 } from '../__generated__/MeetingSelectorQuery.graphql'
 import useQueryLoaderNow from '../hooks/useQueryLoaderNow'
-import useRouter from '../hooks/useRouter'
 import MeetingSelector from './MeetingSelector'
 
 const MeetingRoot = () => {
-  const {history, match} = useRouter<{meetingId: string}>()
-  const {params} = match
-  const {meetingId} = params
+  const history = useHistory()
+  const {meetingId} = useParams<{meetingId: string}>()
   useEffect(() => {
     if (!meetingId) {
       history.replace('/meetings')

--- a/packages/client/components/MeetingSeriesRoot.tsx
+++ b/packages/client/components/MeetingSeriesRoot.tsx
@@ -1,16 +1,13 @@
 import {Suspense} from 'react'
-import {Redirect} from 'react-router'
+import {Redirect, useParams} from 'react-router'
 import meetingSeriesRedirectorQuery, {
   type MeetingSeriesRedirectorQuery
 } from '../__generated__/MeetingSeriesRedirectorQuery.graphql'
 import useQueryLoaderNow from '../hooks/useQueryLoaderNow'
-import useRouter from '../hooks/useRouter'
 import MeetingSeriesRedirector from './MeetingSeriesRedirector'
 
 const MeetingRoot = () => {
-  const {match} = useRouter<{meetingId: string}>()
-  const {params} = match
-  const {meetingId} = params
+  const {meetingId} = useParams<{meetingId: string}>()
   const queryRef = useQueryLoaderNow<MeetingSeriesRedirectorQuery>(meetingSeriesRedirectorQuery, {
     meetingId
   })

--- a/packages/client/components/MeetingStageTimeLimitEnd.tsx
+++ b/packages/client/components/MeetingStageTimeLimitEnd.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import NotificationAction from '~/components/NotificationAction'
 import type {MeetingStageTimeLimitEnd_notification$key} from '../__generated__/MeetingStageTimeLimitEnd_notification.graphql'
-import useRouter from '../hooks/useRouter'
 import NotificationTemplate from './NotificationTemplate'
 
 interface Props {
@@ -27,7 +27,7 @@ const MeetingStageTimeLimitEnd = (props: Props) => {
     `,
     notificationRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const {meeting} = notification
   const {id: meetingId, name: meetingName, team} = meeting
   const {name: teamName} = team

--- a/packages/client/components/Mentioned.tsx
+++ b/packages/client/components/Mentioned.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import NotificationAction from '~/components/NotificationAction'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import anonymousAvatar from '~/styles/theme/images/anonymous-avatar.svg'
 import type {Mentioned_notification$key} from '../__generated__/Mentioned_notification.graphql'
-import useRouter from '../hooks/useRouter'
 import SendClientSideEvent from '../utils/SendClientSideEvent'
 import NotificationTemplate from './NotificationTemplate'
 import {useTipTapContext} from './TipTapProvider'
@@ -35,7 +35,7 @@ const Mentioned = (props: Props) => {
     `,
     notificationRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const atmosphere = useAtmosphere()
   const {generateHTML} = useTipTapContext()
   const {

--- a/packages/client/components/MicrosoftOAuthButtonBlock.tsx
+++ b/packages/client/components/MicrosoftOAuthButtonBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
+import {useHistory, useLocation} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import logo from '../styles/theme/images/graphics/microsoft.svg'
 import {cn} from '../ui/cn'
 import MicrosoftClientManager from '../utils/MicrosoftClientManager'
@@ -33,7 +33,8 @@ const MicrosoftOAuthButtonBlock = (props: Props) => {
   const {invitationToken, isCreate, loginHint, getOffsetTop} = props
   const {onError, error, submitting, onCompleted, submitMutation} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const {history, location} = useRouter()
+  const history = useHistory()
+  const location = useLocation()
   const label = isCreate ? 'Sign up with Microsoft' : 'Sign in with Microsoft'
   const openOAuth = () => {
     const mutationProps = {onError, onCompleted, submitMutation, submitting}

--- a/packages/client/components/PageAccessGranted.tsx
+++ b/packages/client/components/PageAccessGranted.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import NotificationAction from '~/components/NotificationAction'
 import type {
   PageAccessGranted_notification$key,
   PageRoleEnum
 } from '../__generated__/PageAccessGranted_notification.graphql'
-import useRouter from '../hooks/useRouter'
 import NotificationTemplate from './NotificationTemplate'
 
 const pageRoles = {
@@ -21,7 +21,7 @@ interface Props {
 
 const PageAccessGranted = (props: Props) => {
   const {notification: notificationRef} = props
-  const {history} = useRouter()
+  const history = useHistory()
   const notification = useFragment(
     graphql`
       fragment PageAccessGranted_notification on NotifyPageAccessGranted {

--- a/packages/client/components/PageAccessRequested.tsx
+++ b/packages/client/components/PageAccessRequested.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import NotificationAction from '~/components/NotificationAction'
 import type {
   PageAccessRequested_notification$key,
   PageRoleEnum
 } from '../__generated__/PageAccessRequested_notification.graphql'
-import useRouter from '../hooks/useRouter'
 import NotificationTemplate from './NotificationTemplate'
 
 const pageRoles = {
@@ -21,7 +21,7 @@ interface Props {
 
 const PageAccessRequested = (props: Props) => {
   const {notification: notificationRef} = props
-  const {history} = useRouter()
+  const history = useHistory()
   const notification = useFragment(
     graphql`
       fragment PageAccessRequested_notification on NotifyPageAccessRequested {

--- a/packages/client/components/PaymentRejected.tsx
+++ b/packages/client/components/PaymentRejected.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import NotificationAction from '~/components/NotificationAction'
 import type {PaymentRejected_notification$key} from '../__generated__/PaymentRejected_notification.graphql'
-import useRouter from '../hooks/useRouter'
 import NotificationTemplate from './NotificationTemplate'
 
 interface Props {
@@ -25,7 +25,7 @@ const PaymentRejected = (props: Props) => {
     `,
     notificationRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const {organization} = notification
   const {id: orgId, creditCard} = organization
   const {last4, brand} = creditCard || {last4: '****', brand: 'Unknown'}

--- a/packages/client/components/PinnedSnackbarNotifications.tsx
+++ b/packages/client/components/PinnedSnackbarNotifications.tsx
@@ -1,10 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {PinnedSnackbarNotifications_query$key} from '~/__generated__/PinnedSnackbarNotifications_query.graphql'
 import type {NotificationEnum} from '../__generated__/popNotificationToast_notification.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
-import useRouter from '../hooks/useRouter'
 import SetNotificationStatusMutation from '../mutations/SetNotificationStatusMutation'
 import mapPromptToJoinOrgToToast from '../mutations/toasts/mapPromptToJoinOrgToToast'
 import mapRequestToJoinOrgToToast from '../mutations/toasts/mapRequestToJoinOrgToToast'
@@ -49,7 +49,7 @@ const PinnedSnackbarNotifications = ({queryRef}: Props) => {
     `,
     queryRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const atmosphere = useAtmosphere()
   const {viewer} = data
   const notifications = viewer?.pinnedNotifications || {edges: []}

--- a/packages/client/components/PokerMeetingSidebar.tsx
+++ b/packages/client/components/PokerMeetingSidebar.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {Fragment} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {
   NewMeetingPhaseTypeEnum,
   PokerMeetingSidebar_meeting$key
 } from '~/__generated__/PokerMeetingSidebar_meeting.graphql'
-import useRouter from '~/hooks/useRouter'
 import useAtmosphere from '../hooks/useAtmosphere'
 import type useGotoStageId from '../hooks/useGotoStageId'
 import {GQLID} from '../utils/GQLID'
@@ -27,7 +27,7 @@ const collapsiblePhases: NewMeetingPhaseTypeEnum[] = ['checkin', 'ESTIMATE']
 
 const PokerMeetingSidebar = (props: Props) => {
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const {viewerId} = atmosphere
   const {gotoStageId, handleMenuClick, toggleSidebar, meeting: meetingRef} = props
   const meeting = useFragment(

--- a/packages/client/components/PromoteToBillingLeader.tsx
+++ b/packages/client/components/PromoteToBillingLeader.tsx
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {PromoteToBillingLeader_notification$key} from '~/__generated__/PromoteToBillingLeader_notification.graphql'
-import useRouter from '~/hooks/useRouter'
 import defaultOrgAvatar from '~/styles/theme/images/avatar-organization.svg'
 import NotificationAction from './NotificationAction'
 import NotificationTemplate from './NotificationTemplate'
@@ -26,7 +26,7 @@ const PromoteToBillingLeader = (props: Props) => {
     `,
     notificationRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const {organization} = notification
   const {name: orgName, id: orgId, picture: orgPicture} = organization
 

--- a/packages/client/components/Recurrence/EndRecurringMeetingModal.tsx
+++ b/packages/client/components/Recurrence/EndRecurringMeetingModal.tsx
@@ -1,12 +1,12 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useMemo, useState} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import {RRule} from 'rrule'
 import type {EndRecurringMeetingModal_meeting$key} from '../../__generated__/EndRecurringMeetingModal_meeting.graphql'
 import type {MeetingTypeEnum} from '../../__generated__/MeetingSelectorQuery.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useMutationProps from '../../hooks/useMutationProps'
-import useRouter from '../../hooks/useRouter'
 import EndCheckInMutation from '../../mutations/EndCheckInMutation'
 import EndRetrospectiveMutation from '../../mutations/EndRetrospectiveMutation'
 import EndSprintPokerMutation from '../../mutations/EndSprintPokerMutation'
@@ -76,7 +76,7 @@ export const EndRecurringMeetingModal = (props: Props) => {
   const {meetingType, id: meetingId} = meeting
 
   const {onCompleted, onError} = useMutationProps()
-  const {history} = useRouter()
+  const history = useHistory()
 
   const atmosphere = useAtmosphere()
 

--- a/packages/client/components/RequestToJoinOrgNotification.tsx
+++ b/packages/client/components/RequestToJoinOrgNotification.tsx
@@ -1,8 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
-import {useLocation} from 'react-router'
+import {useHistory, useLocation} from 'react-router'
 import type {RequestToJoinOrgNotification_notification$key} from '~/__generated__/RequestToJoinOrgNotification_notification.graphql'
-import useRouter from '../hooks/useRouter'
 import NotificationAction from './NotificationAction'
 import NotificationTemplate from './NotificationTemplate'
 
@@ -12,7 +11,7 @@ interface Props {
 
 const RequestToJoinOrgNotification = (props: Props) => {
   const {notification: notificationRef} = props
-  const {history} = useRouter()
+  const history = useHistory()
   const location = useLocation()
   const notification = useFragment(
     graphql`

--- a/packages/client/components/ResponseMentioned.tsx
+++ b/packages/client/components/ResponseMentioned.tsx
@@ -1,10 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import NotificationAction from '~/components/NotificationAction'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import type {ResponseMentioned_notification$key} from '../__generated__/ResponseMentioned_notification.graphql'
-import useRouter from '../hooks/useRouter'
 import SendClientSideEvent from '../utils/SendClientSideEvent'
 import NotificationTemplate from './NotificationTemplate'
 
@@ -35,7 +35,7 @@ const ResponseMentioned = (props: Props) => {
     `,
     notificationRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const atmosphere = useAtmosphere()
   const {meeting, response, type, status} = notification
   const {picture: authorPicture, preferredName: authorName} = response.user

--- a/packages/client/components/ResponseReplied.tsx
+++ b/packages/client/components/ResponseReplied.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import NotificationAction from '~/components/NotificationAction'
 import type {ResponseReplied_notification$key} from '../__generated__/ResponseReplied_notification.graphql'
-import useRouter from '../hooks/useRouter'
 import {useTipTapCommentEditor} from '../hooks/useTipTapCommentEditor'
 import anonymousAvatar from '../styles/theme/images/anonymous-avatar.svg'
 import NotificationTemplate from './NotificationTemplate'
@@ -36,7 +36,7 @@ const ResponseReplied = (props: Props) => {
     `,
     notificationRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const {meeting, author, comment, response} = notification
   const authorPicture = author ? author.picture : anonymousAvatar
   const authorName = author ? author.preferredName : 'Anonymous'

--- a/packages/client/components/RetroMeetingSidebar.tsx
+++ b/packages/client/components/RetroMeetingSidebar.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {Fragment, useState} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {
   NewMeetingPhaseTypeEnum,
   RetroMeetingSidebar_meeting$key
 } from '~/__generated__/RetroMeetingSidebar_meeting.graphql'
-import useRouter from '~/hooks/useRouter'
 import isDemoRoute from '~/utils/isDemoRoute'
 import useAtmosphere from '../hooks/useAtmosphere'
 import type useGotoStageId from '../hooks/useGotoStageId'
@@ -29,7 +29,7 @@ const collapsiblePhases: NewMeetingPhaseTypeEnum[] = ['checkin', 'discuss']
 
 const RetroMeetingSidebar = (props: Props) => {
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const {viewerId} = atmosphere
   const {gotoStageId, handleMenuClick, toggleSidebar, meeting: meetingRef} = props
   const meeting = useFragment(

--- a/packages/client/components/ReviewRequestToJoinOrgRoot.tsx
+++ b/packages/client/components/ReviewRequestToJoinOrgRoot.tsx
@@ -1,17 +1,14 @@
 import {Suspense, useCallback, useEffect} from 'react'
-import {useHistory, useLocation} from 'react-router'
+import {useHistory, useLocation, useParams} from 'react-router'
 import ReviewRequestToJoinOrgModal from '~/components/ReviewRequestToJoinOrgModal'
 import reviewRequestToJoinOrgModalQuery, {
   type ReviewRequestToJoinOrgModalQuery
 } from '../__generated__/ReviewRequestToJoinOrgModalQuery.graphql'
 import useModal from '../hooks/useModal'
 import useQueryLoaderNow from '../hooks/useQueryLoaderNow'
-import useRouter from '../hooks/useRouter'
 
 const ReviewRequestToJoinOrgRoot = () => {
-  const {match} = useRouter<{requestId: string}>()
-  const {params} = match
-  const {requestId} = params
+  const {requestId} = useParams<{requestId: string}>()
   const queryRef = useQueryLoaderNow<ReviewRequestToJoinOrgModalQuery>(
     reviewRequestToJoinOrgModalQuery,
     {requestId},

--- a/packages/client/components/SAMLRedirect.tsx
+++ b/packages/client/components/SAMLRedirect.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react'
-import useRouter from '../hooks/useRouter'
+import {useHistory} from 'react-router'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 import InviteDialog from './InviteDialog'
@@ -8,7 +8,7 @@ import TeamInvitationMeetingAbstract from './TeamInvitationMeetingAbstract'
 
 const SAMLRedirect = () => {
   const [error, setError] = useState('')
-  const {history} = useRouter()
+  const history = useHistory()
   useEffect(() => {
     const params = new URLSearchParams(location.search)
     const userId = params.get('userId')

--- a/packages/client/components/SelectMeetingDropdownItem.tsx
+++ b/packages/client/components/SelectMeetingDropdownItem.tsx
@@ -7,8 +7,8 @@ import {
 } from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {SelectMeetingDropdownItem_meeting$key} from '~/__generated__/SelectMeetingDropdownItem_meeting.graphql'
-import useRouter from '~/hooks/useRouter'
 import getMeetingPhase from '~/utils/getMeetingPhase'
 import {meetingTypeToIcon, phaseLabelLookup} from '~/utils/meetings/lookups'
 import {MenuItem} from '../ui/Menu/MenuItem'
@@ -40,7 +40,7 @@ const SelectMeetingDropdownItem = (props: Props) => {
     `,
     meetingRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const {name, team, id: meetingId, meetingType, phases, facilitatorStageId} = meeting
   if (!team) {
     // 95% sure there's a bug in relay causing this

--- a/packages/client/components/ShareTopicRouterRoot.tsx
+++ b/packages/client/components/ShareTopicRouterRoot.tsx
@@ -1,18 +1,14 @@
 import {Suspense, useCallback} from 'react'
-import {useHistory, useLocation} from 'react-router'
+import {useHistory, useLocation, useParams} from 'react-router'
 import ShareTopicModal from '~/components/ShareTopicModal'
 import shareTopicModalQuery, {
   type ShareTopicModalQuery
 } from '../__generated__/ShareTopicModalQuery.graphql'
 import useQueryLoaderNow from '../hooks/useQueryLoaderNow'
-import useRouter from '../hooks/useRouter'
 import {Loader} from '../utils/relay/renderLoader'
 
 const ShareTopicRouterRoot = () => {
-  const {match} = useRouter<{stageId: string; meetingId: string}>()
-  const {params} = match
-
-  const {meetingId, stageId} = params
+  const {meetingId, stageId} = useParams<{stageId: string; meetingId: string}>()
 
   const queryRef = useQueryLoaderNow<ShareTopicModalQuery>(
     shareTopicModalQuery,

--- a/packages/client/components/SideBarStartMeetingButton.tsx
+++ b/packages/client/components/SideBarStartMeetingButton.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import {Add} from '@mui/icons-material'
-import useRouter from '~/hooks/useRouter'
+import {useHistory} from 'react-router'
 import {BezierCurve} from '../types/constEnums'
 import FlatPrimaryButton from './FlatPrimaryButton'
 
@@ -29,7 +29,7 @@ const MeetingLabel = styled('div')<{isOpen: boolean}>(({isOpen}) => ({
 }))
 
 const SideBarStartMeetingButton = ({isOpen}: {isOpen: boolean}) => {
-  const {history} = useRouter()
+  const history = useHistory()
 
   const onClick = () => {
     history.push('/activity-library')

--- a/packages/client/components/Snackbar.tsx
+++ b/packages/client/components/Snackbar.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import {memo, useEffect, useLayoutEffect, useRef} from 'react'
+import {useLocation} from 'react-router'
 import useForceUpdate from '~/hooks/useForceUpdate'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useBreakpoint from '../hooks/useBreakpoint'
 import useEventCallback from '../hooks/useEventCallback'
 import usePortal from '../hooks/usePortal'
-import useRouter from '../hooks/useRouter'
 import useTransition from '../hooks/useTransition'
 import {Breakpoint, NavSidebar, ZIndex} from '../types/constEnums'
 import clientTempId from '../utils/relay/clientTempId'
@@ -60,7 +60,7 @@ const Snackbar = memo(() => {
     id: 'snackbar',
     noClose: true
   })
-  const {location} = useRouter()
+  const location = useLocation()
   const hasSidebar =
     location.pathname.startsWith('/meet/') || !!location.pathname.match(/\/meet\/.*\/responses/g)
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)

--- a/packages/client/components/StandardHub/StandardHub.tsx
+++ b/packages/client/components/StandardHub/StandardHub.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
-import useRouter from '~/hooks/useRouter'
+import {useHistory} from 'react-router'
 import type {StandardHub_viewer$key} from '../../__generated__/StandardHub_viewer.graphql'
 import {PALETTE} from '../../styles/paletteV3'
 import defaultUserAvatar from '../../styles/theme/images/avatar-user.svg'
@@ -70,7 +70,7 @@ const StandardHub = (props: Props) => {
   )
   const {email, picture, preferredName} = viewer || DEFAULT_VIEWER
   const userAvatar = picture || defaultUserAvatar
-  const {history} = useRouter()
+  const history = useHistory()
 
   const gotoUserSettings = () => {
     history.push('/me/profile')

--- a/packages/client/components/StartMeetingFAB.tsx
+++ b/packages/client/components/StartMeetingFAB.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import {Add as AddIcon} from '@mui/icons-material'
 import {useEffect, useRef, useState} from 'react'
-import useRouter from '~/hooks/useRouter'
+import {useHistory} from 'react-router'
 import {PALETTE} from '~/styles/paletteV3'
 import useBreakpoint from '../hooks/useBreakpoint'
 import {BezierCurve, Breakpoint, ElementWidth, ZIndex} from '../types/constEnums'
@@ -54,7 +54,7 @@ interface Props {
 const StartMeetingFAB = (props: Props) => {
   const {className} = props
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
-  const {history} = useRouter()
+  const history = useHistory()
   const [isExpanded, setIsExpanded] = useState(true)
   const hoverTimerId = useRef<number | undefined>()
   const initTimerId = useRef<number | undefined>()

--- a/packages/client/components/SubmittedForgotPasswordPage.tsx
+++ b/packages/client/components/SubmittedForgotPasswordPage.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import useRouter from '../hooks/useRouter'
+import {useLocation, useParams} from 'react-router'
 import {emailLinkStyle} from '../modules/email/styles'
 import {ForgotPasswordResType} from '../mutations/EmailPasswordResetMutation'
 import {PALETTE} from '../styles/paletteV3'
@@ -56,11 +56,11 @@ interface Props {
 
 const SubmittedForgotPasswordPage = (props: Props) => {
   const {goToPage} = props
-  const {match, location} = useRouter<{token: string}>()
-  const params = new URLSearchParams(location.search)
-  const forgotPasswordResType = params.get('type') || ForgotPasswordResType.SUCCESS
-  const email = params.get('email')
-  const {token} = match.params
+  const {token} = useParams<{token: string}>()
+  const location = useLocation()
+  const searchParams = new URLSearchParams(location.search)
+  const forgotPasswordResType = searchParams.get('type') || ForgotPasswordResType.SUCCESS
+  const email = searchParams.get('email')
   const contactSupportCopy = (
     <>
       <a

--- a/packages/client/components/TaskInvolves.tsx
+++ b/packages/client/components/TaskInvolves.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import NotificationAction from '~/components/NotificationAction'
 import OutcomeCardStatusIndicator from '~/modules/outcomeCard/components/OutcomeCardStatusIndicator/OutcomeCardStatusIndicator'
 import {cardShadow} from '~/styles/elevation'
 import type {TaskInvolves_notification$key} from '../__generated__/TaskInvolves_notification.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import {useTipTapTaskEditor} from '../hooks/useTipTapTaskEditor'
 import SetNotificationStatusMutation from '../mutations/SetNotificationStatusMutation'
 import {plaintextToTipTap} from '../shared/tiptap/plaintextToTipTap'
@@ -109,7 +109,7 @@ const TaskInvolves = (props: Props) => {
   const {submitMutation, onCompleted, onError, submitting} = useMutationProps()
   const atmosphere = useAtmosphere()
   const {editor} = useTipTapTaskEditor(content, {readOnly: true})
-  const {history} = useRouter()
+  const history = useHistory()
 
   const gotoBoard = () => {
     if (submitting) return

--- a/packages/client/components/TeamFilterMenu.tsx
+++ b/packages/client/components/TeamFilterMenu.tsx
@@ -1,12 +1,12 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useMemo, useRef} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {
   TeamFilterMenu_viewer$data,
   TeamFilterMenu_viewer$key
 } from '~/__generated__/TeamFilterMenu_viewer.graphql'
 import useAtmosphere from '~/hooks/useAtmosphere'
-import useRouter from '~/hooks/useRouter'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import {FilterLabels} from '~/types/constEnums'
 import constructFilterQueryParamURL from '~/utils/constructFilterQueryParamURL'
@@ -24,7 +24,7 @@ interface Props {
 }
 
 const TeamFilterMenu = (props: Props) => {
-  const {history} = useRouter()
+  const history = useHistory()
   const {menuProps, viewer: viewerRef} = props
   const viewer = useFragment(
     graphql`

--- a/packages/client/components/TeamInvitationAccept.tsx
+++ b/packages/client/components/TeamInvitationAccept.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react'
+import {useHistory} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
-import useRouter from '../hooks/useRouter'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 
 interface Props {
@@ -9,7 +9,7 @@ interface Props {
 
 const TeamInvitationAccept = (props: Props) => {
   const {invitationToken} = props
-  const {history} = useRouter()
+  const history = useHistory()
   const atmosphere = useAtmosphere()
   useEffect(() => {
     AcceptTeamInvitationMutation(atmosphere, {invitationToken}, {history})

--- a/packages/client/components/TeamInvitationGoogleCreateAccount.tsx
+++ b/packages/client/components/TeamInvitationGoogleCreateAccount.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useState} from 'react'
 import {useFragment} from 'react-relay'
+import {useParams} from 'react-router'
 import type {TeamInvitationGoogleCreateAccount_verifiedInvitation$key} from '../__generated__/TeamInvitationGoogleCreateAccount_verifiedInvitation.graphql'
 import useDocumentTitle from '../hooks/useDocumentTitle'
-import useRouter from '../hooks/useRouter'
 import {PALETTE} from '../styles/paletteV3'
 import {AUTH_DIALOG_WIDTH} from './AuthenticationDialog'
 import AuthPrivacyFooter from './AuthPrivacyFooter'
@@ -48,9 +48,7 @@ const TeamName = styled('span')({
 
 const TeamInvitationGoogleCreateAccount = (props: Props) => {
   const [isEmailFallback, setIsEmailFallback] = useState(false)
-  const {match} = useRouter<{token: string}>()
-  const {params} = match
-  const {token: invitationToken} = params
+  const {token: invitationToken} = useParams<{token: string}>()
   const {verifiedInvitation: verifiedInvitationRef} = props
   const verifiedInvitation = useFragment(
     graphql`

--- a/packages/client/components/TeamInvitationGoogleSignin.tsx
+++ b/packages/client/components/TeamInvitationGoogleSignin.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useParams} from 'react-router'
 import type {TeamInvitationGoogleSignin_verifiedInvitation$key} from '../__generated__/TeamInvitationGoogleSignin_verifiedInvitation.graphql'
 import useDocumentTitle from '../hooks/useDocumentTitle'
-import useRouter from '../hooks/useRouter'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 import GoogleOAuthButtonBlock from './GoogleOAuthButtonBlock'
@@ -21,9 +21,7 @@ const TeamName = styled('span')({
 })
 
 const TeamInvitationGoogleSignin = (props: Props) => {
-  const {match} = useRouter<{token: string}>()
-  const {params} = match
-  const {token: invitationToken} = params
+  const {token: invitationToken} = useParams<{token: string}>()
   const {verifiedInvitation: verifiedInvitationRef} = props
   const verifiedInvitation = useFragment(
     graphql`

--- a/packages/client/components/TeamInvitationNotification.tsx
+++ b/packages/client/components/TeamInvitationNotification.tsx
@@ -1,10 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {TeamInvitationNotification_notification$key} from '~/__generated__/TeamInvitationNotification_notification.graphql'
 import NotificationAction from '~/components/NotificationAction'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
-import useRouter from '~/hooks/useRouter'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import NotificationTemplate from './NotificationTemplate'
 
@@ -35,7 +35,7 @@ const TeamInvitationNotification = (props: Props) => {
   )
   const {submitMutation, onError, onCompleted} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const {id: notificationId, invitation, team} = notification
   const {name: teamName} = team
   const {token, inviter} = invitation

--- a/packages/client/components/TeamInvitationSSO.tsx
+++ b/packages/client/components/TeamInvitationSSO.tsx
@@ -1,8 +1,8 @@
 import {useEffect} from 'react'
+import {useHistory} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import {LocalStorageKey} from '../types/constEnums'
 import {emitGA4SignUpEvent} from '../utils/handleSuccessfulLogin'
@@ -22,7 +22,7 @@ const TeamInvitationSSO = (props: Props) => {
   const {ssoURL} = props
   const {onCompleted, submitMutation, onError, error} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   useEffect(() => {
     const loginWithSAML = async () => {
       const invitationToken = localStorage.getItem(LocalStorageKey.INVITATION_TOKEN)!

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -2,12 +2,12 @@ import styled from '@emotion/styled'
 import {Flag, Link as MuiLink, OpenInNew, Replay} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import {Link} from 'react-router-dom'
 import type {TeamPromptOptionsMenu_meeting$key} from '~/__generated__/TeamPromptOptionsMenu_meeting.graphql'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import type {MenuProps} from '~/hooks/useMenu'
 import useMutationProps from '~/hooks/useMutationProps'
-import useRouter from '~/hooks/useRouter'
 import EndTeamPromptMutation from '~/mutations/EndTeamPromptMutation'
 import {PALETTE} from '../../styles/paletteV3'
 import makeAppURL from '../../utils/makeAppURL'
@@ -78,7 +78,7 @@ const TeamPromptOptionsMenu = (props: Props) => {
   const {id: meetingId, meetingSeries, endedAt, team} = meeting
   const atmosphere = useAtmosphere()
   const {onCompleted, onError} = useMutationProps()
-  const {history} = useRouter()
+  const history = useHistory()
 
   const isEnded = !!endedAt
   const hasRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt

--- a/packages/client/components/TeamsLimitExceededNotification.tsx
+++ b/packages/client/components/TeamsLimitExceededNotification.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {TeamsLimitExceededNotification_notification$key} from '~/__generated__/TeamsLimitExceededNotification_notification.graphql'
-import useRouter from '~/hooks/useRouter'
 import defaultOrgAvatar from '~/styles/theme/images/avatar-organization.svg'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {Threshold} from '../types/constEnums'
@@ -29,7 +29,7 @@ const TeamsLimitExceededNotification = (props: Props) => {
     `,
     notificationRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const {orgId, orgName, orgPicture} = notification
 
   useEffect(() => {

--- a/packages/client/components/TeamsLimitReminderNotification.tsx
+++ b/packages/client/components/TeamsLimitReminderNotification.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {TeamsLimitReminderNotification_notification$key} from '~/__generated__/TeamsLimitReminderNotification_notification.graphql'
-import useRouter from '~/hooks/useRouter'
 import defaultOrgAvatar from '~/styles/theme/images/avatar-organization.svg'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {Threshold} from '../types/constEnums'
@@ -31,7 +31,7 @@ const TeamsLimitReminderNotification = (props: Props) => {
     `,
     notificationRef
   )
-  const {history} = useRouter()
+  const history = useHistory()
   const {orgId, orgName, orgPicture, scheduledLockAt} = notification
 
   useEffect(() => {

--- a/packages/client/components/TimelineEventTypeMenu.tsx
+++ b/packages/client/components/TimelineEventTypeMenu.tsx
@@ -1,6 +1,6 @@
 import {useMemo} from 'react'
+import {useHistory} from 'react-router'
 import useAtmosphere from '~/hooks/useAtmosphere'
-import useRouter from '~/hooks/useRouter'
 import constructFilterQueryParamURL from '~/utils/constructFilterQueryParamURL'
 import {useQueryParameterParser} from '~/utils/useQueryParameterParser'
 import type {MenuProps} from '../hooks/useMenu'
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const TimelineEventTypeMenu = (props: Props) => {
-  const {history} = useRouter()
+  const history = useHistory()
   const {menuProps} = props
   const atmosphere = useAtmosphere()
   const eventTypes = [

--- a/packages/client/components/TimelineHeader.tsx
+++ b/packages/client/components/TimelineHeader.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useMemo} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {TimelineHeader_viewer$key} from '../__generated__/TimelineHeader_viewer.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
-import useRouter from '../hooks/useRouter'
 import {FilterLabels} from '../types/constEnums'
 import {timelineEventTypeMenuLabels} from '../utils/constants'
 import constructFilterQueryParamURL from '../utils/constructFilterQueryParamURL'
@@ -39,7 +39,7 @@ interface Props {
 
 const TimelineHeader = (props: Props) => {
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const {viewerId} = atmosphere
   const {viewerRef} = props
   const viewer = useFragment(

--- a/packages/client/components/TimelineHistoryLockedCard.tsx
+++ b/packages/client/components/TimelineHistoryLockedCard.tsx
@@ -3,10 +3,10 @@ import {Lock} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect, useRef} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {TimelineHistoryLockedCard_organization$key} from '../__generated__/TimelineHistoryLockedCard_organization.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useIsVisible from '../hooks/useIsVisible'
-import useRouter from '../hooks/useRouter'
 import {cardShadow} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
 import SendClientSideEvent from '../utils/SendClientSideEvent'
@@ -78,7 +78,7 @@ const TimelineHistoryLockedCard = (props: Props) => {
   const {id: orgId, name: orgName, isPaid, unpaidMessageHTML} = organization ?? {}
 
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
 
   const cardRef = useRef<HTMLDivElement>(null)
   const visible = useIsVisible(cardRef.current, 0.7)

--- a/packages/client/components/TopBarNotifications.tsx
+++ b/packages/client/components/TopBarNotifications.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect, useRef} from 'react'
 import {useFragment} from 'react-relay'
+import {useLocation} from 'react-router'
 import type {TopBarNotifications_query$key} from '~/__generated__/TopBarNotifications_query.graphql'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
 import lazyPreload from '~/utils/lazyPreload'
-import useRouter from '../hooks/useRouter'
 import TopBarIcon from './TopBarIcon'
 
 const NotificationDropdown = lazyPreload(
@@ -52,7 +52,7 @@ const TopBarNotifications = ({queryRef}: Props) => {
       id: 'topBarNotificationsMenu'
     }
   )
-  const {location} = useRouter()
+  const location = useLocation()
   useEffect(() => {
     const parsed = new URLSearchParams(location.search)
     if (parsed.get('openNotifs')) {

--- a/packages/client/components/TopBarSearch.tsx
+++ b/packages/client/components/TopBarSearch.tsx
@@ -4,11 +4,10 @@ import graphql from 'babel-plugin-relay/macro'
 import type * as React from 'react'
 import {useRef} from 'react'
 import {useFragment} from 'react-relay'
-import {matchPath, type RouteProps} from 'react-router'
+import {matchPath, type RouteProps, useLocation} from 'react-router'
 import {commitLocalUpdate} from 'relay-runtime'
 import type {TopBarSearch_viewer$key} from '~/__generated__/TopBarSearch_viewer.graphql'
 import useAtmosphere from '~/hooks/useAtmosphere'
-import useRouter from '~/hooks/useRouter'
 import {useSearchDialog} from '~/modules/search/SearchContext'
 import {Input} from '~/ui/Input/Input'
 import type Atmosphere from '../Atmosphere'
@@ -79,7 +78,7 @@ const TopBarSearch = (props: Props) => {
   const dashSearch = viewer?.dashSearch ?? ''
   const inputRef = useRef<HTMLInputElement>(null)
   const atmosphere = useAtmosphere()
-  const {location} = useRouter()
+  const location = useLocation()
   const {openSearch} = useSearchDialog()
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useMemo, useRef} from 'react'
 import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
 import useAtmosphere from '~/hooks/useAtmosphere'
-import useRouter from '~/hooks/useRouter'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import {FilterLabels} from '~/types/constEnums'
 import constructFilterQueryParamURL from '~/utils/constructFilterQueryParamURL'
@@ -24,7 +24,7 @@ interface Props {
 }
 
 const UserDashTeamMemberMenu = (props: Props) => {
-  const {history} = useRouter()
+  const history = useHistory()
   const {menuProps, viewer: viewerRef} = props
 
   const viewer = useFragment(

--- a/packages/client/components/ViewerNotOnTeam.tsx
+++ b/packages/client/components/ViewerNotOnTeam.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect} from 'react'
 import {type PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import {useHistory} from 'react-router'
 import type {ViewerNotOnTeamQuery} from '../__generated__/ViewerNotOnTeamQuery.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useMutationProps from '../hooks/useMutationProps'
-import useRouter from '../hooks/useRouter'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import PushInvitationMutation from '../mutations/PushInvitationMutation'
 import getValidRedirectParam from '../utils/getValidRedirectParam'
@@ -45,7 +45,7 @@ const ViewerNotOnTeam = (props: Props) => {
     teamInvitation: {teamInvitation, meetingId, teamId, isOnTeam}
   } = viewer
   const atmosphere = useAtmosphere()
-  const {history} = useRouter()
+  const history = useHistory()
   const {onError, onCompleted} = useMutationProps()
   useDocumentTitle(`Invitation Required`, 'Invitation Required')
   useEffect(() => {


### PR DESCRIPTION
# Description

To move to `react-router` `v6` we need to move away from the `useRouter` HOC. This is batch 1 of these changes (just so the PRs don't get too big. I'm considering these changes trivial and will merge back directly.
