### PR TITLE
chore: convert navigation from `history` object to `navigate` fn

### DIFF
--- a/docs/react-v18-migration.md
+++ b/docs/react-v18-migration.md
@@ -378,7 +378,7 @@ createRoot(container).render(<Root />)
 - **PR 14:** `RouterProps['history']` in mutation/subscription infrastructure (~35 files)
 
 ### After pre-work, only standard v5 APIs remain:
-- `useHistory()` — ~60 component files (direct navigation)
+- `useHistory()` — ~60 component files (direct navigation) + custom `useNavigate` compat hook
 - `useLocation()` — unchanged in v6
 - `useParams()` — unchanged in v6
 - `useRouteMatch()` — ~5 files
@@ -446,11 +446,37 @@ Completed the `useRouter` replacement in all remaining files (modules/, hooks/, 
 
 ---
 
-### PR 14 — Convert navigation infrastructure from `history` object to `navigate` function
+### PR 14 — Convert navigation infrastructure from `history` object to `navigate` function — DONE
 
-**~500 lines changed | Risk: MEDIUM**
+**~60 files changed, ~400 lines | Risk: MEDIUM**
 
-Convert mutation/subscription infrastructure that passes `RouterProps['history']` to use a `navigate` function pattern instead. ~35 files affected.
+Converted the entire mutation/subscription infrastructure from passing `RouterProps['history']` (an object with `.push()` and `.replace()` methods) to passing a `NavigateFn` (a simple function matching React Router v6's `useNavigate()` signature). This is the key pre-work that makes the v6 flip in PR 15 trivial for the infrastructure layer.
+
+**Foundation changes:**
+
+| File | Change |
+|---|---|
+| `types/relayMutations.ts` | Defined `NavigateFn` type. Renamed `HistoryLocalHandler` → `NavigateLocalHandler`, `HistoryMaybeLocalHandler` → `NavigateMaybeLocalHandler`, `OnNextHistoryContext` → `OnNextNavigateContext`. Updated `LocalHandlers` deprecated type. Removed `import type {RouterProps} from 'react-router'`. |
+| `Atmosphere.ts` | Updated `SubscriptionRequestor` type and `registerQuery` method: `{history: RouterProps['history']}` → `{navigate: NavigateFn}`. Removed `RouterProps` import. |
+| `subscriptions/subscriptionOnNext.ts` | Updated router parameter type. Removed `RouterProps` import. |
+| `subscriptions/createSubscription.ts` | Updated router parameter type. Removed `RouterProps` import. |
+| `hooks/useNavigate.ts` | **New file.** v5-compatible `useNavigate()` hook that wraps `useHistory()` and returns a `NavigateFn`. In PR 15, this file is deleted and imports switch to react-router v6's native `useNavigate`. |
+| `hooks/useSubscription.ts` | Replaced `useHistory`/`useLocation` with `useNavigate`, passing `{navigate}` to subscription infrastructure. |
+| `hooks/useAutoCheckIn.ts` | Same pattern as `useSubscription.ts`. |
+
+**Mutation files updated (26 files):**
+
+All mutations that accepted `history` now accept `navigate`. Usage converted: `history.push(x)` → `navigate(x)`, `history.replace(x)` → `navigate(x, {replace: true})`, `history.push(x, state)` → `navigate(x, {state})`.
+
+Files: `AcceptTeamInvitationMutation`, `AddOrgMutation`, `AddTeamMutation`, `ArchiveOrganizationMutation`, `ArchiveTeamMutation`, `CreateTaskMutation`, `EmailPasswordResetMutation`, `EndCheckInMutation`, `EndRetrospectiveMutation`, `EndSprintPokerMutation`, `EndTeamPromptMutation`, `InviteToTeamMutation`, `LoginWithGoogleMutation`, `LoginWithMicrosoftMutation`, `LoginWithPasswordMutation`, `RemoveOrgUsersMutation`, `RemoveTeamMemberMutation`, `ResetPasswordMutation`, `SetOrgUserRoleMutation`, `SignUpWithPasswordMutation`, `StartCheckInMutation`, `StartRetrospectiveMutation`, `StartSprintPokerMutation`, `StartTeamPromptMutation`, `UpdateTaskMutation`, `VerifyEmailMutation`
+
+**Toast handlers and other handlers (13 files):**
+
+All toast handlers and notification handlers updated: `mapMentionedToToast`, `mapResponseRepliedToToast`, `mapRequestToJoinOrgToToast`, `mapDiscussionMentionedToToast`, `mapTeamsLimitReminderToToast`, `mapResponseMentionedToToast`, `mapPromptToJoinOrgToToast`, `popNotificationToast`, `popInvolvementToast`, `updateNotificationToast`, `handleAuthenticationRedirect`, `NotificationSubscription`, `PinnedSnackbarNotifications`
+
+**Caller components updated (~20 files):**
+
+Components that passed `history` to mutations now use `useNavigate()` and pass `navigate`. OAuth managers (`GoogleClientManager`, `MicrosoftClientManager`) updated parameter type from `RouterProps['history']` to `NavigateFn`.
 
 ---
 
@@ -537,7 +563,7 @@ The Mattermost plugin is an independent package with its own webpack config and 
 | 11 | Router Pre-work | Remove `withRouter` HOC → use hooks directly | ~250 | LOW | **DONE** |
 | 12 | Router Pre-work | Replace custom `useRouter` hook — batch 1 (components/) | ~300 | LOW | **DONE** |
 | 13 | Router Pre-work | Replace custom `useRouter` hook — batch 2 + delete hook + remaining `RouteComponentProps` | ~260 | LOW | **DONE** |
-| 14 | Router Pre-work | Convert navigation infrastructure from `history` object to `navigate` function | ~500 | MEDIUM | |
+| 14 | Router Pre-work | Convert navigation infrastructure from `history` object to `navigate` function | ~400 | MEDIUM | **DONE** |
 | 15 | Router Flip | Upgrade to react-router v6 — convert ALL remaining v5 APIs | ~900 | **HIGH** | |
 | 16 | Polish | Add `React.StrictMode` wrapper | ~200 | MEDIUM | |
 | 17 | Polish | Mattermost plugin upgrade | ~300 | LOW | |

--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -3,7 +3,6 @@ import EventEmitter from 'eventemitter3'
 import type {Client} from 'graphql-ws'
 import jwtDecode from 'jwt-decode'
 import {commitMutation, type Disposable} from 'react-relay'
-import type {RouterProps} from 'react-router'
 import {
   type CacheConfig,
   type ConcreteRequest,
@@ -31,6 +30,7 @@ import type {InviteToTeamMutation_notification$data} from './__generated__/Invit
 import type {Snack, SnackbarRemoveFn} from './components/Snackbar'
 import {providerManager} from './tiptap/providerManager'
 import {AuthToken} from './types/AuthToken'
+import type {NavigateFn} from './types/relayMutations'
 import {getAuthCookie, onAuthCookieChange} from './utils/authCookie'
 import {createWSClient} from './utils/createWSClient'
 import handlerProvider from './utils/relay/handlerProvider'
@@ -62,7 +62,7 @@ interface Subscriptions {
 }
 
 export type SubscriptionRequestor = {
-  (atmosphere: Atmosphere, variables: any, router: {history: RouterProps['history']}): Disposable
+  (atmosphere: Atmosphere, variables: any, router: {navigate: NavigateFn}): Disposable
   key: string
 }
 
@@ -341,7 +341,7 @@ export default class Atmosphere extends Environment {
     queryKey: string,
     subscription: SubscriptionRequestor,
     variables: Variables,
-    router: {history: RouterProps['history']}
+    router: {navigate: NavigateFn}
   ) => {
     window.clearTimeout(this.queryTimeouts[queryKey])
     delete this.queryTimeouts[queryKey]

--- a/packages/client/components/ActionMeetingLastCall.tsx
+++ b/packages/client/components/ActionMeetingLastCall.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
 import EndCheckInMutation from '~/mutations/EndCheckInMutation'
 import type {ActionMeetingLastCall_meeting$key} from '../__generated__/ActionMeetingLastCall_meeting.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import AgendaShortcutHint from '../modules/meeting/components/AgendaShortcutHint/AgendaShortcutHint'
 import MeetingCopy from '../modules/meeting/components/MeetingCopy/MeetingCopy'
 import MeetingFacilitationHint from '../modules/meeting/components/MeetingFacilitationHint/MeetingFacilitationHint'
@@ -59,7 +59,7 @@ const ActionMeetingLastCall = (props: Props) => {
     meetingRef
   )
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const {submitting, onError, onCompleted, submitMutation} = useMutationProps()
   const {viewerId} = atmosphere
   const {endedAt, facilitator, facilitatorUserId, id: meetingId, phases, showSidebar} = meeting
@@ -75,7 +75,7 @@ const ActionMeetingLastCall = (props: Props) => {
   const endMeeting = () => {
     if (submitting) return
     submitMutation()
-    EndCheckInMutation(atmosphere, {meetingId}, {history, onError, onCompleted})
+    EndCheckInMutation(atmosphere, {meetingId}, {navigate, onError, onCompleted})
   }
 
   const getHeadingText = () => {

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -3,7 +3,6 @@ import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect, useRef, useState} from 'react'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
 import type {RRule} from 'rrule'
 import type {ActivityDetailsSidebar_teams$key} from '~/__generated__/ActivityDetailsSidebar_teams.graphql'
 import type {ActivityDetailsSidebar_template$key} from '~/__generated__/ActivityDetailsSidebar_template.graphql'
@@ -14,6 +13,7 @@ import type {MeetingTypeEnum} from '../../__generated__/ActivityDetailsQuery.gra
 import type {CreateGcalEventInput} from '../../__generated__/StartRetrospectiveMutation.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useMutationProps from '../../hooks/useMutationProps'
+import useNavigate from '../../hooks/useNavigate'
 import SelectTemplateMutation from '../../mutations/SelectTemplateMutation'
 import StartCheckInMutation from '../../mutations/StartCheckInMutation'
 import StartTeamPromptMutation from '../../mutations/StartTeamPromptMutation'
@@ -113,7 +113,7 @@ const ActivityDetailsSidebar = (props: Props) => {
   }
   const mutationProps = useMutationProps()
   const {onError, onCompleted, submitting, submitMutation, error} = mutationProps
-  const history = useHistory()
+  const navigate = useNavigate()
 
   // user has no teams
   if (!selectedTeam)
@@ -136,7 +136,7 @@ const ActivityDetailsSidebar = (props: Props) => {
           rrule: rrule?.toString(),
           gcalInput
         },
-        {history, onError, onCompleted}
+        {navigate, onError, onCompleted}
       )
     } else if (type === 'action') {
       const variables = {
@@ -145,7 +145,7 @@ const ActivityDetailsSidebar = (props: Props) => {
       }
 
       StartCheckInMutation(atmosphere, variables, {
-        history,
+        navigate,
         onError,
         onCompleted
       })
@@ -164,13 +164,13 @@ const ActivityDetailsSidebar = (props: Props) => {
                   rrule: rrule?.toString(),
                   gcalInput
                 },
-                {history, onError, onCompleted}
+                {navigate, onError, onCompleted}
               )
             } else if (type === 'poker') {
               StartSprintPokerMutation(
                 atmosphere,
                 {teamId: selectedTeam.id, gcalInput},
-                {history, onError, onCompleted}
+                {navigate, onError, onCompleted}
               )
             }
           },

--- a/packages/client/components/AddTeamDialog.tsx
+++ b/packages/client/components/AddTeamDialog.tsx
@@ -1,7 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useState} from 'react'
 import {type PreloadedQuery, useFragment, usePreloadedQuery} from 'react-relay'
-import {useHistory} from 'react-router'
 import AddTeamMutation from '~/mutations/AddTeamMutation'
 import getGraphQLError from '~/utils/relay/getGraphQLError'
 import SendClientSideEvent from '~/utils/SendClientSideEvent'
@@ -13,6 +12,7 @@ import {
 } from '../components/AdhocTeamMultiSelect/AdhocTeamMultiSelect'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import {Dialog} from '../ui/Dialog/Dialog'
 import {DialogActions} from '../ui/Dialog/DialogActions'
 import {DialogContent} from '../ui/Dialog/DialogContent'
@@ -53,7 +53,7 @@ const query = graphql`
 const AddTeamDialog = (props: Props) => {
   const {isOpen, onClose, queryRef, onTeamAdded} = props
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
 
   const {submitting, onCompleted, onError, error, submitMutation} = useMutationProps()
 
@@ -75,7 +75,7 @@ const AddTeamDialog = (props: Props) => {
       orgId: organization.id,
       upgradeTier: 'team'
     })
-    history.push(`/me/organizations/${organization.id}`)
+    navigate(`/me/organizations/${organization.id}`)
   }
 
   const onSelectedUsersChange = (newUsers: Option[]) => {
@@ -109,7 +109,7 @@ const AddTeamDialog = (props: Props) => {
             onTeamAdded(res.addTeam.team.id)
           }
         },
-        history,
+        navigate,
         showTeamCreatedToast: false
       }
     )

--- a/packages/client/components/DeleteTeamDialog.tsx
+++ b/packages/client/components/DeleteTeamDialog.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react'
 import {useHistory} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import ArchiveTeamMutation from '../mutations/ArchiveTeamMutation'
 import {Dialog} from '../ui/Dialog/Dialog'
 import {DialogActions} from '../ui/Dialog/DialogActions'
@@ -23,6 +24,7 @@ interface Props {
 const DeleteTeamDialog = (props: Props) => {
   const atmosphere = useAtmosphere()
   const history = useHistory()
+  const navigate = useNavigate()
   const {isOpen, onClose, teamId, teamName, teamOrgId, onDeleteTeam} = props
 
   const {submitting, onCompleted, onError, error, submitMutation} = useMutationProps()
@@ -32,7 +34,7 @@ const DeleteTeamDialog = (props: Props) => {
   const handleDeleteTeam = () => {
     if (submitting) return
     submitMutation()
-    ArchiveTeamMutation(atmosphere, {teamId}, {history, onError, onCompleted})
+    ArchiveTeamMutation(atmosphere, {teamId}, {navigate, onError, onCompleted})
     onDeleteTeam(teamId)
     history.push(`/me/organizations/${teamOrgId}/teams`)
   }

--- a/packages/client/components/EmailPasswordAuthForm.tsx
+++ b/packages/client/components/EmailPasswordAuthForm.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled'
 import type * as React from 'react'
 import {forwardRef, useEffect, useImperativeHandle, useState} from 'react'
-import {useHistory, useLocation} from 'react-router'
+import {useLocation} from 'react-router'
 import {commitLocalUpdate} from 'relay-runtime'
 import type Atmosphere from '../Atmosphere'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useForm from '../hooks/useForm'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import LoginWithPasswordMutation from '../mutations/LoginWithPasswordMutation'
 import SignUpWithPasswordMutation from '../mutations/SignUpWithPasswordMutation'
@@ -106,7 +107,7 @@ const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
   const [ssoDomain, setSSODomain] = useState<string>()
   const {submitMutation, onCompleted, submitting, error, onError} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const {fields, onChange, setDirtyField, validateField} = useForm({
     email: {
       getDefault: () => email,
@@ -216,11 +217,11 @@ const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
       AcceptTeamInvitationMutation(
         atmosphere,
         {invitationToken},
-        {history, onCompleted, onError, ignoreApproval: true}
+        {navigate, onCompleted, onError, ignoreApproval: true}
       )
     } else {
       const nextUrl = getValidRedirectParam() || '/meetings'
-      history.push(nextUrl)
+      navigate(nextUrl)
     }
     return true
   }
@@ -250,7 +251,7 @@ const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
           invitationToken: invitationToken || '',
           isInvitation: !!invitationToken
         },
-        {onError, onCompleted, history}
+        {onError, onCompleted, navigate}
       )
     } else {
       const pseudoId = await getAnonymousId()
@@ -267,7 +268,7 @@ const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
         {
           onError,
           onCompleted,
-          history
+          navigate
         }
       )
     }

--- a/packages/client/components/EndMeetingButton.tsx
+++ b/packages/client/components/EndMeetingButton.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import {Flag} from '@mui/icons-material'
 import {forwardRef, type Ref} from 'react'
-import {useHistory} from 'react-router'
 import type {TransitionStatus} from '~/hooks/useTransition'
 import EndCheckInMutation from '~/mutations/EndCheckInMutation'
 import EndRetrospectiveMutation from '~/mutations/EndRetrospectiveMutation'
@@ -9,6 +8,7 @@ import {PALETTE} from '~/styles/paletteV3'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuPosition} from '../hooks/useCoords'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import useTooltip from '../hooks/useTooltip'
 import EndSprintPokerMutation from '../mutations/EndSprintPokerMutation'
 import {ElementWidth, Times} from '../types/constEnums'
@@ -47,7 +47,7 @@ const EndMeetingButton = forwardRef((props: Props, ref: Ref<HTMLButtonElement>) 
     onTransitionEnd
   } = props
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const {submitMutation, onCompleted, onError, submitting} = useMutationProps()
   const {openTooltip, tooltipPortal, originRef} = useTooltip<HTMLDivElement>(
     MenuPosition.UPPER_CENTER,
@@ -62,11 +62,11 @@ const EndMeetingButton = forwardRef((props: Props, ref: Ref<HTMLButtonElement>) 
       setConfirmingButton('')
       submitMutation()
       if (meetingType === 'poker') {
-        EndSprintPokerMutation(atmosphere, {meetingId}, {history, onError, onCompleted})
+        EndSprintPokerMutation(atmosphere, {meetingId}, {navigate, onError, onCompleted})
       } else if (meetingType === 'action') {
-        EndCheckInMutation(atmosphere, {meetingId}, {history, onError, onCompleted})
+        EndCheckInMutation(atmosphere, {meetingId}, {navigate, onError, onCompleted})
       } else {
-        EndRetrospectiveMutation(atmosphere, {meetingId}, {history, onError, onCompleted})
+        EndRetrospectiveMutation(atmosphere, {meetingId}, {navigate, onError, onCompleted})
       }
     } else {
       setConfirmingButton('end')

--- a/packages/client/components/ForgotPasswordPage.tsx
+++ b/packages/client/components/ForgotPasswordPage.tsx
@@ -4,10 +4,10 @@
  */
 import styled from '@emotion/styled'
 import type * as React from 'react'
-import {useHistory} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useForm from '../hooks/useForm'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import EmailPasswordResetMutation from '../mutations/EmailPasswordResetMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {AuthenticationError} from '../types/constEnums'
@@ -95,7 +95,7 @@ const ForgotPasswordPage = (props: Props) => {
       validate: validateEmail
     }
   })
-  const history = useHistory()
+  const navigate = useNavigate()
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const {name} = e.target
@@ -117,7 +117,7 @@ const ForgotPasswordPage = (props: Props) => {
       atmosphere,
       {email},
       {
-        history,
+        navigate,
         onCompleted,
         onError
       }

--- a/packages/client/components/GoogleOAuthButtonBlock.tsx
+++ b/packages/client/components/GoogleOAuthButtonBlock.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled'
-import {useHistory, useLocation} from 'react-router'
+import {useLocation} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import logo from '../styles/theme/images/graphics/google.svg'
 import {cn} from '../ui/cn'
 import GoogleClientManager from '../utils/GoogleClientManager'
@@ -33,7 +34,7 @@ const GoogleOAuthButtonBlock = (props: Props) => {
   const {invitationToken, isCreate, loginHint, getOffsetTop} = props
   const {onError, error, submitting, onCompleted, submitMutation} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const location = useLocation()
   const label = isCreate ? 'Sign up with Google' : 'Sign in with Google'
   const openOAuth = () => {
@@ -41,7 +42,7 @@ const GoogleOAuthButtonBlock = (props: Props) => {
     GoogleClientManager.openOAuth(
       atmosphere,
       mutationProps,
-      history,
+      navigate,
       location.search,
       invitationToken,
       loginHint,

--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -7,11 +7,11 @@ import {
 } from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import {type PreloadedQuery, usePreloadedQuery} from 'react-relay'
-import {useHistory} from 'react-router'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
 import type {MeetingCardOptionsMenuQuery} from '../__generated__/MeetingCardOptionsMenuQuery.graphql'
 import type {MenuProps} from '../hooks/useMenu'
+import useNavigate from '../hooks/useNavigate'
 import {PALETTE} from '../styles/paletteV3'
 import getMassInvitationUrl from '../utils/getMassInvitationUrl'
 import makeAppURL from '../utils/makeAppURL'
@@ -89,7 +89,7 @@ const MeetingCardOptionsMenu = (props: Props) => {
   const canEndMeeting = meetingType === 'teamPrompt' || isViewerFacilitator
   const atmosphere = useAtmosphere()
   const {onCompleted, onError} = useMutationProps()
-  const history = useHistory()
+  const navigate = useNavigate()
 
   const hasRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt
 
@@ -174,7 +174,7 @@ const MeetingCardOptionsMenu = (props: Props) => {
               EndMeetingMutationLookup[meetingType]?.(
                 atmosphere,
                 {meetingId},
-                {onError, onCompleted, history}
+                {onError, onCompleted, navigate}
               )
             } else {
               openEndRecurringMeetingModal()

--- a/packages/client/components/MicrosoftOAuthButtonBlock.tsx
+++ b/packages/client/components/MicrosoftOAuthButtonBlock.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled'
-import {useHistory, useLocation} from 'react-router'
+import {useLocation} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import logo from '../styles/theme/images/graphics/microsoft.svg'
 import {cn} from '../ui/cn'
 import MicrosoftClientManager from '../utils/MicrosoftClientManager'
@@ -33,7 +34,7 @@ const MicrosoftOAuthButtonBlock = (props: Props) => {
   const {invitationToken, isCreate, loginHint, getOffsetTop} = props
   const {onError, error, submitting, onCompleted, submitMutation} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const location = useLocation()
   const label = isCreate ? 'Sign up with Microsoft' : 'Sign in with Microsoft'
   const openOAuth = () => {
@@ -41,7 +42,7 @@ const MicrosoftOAuthButtonBlock = (props: Props) => {
     MicrosoftClientManager.openOAuth(
       atmosphere,
       mutationProps,
-      history,
+      navigate,
       location.search,
       invitationToken,
       loginHint,

--- a/packages/client/components/PinnedSnackbarNotifications.tsx
+++ b/packages/client/components/PinnedSnackbarNotifications.tsx
@@ -1,15 +1,15 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect} from 'react'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
 import type {PinnedSnackbarNotifications_query$key} from '~/__generated__/PinnedSnackbarNotifications_query.graphql'
 import type {NotificationEnum} from '../__generated__/popNotificationToast_notification.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
+import useNavigate from '../hooks/useNavigate'
 import SetNotificationStatusMutation from '../mutations/SetNotificationStatusMutation'
 import mapPromptToJoinOrgToToast from '../mutations/toasts/mapPromptToJoinOrgToToast'
 import mapRequestToJoinOrgToToast from '../mutations/toasts/mapRequestToJoinOrgToToast'
 import mapTeamsLimitReminderToToast from '../mutations/toasts/mapTeamsLimitReminderToToast'
-import type {OnNextHistoryContext} from '../types/relayMutations'
+import type {OnNextNavigateContext} from '../types/relayMutations'
 import type {Snack} from './Snackbar'
 
 interface Props {
@@ -17,7 +17,7 @@ interface Props {
 }
 
 const typePicker: Partial<
-  Record<NotificationEnum, (notification: any, context: OnNextHistoryContext) => Snack | null>
+  Record<NotificationEnum, (notification: any, context: OnNextNavigateContext) => Snack | null>
 > = {
   TEAMS_LIMIT_REMINDER: mapTeamsLimitReminderToToast,
   PROMPT_TO_JOIN_ORG: mapPromptToJoinOrgToToast,
@@ -49,7 +49,7 @@ const PinnedSnackbarNotifications = ({queryRef}: Props) => {
     `,
     queryRef
   )
-  const history = useHistory()
+  const navigate = useNavigate()
   const atmosphere = useAtmosphere()
   const {viewer} = data
   const notifications = viewer?.pinnedNotifications || {edges: []}
@@ -67,7 +67,7 @@ const PinnedSnackbarNotifications = ({queryRef}: Props) => {
 
       const notificationSnack = specificNotificationToastMapper(node, {
         atmosphere,
-        history
+        navigate
       })
 
       if (!notificationSnack) {

--- a/packages/client/components/Recurrence/EndRecurringMeetingModal.tsx
+++ b/packages/client/components/Recurrence/EndRecurringMeetingModal.tsx
@@ -1,12 +1,12 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useMemo, useState} from 'react'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
 import {RRule} from 'rrule'
 import type {EndRecurringMeetingModal_meeting$key} from '../../__generated__/EndRecurringMeetingModal_meeting.graphql'
 import type {MeetingTypeEnum} from '../../__generated__/MeetingSelectorQuery.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useMutationProps from '../../hooks/useMutationProps'
+import useNavigate from '../../hooks/useNavigate'
 import EndCheckInMutation from '../../mutations/EndCheckInMutation'
 import EndRetrospectiveMutation from '../../mutations/EndRetrospectiveMutation'
 import EndSprintPokerMutation from '../../mutations/EndSprintPokerMutation'
@@ -14,7 +14,7 @@ import EndTeamPromptMutation from '../../mutations/EndTeamPromptMutation'
 import UpdateRecurrenceSettingsMutation from '../../mutations/UpdateRecurrenceSettingsMutation'
 import type {
   CompletedHandler,
-  HistoryMaybeLocalHandler,
+  NavigateMaybeLocalHandler,
   StandardMutation
 } from '../../types/relayMutations'
 import {cn} from '../../ui/cn'
@@ -26,7 +26,7 @@ export const EndMeetingMutationLookup = {
   action: EndCheckInMutation,
   retrospective: EndRetrospectiveMutation,
   poker: EndSprintPokerMutation
-} satisfies Record<MeetingTypeEnum, StandardMutation<any, HistoryMaybeLocalHandler>>
+} satisfies Record<MeetingTypeEnum, StandardMutation<any, NavigateMaybeLocalHandler>>
 
 interface RadioToggleProps {
   checked: boolean
@@ -76,7 +76,7 @@ export const EndRecurringMeetingModal = (props: Props) => {
   const {meetingType, id: meetingId} = meeting
 
   const {onCompleted, onError} = useMutationProps()
-  const history = useHistory()
+  const navigate = useNavigate()
 
   const atmosphere = useAtmosphere()
 
@@ -99,7 +99,7 @@ export const EndRecurringMeetingModal = (props: Props) => {
     EndMeetingMutationLookup[meetingType]?.(
       atmosphere,
       {meetingId},
-      {onCompleted: handleCompleted, onError, history}
+      {onCompleted: handleCompleted, onError, navigate}
     )
   }
 

--- a/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
+++ b/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled'
 import type * as React from 'react'
-import {useHistory, useParams} from 'react-router'
+import {useParams} from 'react-router'
 import useCanonical from '~/hooks/useCanonical'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useForm from '../../hooks/useForm'
 import useMutationProps from '../../hooks/useMutationProps'
+import useNavigate from '../../hooks/useNavigate'
 import ResetPasswordMutation from '../../mutations/ResetPasswordMutation'
 import Legitity from '../../validation/Legitity'
 import AuthenticationDialog from '../AuthenticationDialog'
@@ -44,7 +45,7 @@ const validatePassword = (password: string) => {
 }
 
 const SetNewPassword = () => {
-  const history = useHistory()
+  const navigate = useNavigate()
   const {token} = useParams<{token: string}>()
   const atmosphere = useAtmosphere()
   useCanonical('reset-password')
@@ -70,7 +71,7 @@ const SetNewPassword = () => {
     if (passwordRes.error) return
     const {value: newPassword} = passwordRes
     submitMutation()
-    ResetPasswordMutation(atmosphere, {newPassword, token}, {onError, onCompleted, history})
+    ResetPasswordMutation(atmosphere, {newPassword, token}, {onError, onCompleted, navigate})
   }
   return (
     <TeamInvitationWrapper>

--- a/packages/client/components/TeamInvitationAccept.tsx
+++ b/packages/client/components/TeamInvitationAccept.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react'
-import {useHistory} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
+import useNavigate from '../hooks/useNavigate'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 
 interface Props {
@@ -9,10 +9,10 @@ interface Props {
 
 const TeamInvitationAccept = (props: Props) => {
   const {invitationToken} = props
-  const history = useHistory()
+  const navigate = useNavigate()
   const atmosphere = useAtmosphere()
   useEffect(() => {
-    AcceptTeamInvitationMutation(atmosphere, {invitationToken}, {history})
+    AcceptTeamInvitationMutation(atmosphere, {invitationToken}, {navigate})
   })
   return null
 }

--- a/packages/client/components/TeamInvitationNotification.tsx
+++ b/packages/client/components/TeamInvitationNotification.tsx
@@ -1,10 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
 import type {TeamInvitationNotification_notification$key} from '~/__generated__/TeamInvitationNotification_notification.graphql'
 import NotificationAction from '~/components/NotificationAction'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import NotificationTemplate from './NotificationTemplate'
 
@@ -35,7 +35,7 @@ const TeamInvitationNotification = (props: Props) => {
   )
   const {submitMutation, onError, onCompleted} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const {id: notificationId, invitation, team} = notification
   const {name: teamName} = team
   const {token, inviter} = invitation
@@ -45,7 +45,7 @@ const TeamInvitationNotification = (props: Props) => {
     AcceptTeamInvitationMutation(
       atmosphere,
       {notificationId, invitationToken: token},
-      {history, onError, onCompleted}
+      {navigate, onError, onCompleted}
     )
   }
 

--- a/packages/client/components/TeamInvitationSSO.tsx
+++ b/packages/client/components/TeamInvitationSSO.tsx
@@ -1,8 +1,8 @@
 import {useEffect} from 'react'
-import {useHistory} from 'react-router'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import {LocalStorageKey} from '../types/constEnums'
 import {emitGA4SignUpEvent} from '../utils/handleSuccessfulLogin'
@@ -22,7 +22,7 @@ const TeamInvitationSSO = (props: Props) => {
   const {ssoURL} = props
   const {onCompleted, submitMutation, onError, error} = useMutationProps()
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   useEffect(() => {
     const loginWithSAML = async () => {
       const invitationToken = localStorage.getItem(LocalStorageKey.INVITATION_TOKEN)!
@@ -34,7 +34,7 @@ const TeamInvitationSSO = (props: Props) => {
       }
       const {ga4Args} = response
       emitGA4SignUpEvent(ga4Args)
-      AcceptTeamInvitationMutation(atmosphere, {invitationToken}, {history, onCompleted, onError})
+      AcceptTeamInvitationMutation(atmosphere, {invitationToken}, {navigate, onCompleted, onError})
     }
     loginWithSAML().catch(() => {
       /*ignore*/

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled'
 import {Flag, Link as MuiLink, OpenInNew, Replay} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
 import {Link} from 'react-router-dom'
 import type {TeamPromptOptionsMenu_meeting$key} from '~/__generated__/TeamPromptOptionsMenu_meeting.graphql'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import type {MenuProps} from '~/hooks/useMenu'
 import useMutationProps from '~/hooks/useMutationProps'
 import EndTeamPromptMutation from '~/mutations/EndTeamPromptMutation'
+import useNavigate from '../../hooks/useNavigate'
 import {PALETTE} from '../../styles/paletteV3'
 import makeAppURL from '../../utils/makeAppURL'
 import SendClientSideEvent from '../../utils/SendClientSideEvent'
@@ -78,7 +78,7 @@ const TeamPromptOptionsMenu = (props: Props) => {
   const {id: meetingId, meetingSeries, endedAt, team} = meeting
   const atmosphere = useAtmosphere()
   const {onCompleted, onError} = useMutationProps()
-  const history = useHistory()
+  const navigate = useNavigate()
 
   const isEnded = !!endedAt
   const hasRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt
@@ -161,7 +161,7 @@ const TeamPromptOptionsMenu = (props: Props) => {
         onClick={() => {
           menuProps.closePortal()
           if (!hasRecurrenceEnabled) {
-            EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted, onError, history})
+            EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted, onError, navigate})
           } else {
             openEndRecurringMeetingModal()
           }

--- a/packages/client/components/VerifyEmail.tsx
+++ b/packages/client/components/VerifyEmail.tsx
@@ -1,9 +1,10 @@
 import {useEffect} from 'react'
-import {useHistory, useParams} from 'react-router'
+import {useParams} from 'react-router'
 import useCanonical from '~/hooks/useCanonical'
 import VerifyEmailMutation from '~/mutations/VerifyEmailMutation'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 import Ellipsis from './Ellipsis/Ellipsis'
@@ -14,7 +15,7 @@ import PrimaryButton from './PrimaryButton'
 import TeamInvitationWrapper from './TeamInvitationWrapper'
 
 const VerifyEmail = () => {
-  const history = useHistory()
+  const navigate = useNavigate()
   const {verificationToken, invitationToken} = useParams<{
     verificationToken: string
     invitationToken?: string
@@ -31,7 +32,7 @@ const VerifyEmail = () => {
         invitationToken: invitationToken || '',
         isInvitation: !!invitationToken
       },
-      {onCompleted, onError, history}
+      {onCompleted, onError, navigate}
     )
   }, [])
   return (

--- a/packages/client/components/ViewerNotOnTeam.tsx
+++ b/packages/client/components/ViewerNotOnTeam.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect} from 'react'
 import {type PreloadedQuery, usePreloadedQuery} from 'react-relay'
-import {useHistory} from 'react-router'
 import type {ViewerNotOnTeamQuery} from '../__generated__/ViewerNotOnTeamQuery.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useMutationProps from '../hooks/useMutationProps'
+import useNavigate from '../hooks/useNavigate'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import PushInvitationMutation from '../mutations/PushInvitationMutation'
 import getValidRedirectParam from '../utils/getValidRedirectParam'
@@ -45,19 +45,19 @@ const ViewerNotOnTeam = (props: Props) => {
     teamInvitation: {teamInvitation, meetingId, teamId, isOnTeam}
   } = viewer
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const {onError, onCompleted} = useMutationProps()
   useDocumentTitle(`Invitation Required`, 'Invitation Required')
   useEffect(() => {
     if (isOnTeam) {
       const redirectTo = getValidRedirectParam() || '/meetings'
-      history.replace(redirectTo)
+      navigate(redirectTo, {replace: true})
     } else if (teamInvitation) {
       // if an invitation already exists, accept it
       AcceptTeamInvitationMutation(
         atmosphere,
         {invitationToken: teamInvitation.token},
-        {history, meetingId}
+        {navigate, meetingId}
       )
     } else if (teamId) {
       PushInvitationMutation(atmosphere, {meetingId, teamId}, {onError, onCompleted})

--- a/packages/client/hooks/useAutoCheckIn.ts
+++ b/packages/client/hooks/useAutoCheckIn.ts
@@ -1,17 +1,16 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect, useRef} from 'react'
-import {useHistory, useLocation} from 'react-router'
 import {readInlineData} from 'relay-runtime'
 import type {useAutoCheckIn_meeting$key} from '~/__generated__/useAutoCheckIn_meeting.graphql'
 import JoinMeetingMutation from '../mutations/JoinMeetingMutation'
 import MeetingSubscription from '../subscriptions/MeetingSubscription'
 import useAtmosphere from './useAtmosphere'
+import useNavigate from './useNavigate'
 
 const useAutoCheckIn = (meetingRef: useAutoCheckIn_meeting$key) => {
   const atmosphere = useAtmosphere()
-  const history = useHistory()
-  const location = useLocation()
-  const router = {history, location}
+  const navigate = useNavigate()
+  const router = {navigate}
   const queryKey = 'useAutoCheckIn'
   const hasCalledJoinedRef = useRef(false)
   useEffect(() => {

--- a/packages/client/hooks/useEndMeetingHotkey.ts
+++ b/packages/client/hooks/useEndMeetingHotkey.ts
@@ -1,4 +1,3 @@
-import {useHistory} from 'react-router'
 import type {MeetingTypeEnum} from '~/__generated__/MeetingSelectorQuery.graphql'
 import EndCheckInMutation from '~/mutations/EndCheckInMutation'
 import EndRetrospectiveMutation from '~/mutations/EndRetrospectiveMutation'
@@ -6,17 +5,18 @@ import EndSprintPokerMutation from '~/mutations/EndSprintPokerMutation'
 import handleHotkey from '../utils/meetings/handleHotkey'
 import useAtmosphere from './useAtmosphere'
 import useHotkey from './useHotkey'
+import useNavigate from './useNavigate'
 
 const useEndMeetingHotkey = (meetingId: string, meetingType: MeetingTypeEnum) => {
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const endMeeting = handleHotkey(() => {
     if (meetingType === 'action') {
-      EndCheckInMutation(atmosphere, {meetingId}, {history})
+      EndCheckInMutation(atmosphere, {meetingId}, {navigate})
     } else if (meetingType === 'retrospective') {
-      EndRetrospectiveMutation(atmosphere, {meetingId}, {history})
+      EndRetrospectiveMutation(atmosphere, {meetingId}, {navigate})
     } else if (meetingType === 'poker') {
-      EndSprintPokerMutation(atmosphere, {meetingId}, {history})
+      EndSprintPokerMutation(atmosphere, {meetingId}, {navigate})
     }
   })
   useHotkey('i c a n t h a c k i t', endMeeting)

--- a/packages/client/hooks/useNavigate.ts
+++ b/packages/client/hooks/useNavigate.ts
@@ -1,0 +1,24 @@
+import {useMemo} from 'react'
+import {useHistory} from 'react-router'
+import type {NavigateFn} from '../types/relayMutations'
+
+/**
+ * v5-compatible useNavigate hook that returns a NavigateFn.
+ * In the v6 upgrade (PR 15), this file is deleted and all imports
+ * switch to `import {useNavigate} from 'react-router'`.
+ */
+const useNavigate = (): NavigateFn => {
+  const history = useHistory()
+  return useMemo<NavigateFn>(
+    () => (to, options) => {
+      if (options?.replace) {
+        history.replace(to as any, options?.state)
+      } else {
+        history.push(to as any, options?.state)
+      }
+    },
+    [history]
+  )
+}
+
+export default useNavigate

--- a/packages/client/hooks/useSubscription.ts
+++ b/packages/client/hooks/useSubscription.ts
@@ -1,8 +1,8 @@
 import {useEffect} from 'react'
-import {useHistory, useLocation} from 'react-router'
 import type {SubscriptionRequestor} from '../Atmosphere'
 import useAtmosphere from './useAtmosphere'
 import useDeepEqual from './useDeepEqual'
+import useNavigate from './useNavigate'
 
 const useSubscription = (
   queryKey: string,
@@ -10,10 +10,9 @@ const useSubscription = (
   inVariables: any = {}
 ) => {
   const atmosphere = useAtmosphere()
-  const history = useHistory()
-  const location = useLocation()
+  const navigate = useNavigate()
   const variables = useDeepEqual(inVariables)
-  const router = {history, location}
+  const router = {navigate}
   useEffect(() => {
     if (atmosphere.registerQuery) {
       atmosphere.registerQuery(queryKey, subscription, variables, router).catch(() => {

--- a/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -17,6 +17,7 @@ import Toggle from '../../../../components/Toggle/Toggle'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useForm from '../../../../hooks/useForm'
 import useMutationProps from '../../../../hooks/useMutationProps'
+import useNavigate from '../../../../hooks/useNavigate'
 import AddOrgMutation from '../../../../mutations/AddOrgMutation'
 import AddTeamMutation from '../../../../mutations/AddTeamMutation'
 import {PALETTE} from '../../../../styles/paletteV3'
@@ -184,6 +185,7 @@ const NewTeamForm = (props: Props) => {
   const {submitting, onError, error, onCompleted, submitMutation} = useMutationProps()
   const atmosphere = useAtmosphere()
   const history = useHistory()
+  const navigate = useNavigate()
 
   const updateOrgId = (orgId: string) => {
     setOrgId(orgId)
@@ -209,7 +211,7 @@ const NewTeamForm = (props: Props) => {
       }
       const variables = {newTeam, orgName, invitees}
       submitMutation()
-      AddOrgMutation(atmosphere, variables, {history, onError, onCompleted})
+      AddOrgMutation(atmosphere, variables, {navigate, onError, onCompleted})
     } else {
       const newTeam = {
         name: teamName,
@@ -217,7 +219,7 @@ const NewTeamForm = (props: Props) => {
         isPublic
       }
       submitMutation()
-      AddTeamMutation(atmosphere, {newTeam, invitees}, {onError, onCompleted, history})
+      AddTeamMutation(atmosphere, {newTeam, invitees}, {onError, onCompleted, navigate})
     }
   }
 

--- a/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveOrganizationForm.tsx
+++ b/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveOrganizationForm.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import type * as React from 'react'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
 import type {ArchiveOrganizationForm_organization$key} from '~/__generated__/ArchiveOrganizationForm_organization.graphql'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useForm from '~/hooks/useForm'
 import useMutationProps from '~/hooks/useMutationProps'
+import useNavigate from '~/hooks/useNavigate'
 import ArchiveOrganizationMutation from '~/mutations/ArchiveOrganizationMutation'
 import FieldLabel from '../../../../components/FieldLabel/FieldLabel'
 import BasicInput from '../../../../components/InputField/BasicInput'
@@ -21,7 +21,7 @@ const normalize = (str: string | null | undefined) => str && str.toLowerCase().r
 const ArchiveOrganizationForm = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
-  const history = useHistory()
+  const navigate = useNavigate()
   const {handleFormBlur, organization: organizationRef} = props
   const organization = useFragment(
     graphql`
@@ -54,7 +54,7 @@ const ArchiveOrganizationForm = (props: Props) => {
     const {archivedOrganizationName: res} = validateField()
     if (submitting || res.error) return
     submitMutation()
-    ArchiveOrganizationMutation(atmosphere, {orgId}, {history, onError, onCompleted})
+    ArchiveOrganizationMutation(atmosphere, {orgId}, {navigate, onError, onCompleted})
   }
 
   return (

--- a/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeamForm.tsx
+++ b/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeamForm.tsx
@@ -2,12 +2,12 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import type * as React from 'react'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
 import type {ArchiveTeamForm_team$key} from '~/__generated__/ArchiveTeamForm_team.graphql'
 import SecondaryButton from '~/components/SecondaryButton'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useForm from '~/hooks/useForm'
 import useMutationProps from '~/hooks/useMutationProps'
+import useNavigate from '~/hooks/useNavigate'
 import FieldLabel from '../../../../components/FieldLabel/FieldLabel'
 import BasicInput from '../../../../components/InputField/BasicInput'
 import PrimaryButton from '../../../../components/PrimaryButton'
@@ -33,7 +33,7 @@ const normalize = (str: string | undefined | null) => str && str.toLowerCase().r
 const ArchiveTeamForm = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
-  const history = useHistory()
+  const navigate = useNavigate()
   const {handleCancel, team: teamRef} = props
   const team = useFragment(
     graphql`
@@ -66,7 +66,7 @@ const ArchiveTeamForm = (props: Props) => {
     const {archivedTeamName: res} = validateField()
     if (submitting || res?.error) return
     submitMutation()
-    ArchiveTeamMutation(atmosphere, {teamId}, {history, onError, onCompleted})
+    ArchiveTeamMutation(atmosphere, {teamId}, {navigate, onError, onCompleted})
   }
 
   return (

--- a/packages/client/modules/userDashboard/components/LeaveOrgModal/LeaveOrgModal.tsx
+++ b/packages/client/modules/userDashboard/components/LeaveOrgModal/LeaveOrgModal.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled'
-import {useHistory} from 'react-router'
 import DialogContainer from '../../../../components/DialogContainer'
 import DialogContent from '../../../../components/DialogContent'
 import DialogTitle from '../../../../components/DialogTitle'
@@ -7,6 +6,7 @@ import IconLabel from '../../../../components/IconLabel'
 import PrimaryButton from '../../../../components/PrimaryButton'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'
+import useNavigate from '../../../../hooks/useNavigate'
 import RemoveOrgUsersMutation from '../../../../mutations/RemoveOrgUsersMutation'
 
 const StyledButton = styled(PrimaryButton)({
@@ -25,7 +25,7 @@ const StyledDialogContainer = styled(DialogContainer)({
 const LeaveOrgModal = (props: Props) => {
   const {orgId, closePortal} = props
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
   const handleClick = () => {
     if (submitting) return
@@ -34,7 +34,7 @@ const LeaveOrgModal = (props: Props) => {
       atmosphere,
       {orgId, userIds: [atmosphere.viewerId]},
       {
-        history,
+        navigate,
         onError,
         onCompleted: () => {
           onCompleted()

--- a/packages/client/modules/userDashboard/components/RemoveFromOrgModal/RemoveFromOrgModal.tsx
+++ b/packages/client/modules/userDashboard/components/RemoveFromOrgModal/RemoveFromOrgModal.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
 import type {RemoveFromOrgModal_organizationUsers$key} from '../../../../__generated__/RemoveFromOrgModal_organizationUsers.graphql'
 import DialogContainer from '../../../../components/DialogContainer'
 import DialogContent from '../../../../components/DialogContent'
@@ -10,6 +9,7 @@ import IconLabel from '../../../../components/IconLabel'
 import PrimaryButton from '../../../../components/PrimaryButton'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'
+import useNavigate from '../../../../hooks/useNavigate'
 import RemoveOrgUsersMutation from '../../../../mutations/RemoveOrgUsersMutation'
 import plural from '../../../../utils/plural'
 
@@ -43,7 +43,7 @@ const organizationUsersFragment = graphql`
 const RemoveFromOrgModal = (props: Props) => {
   const {orgId, userIds, organizationUsers, closePortal, onSuccess} = props
   const atmosphere = useAtmosphere()
-  const history = useHistory()
+  const navigate = useNavigate()
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
   const {viewerId} = atmosphere
 
@@ -88,7 +88,7 @@ const RemoveFromOrgModal = (props: Props) => {
       atmosphere,
       {orgId, userIds: removableUserIds},
       {
-        history,
+        navigate,
         onError,
         onCompleted: () => {
           onCompleted()

--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -6,7 +6,7 @@ import type {AcceptTeamInvitationMutation as TAcceptTeamInvitationMutation} from
 import type {AcceptTeamInvitationMutation_team$data} from '../__generated__/AcceptTeamInvitationMutation_team.graphql'
 import type Atmosphere from '../Atmosphere'
 import type {
-  HistoryMaybeLocalHandler,
+  NavigateMaybeLocalHandler,
   OnNextHandler,
   SharedUpdater,
   StandardMutation
@@ -173,7 +173,7 @@ export const acceptTeamInvitationTeamOnNext: OnNextHandler<
   }
 }
 
-interface LocalHandler extends HistoryMaybeLocalHandler {
+interface LocalHandler extends NavigateMaybeLocalHandler {
   meetingId?: string | null
   ignoreApproval?: boolean
 }
@@ -203,7 +203,7 @@ const AcceptTeamInvitationMutation: StandardMutation<
 > = (
   atmosphere,
   variables,
-  {history, onCompleted, onError, meetingId: locallyRequestedMeetingId, ignoreApproval}
+  {navigate, onCompleted, onError, meetingId: locallyRequestedMeetingId, ignoreApproval}
 ) => {
   return commitMutation<TAcceptTeamInvitationMutation>(atmosphere, {
     mutation,
@@ -229,7 +229,7 @@ const AcceptTeamInvitationMutation: StandardMutation<
         } else if (message === InvitationTokenError.ALREADY_ACCEPTED) {
           handleAuthenticationRedirect(acceptTeamInvitation, {
             atmosphere,
-            history,
+            navigate,
             meetingId: locallyRequestedMeetingId
           })
         } else if (!ignoreApproval) {
@@ -257,7 +257,7 @@ const AcceptTeamInvitationMutation: StandardMutation<
       })
       handleAuthenticationRedirect(acceptTeamInvitation, {
         atmosphere,
-        history,
+        navigate,
         meetingId: locallyRequestedMeetingId
       })
     }

--- a/packages/client/mutations/AddOrgMutation.ts
+++ b/packages/client/mutations/AddOrgMutation.ts
@@ -3,7 +3,7 @@ import {commitMutation} from 'react-relay'
 import type {AddOrgMutation as TAddOrgMutation} from '../__generated__/AddOrgMutation.graphql'
 import type {AddOrgMutation_notification$data} from '../__generated__/AddOrgMutation_notification.graphql'
 import type {
-  HistoryLocalHandler,
+  NavigateLocalHandler,
   OnNextHandler,
   SharedUpdater,
   StandardMutation
@@ -77,10 +77,10 @@ export const addOrgMutationNotificationUpdater: SharedUpdater<AddOrgMutation_not
   handleRemoveSuggestedActions(removedSuggestedActionId, store)
 }
 
-const AddOrgMutation: StandardMutation<TAddOrgMutation, HistoryLocalHandler> = (
+const AddOrgMutation: StandardMutation<TAddOrgMutation, NavigateLocalHandler> = (
   atmosphere,
   variables,
-  {history, onError, onCompleted}
+  {navigate, onError, onCompleted}
 ) => {
   return commitMutation<TAddOrgMutation>(atmosphere, {
     mutation,
@@ -99,7 +99,7 @@ const AddOrgMutation: StandardMutation<TAddOrgMutation, HistoryLocalHandler> = (
       if (!error) {
         popOrganizationCreatedToast(addOrg, {atmosphere})
         const teamId = addOrg.team && addOrg.team.id
-        history.push(`/team/${teamId}`)
+        navigate(`/team/${teamId}`)
       }
     },
     onError

--- a/packages/client/mutations/AddTeamMutation.ts
+++ b/packages/client/mutations/AddTeamMutation.ts
@@ -3,9 +3,9 @@ import {commitMutation} from 'react-relay'
 import type {AddTeamMutation as TAddTeamMutation} from '../__generated__/AddTeamMutation.graphql'
 import type {AddTeamMutation_notification$data} from '../__generated__/AddTeamMutation_notification.graphql'
 import type {
-  HistoryLocalHandler,
+  NavigateLocalHandler,
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -41,8 +41,8 @@ const mutation = graphql`
 
 const popTeamCreatedToast: OnNextHandler<
   AddTeamMutation_notification$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
   const {team} = payload
   if (!team) return
   const {id: teamId, name: teamName} = team
@@ -51,7 +51,7 @@ const popTeamCreatedToast: OnNextHandler<
     key: `teamCreated:${teamId}`,
     message: `Team created! Here's your new team dashboard for ${teamName}`
   })
-  history && history.push(`/team/${teamId}`)
+  navigate?.(`/team/${teamId}`)
 }
 
 export const addTeamMutationNotificationUpdater: SharedUpdater<
@@ -64,13 +64,13 @@ export const addTeamMutationNotificationUpdater: SharedUpdater<
   handleRemoveSuggestedActions(removedSuggestedActionId, store)
 }
 
-type ExtendedHistoryLocalHandler = HistoryLocalHandler & {
+type ExtendedNavigateLocalHandler = NavigateLocalHandler & {
   showTeamCreatedToast?: boolean
 }
-const AddTeamMutation: StandardMutation<TAddTeamMutation, ExtendedHistoryLocalHandler> = (
+const AddTeamMutation: StandardMutation<TAddTeamMutation, ExtendedNavigateLocalHandler> = (
   atmosphere,
   variables,
-  {history, onError, onCompleted, showTeamCreatedToast = true}
+  {navigate, onError, onCompleted, showTeamCreatedToast = true}
 ) => {
   return commitMutation<TAddTeamMutation>(atmosphere, {
     mutation,
@@ -86,7 +86,7 @@ const AddTeamMutation: StandardMutation<TAddTeamMutation, ExtendedHistoryLocalHa
       const {addTeam} = res
       if (!error) {
         if (showTeamCreatedToast) {
-          popTeamCreatedToast(addTeam, {atmosphere, history})
+          popTeamCreatedToast(addTeam, {atmosphere, navigate})
         }
       }
     },

--- a/packages/client/mutations/ArchiveOrganizationMutation.ts
+++ b/packages/client/mutations/ArchiveOrganizationMutation.ts
@@ -3,9 +3,9 @@ import {commitMutation} from 'react-relay'
 import type {ArchiveOrganizationMutation as TArchiveOrganizationMutation} from '../__generated__/ArchiveOrganizationMutation.graphql'
 import type {ArchiveOrganizationMutation_organization$data} from '../__generated__/ArchiveOrganizationMutation_organization.graphql'
 import type {
-  HistoryLocalHandler,
+  NavigateLocalHandler,
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -41,8 +41,8 @@ const mutation = graphql`
 
 const popOrgArchivedToast: OnNextHandler<
   ArchiveOrganizationMutation_organization$data,
-  OnNextHistoryContext
-> = (payload, {history, atmosphere}) => {
+  OnNextNavigateContext
+> = (payload, {navigate, atmosphere}) => {
   if (!payload) return
   const {orgId, teams} = payload
   if (!teams) return
@@ -58,7 +58,7 @@ const popOrgArchivedToast: OnNextHandler<
         autoDismiss: 5,
         message: `${teamName} has been archived.`
       })
-      history && history.push('/meetings')
+      navigate?.('/meetings')
     }
   })
 }
@@ -83,15 +83,15 @@ export const archiveOrganizationOrganizationUpdater: SharedUpdater<
 
 export const archiveOrganizationOrganizationOnNext: OnNextHandler<
   ArchiveOrganizationMutation_organization$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
-  popOrgArchivedToast(payload, {atmosphere, history})
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
+  popOrgArchivedToast(payload, {atmosphere, navigate})
 }
 
 const ArchiveOrganizationMutation: StandardMutation<
   TArchiveOrganizationMutation,
-  HistoryLocalHandler
-> = (atmosphere, variables, {onError, onCompleted, history}) => {
+  NavigateLocalHandler
+> = (atmosphere, variables, {onError, onCompleted, navigate}) => {
   return commitMutation<TArchiveOrganizationMutation>(atmosphere, {
     mutation,
     variables,
@@ -107,9 +107,9 @@ const ArchiveOrganizationMutation: StandardMutation<
       }
       const payload = res.archiveOrganization
       if (payload) {
-        popOrgArchivedToast(payload, {atmosphere, history})
+        popOrgArchivedToast(payload, {atmosphere, navigate})
       }
-      history.replace('/meetings')
+      navigate('/meetings', {replace: true})
     },
     onError
   })

--- a/packages/client/mutations/ArchiveTeamMutation.ts
+++ b/packages/client/mutations/ArchiveTeamMutation.ts
@@ -3,9 +3,9 @@ import {commitMutation} from 'react-relay'
 import type {ArchiveTeamMutation as TArchiveTeamMutation} from '../__generated__/ArchiveTeamMutation.graphql'
 import type {ArchiveTeamMutation_team$data} from '../__generated__/ArchiveTeamMutation_team.graphql'
 import type {
-  HistoryLocalHandler,
+  NavigateLocalHandler,
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -52,9 +52,9 @@ const mutation = graphql`
   }
 `
 
-const popTeamArchivedToast: OnNextHandler<ArchiveTeamMutation_team$data, OnNextHistoryContext> = (
+const popTeamArchivedToast: OnNextHandler<ArchiveTeamMutation_team$data, OnNextNavigateContext> = (
   payload,
-  {history, atmosphere}
+  {navigate, atmosphere}
 ) => {
   if (!payload) return
   const {team, notification} = payload
@@ -88,7 +88,7 @@ const popTeamArchivedToast: OnNextHandler<ArchiveTeamMutation_team$data, OnNextH
     onTeamRoute(window.location.pathname, teamId) ||
     onMeetingRoute(window.location.pathname, meetingIds)
   ) {
-    history && history.push('/meetings')
+    navigate?.('/meetings')
   }
 }
 
@@ -111,15 +111,15 @@ export const archiveTeamTeamUpdater: SharedUpdater<ArchiveTeamMutation_team$data
 
 export const archiveTeamTeamOnNext: OnNextHandler<
   ArchiveTeamMutation_team$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
-  popTeamArchivedToast(payload, {atmosphere, history})
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
+  popTeamArchivedToast(payload, {atmosphere, navigate})
 }
 
-const ArchiveTeamMutation: StandardMutation<TArchiveTeamMutation, HistoryLocalHandler> = (
+const ArchiveTeamMutation: StandardMutation<TArchiveTeamMutation, NavigateLocalHandler> = (
   atmosphere,
   variables,
-  {onError, onCompleted, history}
+  {onError, onCompleted, navigate}
 ) => {
   return commitMutation<TArchiveTeamMutation>(atmosphere, {
     mutation,
@@ -143,7 +143,7 @@ const ArchiveTeamMutation: StandardMutation<TArchiveTeamMutation, HistoryLocalHa
       }
       const payload = res.archiveTeam
       if (payload) {
-        popTeamArchivedToast(payload, {atmosphere, history})
+        popTeamArchivedToast(payload, {atmosphere, navigate})
       }
     },
     onError

--- a/packages/client/mutations/CreateTaskMutation.ts
+++ b/packages/client/mutations/CreateTaskMutation.ts
@@ -11,7 +11,7 @@ import JiraProjectId from '../shared/gqlIds/JiraProjectId'
 import {serverTipTapExtensions} from '../shared/tiptap/serverTipTapExtensions'
 import type {
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   OptionalHandlers,
   SharedUpdater,
   StandardMutation
@@ -139,10 +139,10 @@ export const createTaskTaskUpdater: SharedUpdater<CreateTaskMutation_task$data> 
 
 export const createTaskNotificationOnNext: OnNextHandler<
   CreateTaskMutation_notification$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
   if (!payload || !payload.involvementNotification) return
-  popInvolvementToast(payload.involvementNotification, {atmosphere, history})
+  popInvolvementToast(payload.involvementNotification, {atmosphere, navigate})
 }
 
 export const createTaskNotificationUpdater: SharedUpdater<CreateTaskMutation_notification$data> = (

--- a/packages/client/mutations/EmailPasswordResetMutation.ts
+++ b/packages/client/mutations/EmailPasswordResetMutation.ts
@@ -26,7 +26,7 @@ const mutation = graphql`
 const EmailPasswordResetMutation: StandardMutation<TEmailPasswordResetMutation, LocalHandlers> = (
   atmosphere,
   variables,
-  {history, onError, onCompleted}: LocalHandlers = {}
+  {navigate, onError, onCompleted}: LocalHandlers = {}
 ) => {
   return commitMutation<TEmailPasswordResetMutation>(atmosphere, {
     mutation,
@@ -49,7 +49,7 @@ const EmailPasswordResetMutation: StandardMutation<TEmailPasswordResetMutation, 
         params.set('type', ForgotPasswordResType.SUCCESS)
         params.set('email', email)
       }
-      if (history) history.push(`/forgot-password/submitted?${params}`)
+      if (navigate) navigate(`/forgot-password/submitted?${params}`)
     }
   })
 }

--- a/packages/client/mutations/EndCheckInMutation.ts
+++ b/packages/client/mutations/EndCheckInMutation.ts
@@ -6,9 +6,9 @@ import type {EndCheckInMutation_team$data} from '~/__generated__/EndCheckInMutat
 import onMeetingRoute from '~/utils/onMeetingRoute'
 import type {EndCheckInMutation as TEndCheckInMutation} from '../__generated__/EndCheckInMutation.graphql'
 import type {
-  HistoryMaybeLocalHandler,
+  NavigateMaybeLocalHandler,
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -78,19 +78,19 @@ const mutation = graphql`
 `
 export const endCheckInTeamOnNext: OnNextHandler<
   EndCheckInMutation_team$data,
-  OnNextHistoryContext
+  OnNextNavigateContext
 > = (payload, context) => {
   const {isKill, meeting} = payload
-  const {atmosphere, history} = context
+  const {atmosphere, navigate} = context
   if (!meeting) return
   const {id: meetingId, teamId, summaryPageId} = meeting
   if (onMeetingRoute(window.location.pathname, [meetingId])) {
     if (isKill) {
-      history.push(`/team/${teamId}`)
+      navigate(`/team/${teamId}`)
       popEndMeetingToast(atmosphere, meetingId)
     } else if (summaryPageId) {
       const pageCode = GQLID.fromKey(summaryPageId)[0]
-      history.push(`/pages/${pageCode}`)
+      navigate(`/pages/${pageCode}`)
     }
   }
 }
@@ -116,10 +116,10 @@ export const endCheckInTeamUpdater: SharedUpdater<EndCheckInMutation_team$data> 
   handleUpsertTasks(updatedTasks as any, store)
 }
 
-const EndCheckInMutation: StandardMutation<TEndCheckInMutation, HistoryMaybeLocalHandler> = (
+const EndCheckInMutation: StandardMutation<TEndCheckInMutation, NavigateMaybeLocalHandler> = (
   atmosphere,
   variables,
-  {onError, onCompleted, history}
+  {onError, onCompleted, navigate}
 ) => {
   return commitMutation<TEndCheckInMutation>(atmosphere, {
     mutation,
@@ -135,7 +135,7 @@ const EndCheckInMutation: StandardMutation<TEndCheckInMutation, HistoryMaybeLoca
       if (onCompleted) {
         onCompleted(res, errors)
       }
-      endCheckInTeamOnNext(res.endCheckIn as any, {atmosphere, history})
+      endCheckInTeamOnNext(res.endCheckIn as any, {atmosphere, navigate})
     },
     onError
   })

--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -7,9 +7,9 @@ import onMeetingRoute from '~/utils/onMeetingRoute'
 import type {EndRetrospectiveMutation as TEndRetrospectiveMutation} from '../__generated__/EndRetrospectiveMutation.graphql'
 import {RetroDemo} from '../types/constEnums'
 import type {
-  HistoryMaybeLocalHandler,
+  NavigateMaybeLocalHandler,
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -80,26 +80,26 @@ const mutation = graphql`
 
 export const endRetrospectiveTeamOnNext: OnNextHandler<
   EndRetrospectiveMutation_team$data,
-  OnNextHistoryContext
+  OnNextNavigateContext
 > = (payload, context) => {
   const {isKill, meeting} = payload
-  const {atmosphere, history} = context
+  const {atmosphere, navigate} = context
   if (!meeting) return
   const {id: meetingId, teamId, summaryPageId} = meeting
   if (meetingId === RetroDemo.MEETING_ID) {
     if (isKill) {
       window.localStorage.removeItem('retroDemo')
-      history.push('/create-account')
+      navigate('/create-account')
     } else {
-      history.push('/retrospective-demo-summary')
+      navigate('/retrospective-demo-summary')
     }
   } else if (onMeetingRoute(window.location.pathname, [meetingId])) {
     if (isKill) {
-      history.push(`/team/${teamId}`)
+      navigate(`/team/${teamId}`)
       popEndMeetingToast(atmosphere, meetingId)
     } else if (summaryPageId) {
       const pageCode = GQLID.fromKey(summaryPageId)[0]
-      history.push(`/pages/${pageCode}`)
+      navigate(`/pages/${pageCode}`)
     }
   }
 }
@@ -122,8 +122,8 @@ export const endRetrospectiveTeamUpdater: SharedUpdater<EndRetrospectiveMutation
 
 const EndRetrospectiveMutation: StandardMutation<
   TEndRetrospectiveMutation,
-  HistoryMaybeLocalHandler
-> = (atmosphere, variables, {onError, onCompleted, history}) => {
+  NavigateMaybeLocalHandler
+> = (atmosphere, variables, {onError, onCompleted, navigate}) => {
   return commitMutation<TEndRetrospectiveMutation>(atmosphere, {
     mutation,
     variables,
@@ -140,7 +140,7 @@ const EndRetrospectiveMutation: StandardMutation<
       }
       endRetrospectiveTeamOnNext(res.endRetrospective as any, {
         atmosphere,
-        history
+        navigate
       })
     },
     onError

--- a/packages/client/mutations/EndSprintPokerMutation.ts
+++ b/packages/client/mutations/EndSprintPokerMutation.ts
@@ -5,9 +5,9 @@ import type {EndSprintPokerMutation_team$data} from '~/__generated__/EndSprintPo
 import onMeetingRoute from '~/utils/onMeetingRoute'
 import type {EndSprintPokerMutation as TEndSprintPokerMutation} from '../__generated__/EndSprintPokerMutation.graphql'
 import type {
-  HistoryMaybeLocalHandler,
+  NavigateMaybeLocalHandler,
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -71,19 +71,19 @@ const mutation = graphql`
 
 export const endSprintPokerTeamOnNext: OnNextHandler<
   EndSprintPokerMutation_team$data,
-  OnNextHistoryContext
+  OnNextNavigateContext
 > = (payload, context) => {
   const {isKill, meeting} = payload
-  const {atmosphere, history} = context
+  const {atmosphere, navigate} = context
   if (!meeting) return
   const {id: meetingId, teamId, summaryPageId} = meeting
   if (onMeetingRoute(window.location.pathname, [meetingId])) {
     if (isKill) {
-      history.push(`/team/${teamId}`)
+      navigate(`/team/${teamId}`)
       popEndMeetingToast(atmosphere, meetingId)
     } else if (summaryPageId) {
       const pageCode = GQLID.fromKey(summaryPageId)[0]
-      history.push(`/pages/${pageCode}`)
+      navigate(`/pages/${pageCode}`)
     }
   }
 }
@@ -102,8 +102,8 @@ export const endSprintPokerTeamUpdater: SharedUpdater<EndSprintPokerMutation_tea
 
 const EndSprintPokerMutation: StandardMutation<
   TEndSprintPokerMutation,
-  HistoryMaybeLocalHandler
-> = (atmosphere, variables, {onError, onCompleted, history}) => {
+  NavigateMaybeLocalHandler
+> = (atmosphere, variables, {onError, onCompleted, navigate}) => {
   return commitMutation<TEndSprintPokerMutation>(atmosphere, {
     mutation,
     variables,
@@ -119,7 +119,7 @@ const EndSprintPokerMutation: StandardMutation<
       }
       endSprintPokerTeamOnNext(res.endSprintPoker as any, {
         atmosphere,
-        history
+        navigate
       })
     },
     onError

--- a/packages/client/mutations/EndTeamPromptMutation.ts
+++ b/packages/client/mutations/EndTeamPromptMutation.ts
@@ -5,9 +5,9 @@ import type {EndTeamPromptMutation_team$data} from '~/__generated__/EndTeamPromp
 import onMeetingRoute from '~/utils/onMeetingRoute'
 import type {EndTeamPromptMutation as TEndTeamPromptMutation} from '../__generated__/EndTeamPromptMutation.graphql'
 import type {
-  HistoryMaybeLocalHandler,
+  NavigateMaybeLocalHandler,
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -62,16 +62,16 @@ const mutation = graphql`
 
 export const endTeamPromptTeamOnNext: OnNextHandler<
   EndTeamPromptMutation_team$data,
-  OnNextHistoryContext
+  OnNextNavigateContext
 > = (payload, context) => {
   const {meeting} = payload
-  const {history} = context
+  const {navigate} = context
   if (!meeting) return
   const {id: meetingId, summaryPageId} = meeting
   if (onMeetingRoute(window.location.pathname, [meetingId])) {
     if (summaryPageId) {
       const pageCode = GQLID.fromKey(summaryPageId)[0]
-      history.push(`/pages/${pageCode}`)
+      navigate(`/pages/${pageCode}`)
     }
   }
 }
@@ -85,10 +85,10 @@ export const endTeamPromptTeamUpdater: SharedUpdater<EndTeamPromptMutation_team$
   handleAddTimelineEvent(meeting, timelineEvent, store)
 }
 
-const EndTeamPromptMutation: StandardMutation<TEndTeamPromptMutation, HistoryMaybeLocalHandler> = (
+const EndTeamPromptMutation: StandardMutation<TEndTeamPromptMutation, NavigateMaybeLocalHandler> = (
   atmosphere,
   variables,
-  {onError, onCompleted, history}
+  {onError, onCompleted, navigate}
 ) => {
   return commitMutation<TEndTeamPromptMutation>(atmosphere, {
     mutation,
@@ -105,7 +105,7 @@ const EndTeamPromptMutation: StandardMutation<TEndTeamPromptMutation, HistoryMay
       }
       endTeamPromptTeamOnNext(res.endTeamPrompt as any, {
         atmosphere,
-        history
+        navigate
       })
     },
     onError

--- a/packages/client/mutations/InviteToTeamMutation.ts
+++ b/packages/client/mutations/InviteToTeamMutation.ts
@@ -6,7 +6,7 @@ import type {InviteToTeamMutation_notification$data} from '../__generated__/Invi
 import type {
   LocalHandlers,
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -49,7 +49,7 @@ const mutation = graphql`
 
 const popInvitationReceivedToast = (
   notification: InviteToTeamMutation_notification$data['teamInvitationNotification'] | null,
-  {atmosphere, history}: OnNextHistoryContext
+  {atmosphere, navigate}: OnNextNavigateContext
 ) => {
   if (!notification) return
   const {
@@ -67,7 +67,7 @@ const popInvitationReceivedToast = (
     action: {
       label: 'Accept!',
       callback: () => {
-        AcceptTeamInvitationMutation(atmosphere, {invitationToken, notificationId}, {history})
+        AcceptTeamInvitationMutation(atmosphere, {invitationToken, notificationId}, {navigate})
       }
     }
   })
@@ -82,8 +82,8 @@ export const inviteToTeamNotificationUpdater: SharedUpdater<
 
 export const inviteToTeamNotificationOnNext: OnNextHandler<
   InviteToTeamMutation_notification$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
   const {teamInvitationNotification} = payload
   if (!teamInvitationNotification) return
   const isWaiting = !!matchPath(window.location.pathname, {
@@ -97,12 +97,12 @@ export const inviteToTeamNotificationOnNext: OnNextHandler<
     AcceptTeamInvitationMutation(
       atmosphere,
       {invitationToken, notificationId},
-      {history, meetingId}
+      {navigate, meetingId}
     )
   } else {
     popInvitationReceivedToast(teamInvitationNotification, {
       atmosphere,
-      history
+      navigate
     })
   }
 }

--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {handleSuccessfulLogin} from '~/utils/handleSuccessfulLogin'
 import type {LoginWithGoogleMutation as TLoginWithGoogleMutation} from '../__generated__/LoginWithGoogleMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 import {handleAcceptTeamInvitationErrors} from './AcceptTeamInvitationMutation'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
 
@@ -32,10 +32,10 @@ const mutation = graphql`
     }
   }
 `
-const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, HistoryLocalHandler> = (
+const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, NavigateLocalHandler> = (
   atmosphere,
   variables,
-  {onError, onCompleted, history}
+  {onError, onCompleted, navigate}
 ) => {
   return commitMutation<TLoginWithGoogleMutation>(atmosphere, {
     mutation,
@@ -52,7 +52,7 @@ const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, Histor
 
         handleAuthenticationRedirect(acceptTeamInvitation, {
           atmosphere,
-          history,
+          navigate,
           redirectPath
         })
       }

--- a/packages/client/mutations/LoginWithMicrosoftMutation.ts
+++ b/packages/client/mutations/LoginWithMicrosoftMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {handleSuccessfulLogin} from '~/utils/handleSuccessfulLogin'
 import type {LoginWithMicrosoftMutation as TLoginWithMicrosoftMutation} from '../__generated__/LoginWithMicrosoftMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 import {handleAcceptTeamInvitationErrors} from './AcceptTeamInvitationMutation'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
 
@@ -34,8 +34,8 @@ const mutation = graphql`
 `
 const LoginWithMicrosoftMutation: StandardMutation<
   TLoginWithMicrosoftMutation,
-  HistoryLocalHandler
-> = (atmosphere, variables, {onError, onCompleted, history}) => {
+  NavigateLocalHandler
+> = (atmosphere, variables, {onError, onCompleted, navigate}) => {
   return commitMutation<TLoginWithMicrosoftMutation>(atmosphere, {
     mutation,
     variables: {...variables, isInvitation: !!variables.invitationToken},
@@ -49,7 +49,7 @@ const LoginWithMicrosoftMutation: StandardMutation<
         handleSuccessfulLogin(atmosphere, loginWithMicrosoft)
         handleAuthenticationRedirect(acceptTeamInvitation, {
           atmosphere,
-          history
+          navigate
         })
       }
     }

--- a/packages/client/mutations/LoginWithPasswordMutation.ts
+++ b/packages/client/mutations/LoginWithPasswordMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {handleSuccessfulLogin} from '~/utils/handleSuccessfulLogin'
 import type {LoginWithPasswordMutation as TLoginWithPasswordMutation} from '../__generated__/LoginWithPasswordMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 import {handleAcceptTeamInvitationErrors} from './AcceptTeamInvitationMutation'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
 
@@ -27,8 +27,8 @@ const mutation = graphql`
 
 const LoginWithPasswordMutation: StandardMutation<
   TLoginWithPasswordMutation,
-  HistoryLocalHandler
-> = (atmosphere, variables, {onError, onCompleted, history}) => {
+  NavigateLocalHandler
+> = (atmosphere, variables, {onError, onCompleted, navigate}) => {
   return commitMutation<TLoginWithPasswordMutation>(atmosphere, {
     mutation,
     variables,
@@ -42,7 +42,7 @@ const LoginWithPasswordMutation: StandardMutation<
         handleSuccessfulLogin(atmosphere, loginWithPassword)
         handleAuthenticationRedirect(acceptTeamInvitation, {
           atmosphere,
-          history
+          navigate
         })
       }
     }

--- a/packages/client/mutations/RemoveOrgUsersMutation.ts
+++ b/packages/client/mutations/RemoveOrgUsersMutation.ts
@@ -7,9 +7,9 @@ import type {RemoveOrgUsersMutation_notification$data} from '../__generated__/Re
 import type {RemoveOrgUsersMutation_task$data} from '../__generated__/RemoveOrgUsersMutation_task.graphql'
 import type {RemoveOrgUsersMutation_team$data} from '../__generated__/RemoveOrgUsersMutation_team.graphql'
 import type {
-  HistoryLocalHandler,
+  NavigateLocalHandler,
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -179,26 +179,26 @@ export const removeOrgUsersTeamOnNext: OnNextHandler<RemoveOrgUsersMutation_team
 
 export const removeOrgUsersOrganizationOnNext: OnNextHandler<
   RemoveOrgUsersMutation_organization$data,
-  OnNextHistoryContext
+  OnNextNavigateContext
 > = (payload, context) => {
   const {
     atmosphere: {viewerId},
-    history
+    navigate
   } = context
-  const {pathname} = history.location
+  const {pathname} = window.location
   const {removedUserIds, affectedOrganizationId} = payload
   if (
     removedUserIds.some((removedUserId) => removedUserId === viewerId) &&
     onExOrgRoute(pathname, affectedOrganizationId)
   ) {
-    history.push('/meetings')
+    navigate('/meetings')
   }
 }
 
 export const removeOrgUsersNotificationOnNext: OnNextHandler<
   RemoveOrgUsersMutation_notification$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
   if (!payload) return
   const {
     affectedOrganizationId,
@@ -217,11 +217,11 @@ export const removeOrgUsersNotificationOnNext: OnNextHandler<
     })
 
     if (onMeetingRoute(window.location.pathname, affectedMeetingIds)) {
-      history.push('/meetings')
+      navigate('/meetings')
       return
     }
     if (affectedTeamIds.some((teamId) => onTeamRoute(window.location.pathname, teamId))) {
-      history.push('/meetings')
+      navigate('/meetings')
       return
     }
   } else {
@@ -234,10 +234,10 @@ export const removeOrgUsersNotificationOnNext: OnNextHandler<
   }
 }
 
-const RemoveOrgUsersMutation: StandardMutation<TRemoveOrgUsersMutation, HistoryLocalHandler> = (
+const RemoveOrgUsersMutation: StandardMutation<TRemoveOrgUsersMutation, NavigateLocalHandler> = (
   atmosphere,
   variables,
-  {history, onError, onCompleted}
+  {navigate, onError, onCompleted}
 ) => {
   return commitMutation<TRemoveOrgUsersMutation>(atmosphere, {
     mutation,
@@ -260,11 +260,11 @@ const RemoveOrgUsersMutation: StandardMutation<TRemoveOrgUsersMutation, HistoryL
       if (!payload || payload.error) return
 
       removeOrgUsersOrganizationOnNext(payload as any, {
-        history,
+        navigate,
         atmosphere
       })
       removeOrgUsersTeamOnNext(payload as any, {atmosphere})
-      removeOrgUsersNotificationOnNext(payload as any, {atmosphere, history})
+      removeOrgUsersNotificationOnNext(payload as any, {atmosphere, navigate})
     },
     onError
   })

--- a/packages/client/mutations/RemoveTeamMemberMutation.ts
+++ b/packages/client/mutations/RemoveTeamMemberMutation.ts
@@ -6,7 +6,7 @@ import type {RemoveTeamMemberMutation_task$data} from '../__generated__/RemoveTe
 import type {RemoveTeamMemberMutation_team$data} from '../__generated__/RemoveTeamMemberMutation_team.graphql'
 import type {
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   SimpleMutation
 } from '../types/relayMutations'
@@ -110,8 +110,8 @@ const mutation = graphql`
 
 export const removeTeamMemberNotificationOnNext: OnNextHandler<
   RemoveTeamMemberMutation_notification$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
   if (!payload) return
   const {kickOutNotification} = payload
   if (!kickOutNotification) return
@@ -141,7 +141,7 @@ export const removeTeamMemberNotificationOnNext: OnNextHandler<
     onTeamRoute(window.location.pathname, teamId) ||
     onMeetingRoute(window.location.pathname, meetingIds)
   ) {
-    history.push('/meetings')
+    navigate('/meetings')
   }
 }
 

--- a/packages/client/mutations/ResetPasswordMutation.ts
+++ b/packages/client/mutations/ResetPasswordMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import getValidRedirectParam from '~/utils/getValidRedirectParam'
 import type {ResetPasswordMutation as TResetPasswordMutation} from '../__generated__/ResetPasswordMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 
 const mutation = graphql`
   mutation ResetPasswordMutation($newPassword: String!, $token: ID!) {
@@ -17,10 +17,10 @@ const mutation = graphql`
     }
   }
 `
-const ResetPasswordMutation: StandardMutation<TResetPasswordMutation, HistoryLocalHandler> = (
+const ResetPasswordMutation: StandardMutation<TResetPasswordMutation, NavigateLocalHandler> = (
   atmosphere,
   variables,
-  {onError, onCompleted, history}
+  {onError, onCompleted, navigate}
 ) => {
   return commitMutation<TResetPasswordMutation>(atmosphere, {
     mutation,
@@ -32,7 +32,7 @@ const ResetPasswordMutation: StandardMutation<TResetPasswordMutation, HistoryLoc
       onCompleted(res, errors)
       if (!uiError && !errors) {
         const nextUrl = getValidRedirectParam() || '/meetings'
-        history.push(nextUrl)
+        navigate(nextUrl)
       }
     }
   })

--- a/packages/client/mutations/SetOrgUserRoleMutation.ts
+++ b/packages/client/mutations/SetOrgUserRoleMutation.ts
@@ -4,7 +4,7 @@ import type {SetOrgUserRoleMutation as TSetOrgUserRoleMutation} from '../__gener
 import type {SetOrgUserRoleMutation_organization$data} from '../__generated__/SetOrgUserRoleMutation_organization.graphql'
 import type {
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   SharedUpdater,
   StandardMutation
 } from '../types/relayMutations'
@@ -45,8 +45,8 @@ const mutation = graphql`
 
 export const setOrgUserRoleAddedOrganizationOnNext: OnNextHandler<
   SetOrgUserRoleMutation_organization$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
   if (!payload || !payload.organization || !payload.notificationsAdded?.length) return
   const {id: orgId, name: orgName} = payload.organization
   atmosphere.eventEmitter.emit('addSnackbar', {
@@ -56,7 +56,7 @@ export const setOrgUserRoleAddedOrganizationOnNext: OnNextHandler<
     action: {
       label: 'Check it out!',
       callback: () => {
-        history && history.push(`/me/organizations/${orgId}/members`)
+        navigate?.(`/me/organizations/${orgId}/members`)
       }
     }
   })

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {handleSuccessfulLogin} from '~/utils/handleSuccessfulLogin'
 import type {SignUpWithPasswordMutation as TSignUpWithPasswordMutation} from '../__generated__/SignUpWithPasswordMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 import {handleAcceptTeamInvitationErrors} from './AcceptTeamInvitationMutation'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
 
@@ -34,8 +34,8 @@ const mutation = graphql`
 `
 const SignUpWithPasswordMutation: StandardMutation<
   TSignUpWithPasswordMutation,
-  HistoryLocalHandler
-> = (atmosphere, variables, {onError, onCompleted, history}) => {
+  NavigateLocalHandler
+> = (atmosphere, variables, {onError, onCompleted, navigate}) => {
   return commitMutation<TSignUpWithPasswordMutation>(atmosphere, {
     mutation,
     variables: {...variables, isInvitation: !!variables.invitationToken},
@@ -51,7 +51,7 @@ const SignUpWithPasswordMutation: StandardMutation<
 
         handleAuthenticationRedirect(acceptTeamInvitation, {
           atmosphere,
-          history,
+          navigate,
           redirectPath
         })
       }

--- a/packages/client/mutations/StartCheckInMutation.ts
+++ b/packages/client/mutations/StartCheckInMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import type {StartCheckInMutation as TStartCheckInMutation} from '../__generated__/StartCheckInMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 
 graphql`
   fragment StartCheckInMutation_team on StartCheckInSuccess {
@@ -28,10 +28,10 @@ const mutation = graphql`
   }
 `
 
-const StartCheckInMutation: StandardMutation<TStartCheckInMutation, HistoryLocalHandler> = (
+const StartCheckInMutation: StandardMutation<TStartCheckInMutation, NavigateLocalHandler> = (
   atmosphere,
   variables,
-  {history, onError, onCompleted}
+  {navigate, onError, onCompleted}
 ) => {
   return commitMutation<TStartCheckInMutation>(atmosphere, {
     mutation,
@@ -51,7 +51,7 @@ const StartCheckInMutation: StandardMutation<TStartCheckInMutation, HistoryLocal
           message: `Sorry, we couldn't create your Google Calendar event`
         })
       }
-      history.push(`/meet/${meetingId}`)
+      navigate(`/meet/${meetingId}`)
     }
   })
 }

--- a/packages/client/mutations/StartRetrospectiveMutation.ts
+++ b/packages/client/mutations/StartRetrospectiveMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import type {StartRetrospectiveMutation as TStartRetrospectiveMutation} from '../__generated__/StartRetrospectiveMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 
 graphql`
   fragment StartRetrospectiveMutation_team on StartRetrospectiveSuccess {
@@ -42,8 +42,8 @@ const mutation = graphql`
 
 const StartRetrospectiveMutation: StandardMutation<
   TStartRetrospectiveMutation,
-  HistoryLocalHandler
-> = (atmosphere, variables, {history, onError, onCompleted}) => {
+  NavigateLocalHandler
+> = (atmosphere, variables, {navigate, onError, onCompleted}) => {
   return commitMutation<TStartRetrospectiveMutation>(atmosphere, {
     mutation,
     variables,
@@ -62,7 +62,7 @@ const StartRetrospectiveMutation: StandardMutation<
           message: `Sorry, we couldn't create your Google Calendar event`
         })
       }
-      history.push(`/meet/${meetingId}`)
+      navigate(`/meet/${meetingId}`)
     }
   })
 }

--- a/packages/client/mutations/StartSprintPokerMutation.ts
+++ b/packages/client/mutations/StartSprintPokerMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import type {StartSprintPokerMutation as TStartSprintPokerMutation} from '../__generated__/StartSprintPokerMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 
 graphql`
   fragment StartSprintPokerMutation_team on StartSprintPokerSuccess {
@@ -28,11 +28,10 @@ const mutation = graphql`
   }
 `
 
-const StartSprintPokerMutation: StandardMutation<TStartSprintPokerMutation, HistoryLocalHandler> = (
-  atmosphere,
-  variables,
-  {history, onError, onCompleted}
-) => {
+const StartSprintPokerMutation: StandardMutation<
+  TStartSprintPokerMutation,
+  NavigateLocalHandler
+> = (atmosphere, variables, {navigate, onError, onCompleted}) => {
   return commitMutation<TStartSprintPokerMutation>(atmosphere, {
     mutation,
     variables,
@@ -51,7 +50,7 @@ const StartSprintPokerMutation: StandardMutation<TStartSprintPokerMutation, Hist
           message: `Sorry, we couldn't create your Google Calendar event`
         })
       }
-      history.push(`/meet/${meetingId}`)
+      navigate(`/meet/${meetingId}`)
     }
   })
 }

--- a/packages/client/mutations/StartTeamPromptMutation.ts
+++ b/packages/client/mutations/StartTeamPromptMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import type {StartTeamPromptMutation as TStartTeamPromptMutation} from '../__generated__/StartTeamPromptMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 
 graphql`
   fragment StartTeamPromptMutation_team on StartTeamPromptSuccess {
@@ -34,10 +34,10 @@ const mutation = graphql`
   }
 `
 
-const StartTeamPromptMutation: StandardMutation<TStartTeamPromptMutation, HistoryLocalHandler> = (
+const StartTeamPromptMutation: StandardMutation<TStartTeamPromptMutation, NavigateLocalHandler> = (
   atmosphere,
   variables,
-  {history, onError, onCompleted}
+  {navigate, onError, onCompleted}
 ) => {
   return commitMutation<TStartTeamPromptMutation>(atmosphere, {
     mutation,
@@ -56,7 +56,7 @@ const StartTeamPromptMutation: StandardMutation<TStartTeamPromptMutation, Histor
           message: `Sorry, we couldn't create your Google Calendar event`
         })
       }
-      history.push(`/meet/${meetingId}`)
+      navigate(`/meet/${meetingId}`)
     },
     onError
   })

--- a/packages/client/mutations/UpdateTaskMutation.ts
+++ b/packages/client/mutations/UpdateTaskMutation.ts
@@ -7,7 +7,7 @@ import {getTagsFromTipTapTask} from '../shared/tiptap/getTagsFromTipTapTask'
 import {serverTipTapExtensions} from '../shared/tiptap/serverTipTapExtensions'
 import type {
   OnNextHandler,
-  OnNextHistoryContext,
+  OnNextNavigateContext,
   OptionalHandlers,
   SharedUpdater,
   StandardMutation
@@ -57,10 +57,10 @@ const mutation = graphql`
 
 export const updateTaskTaskOnNext: OnNextHandler<
   UpdateTaskMutation_task$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
   if (!payload || !payload.addedNotification) return
-  popInvolvementToast(payload.addedNotification, {atmosphere, history})
+  popInvolvementToast(payload.addedNotification, {atmosphere, navigate})
 }
 
 export const updateTaskTaskUpdater: SharedUpdater<UpdateTaskMutation_task$data> = (

--- a/packages/client/mutations/VerifyEmailMutation.ts
+++ b/packages/client/mutations/VerifyEmailMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {handleSuccessfulLogin} from '~/utils/handleSuccessfulLogin'
 import type {VerifyEmailMutation as TSignUpWithPasswordMutation} from '../__generated__/VerifyEmailMutation.graphql'
-import type {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
+import type {NavigateLocalHandler, StandardMutation} from '../types/relayMutations'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
 
 const mutation = graphql`
@@ -22,10 +22,10 @@ const mutation = graphql`
     }
   }
 `
-const VerifyEmailMutation: StandardMutation<TSignUpWithPasswordMutation, HistoryLocalHandler> = (
+const VerifyEmailMutation: StandardMutation<TSignUpWithPasswordMutation, NavigateLocalHandler> = (
   atmosphere,
   variables,
-  {onError, onCompleted, history}
+  {onError, onCompleted, navigate}
 ) => {
   return commitMutation<TSignUpWithPasswordMutation>(atmosphere, {
     mutation,
@@ -40,7 +40,7 @@ const VerifyEmailMutation: StandardMutation<TSignUpWithPasswordMutation, History
 
         handleAuthenticationRedirect(acceptTeamInvitation, {
           atmosphere,
-          history,
+          navigate,
           redirectPath
         })
       }

--- a/packages/client/mutations/handlers/handleAuthenticationRedirect.ts
+++ b/packages/client/mutations/handlers/handleAuthenticationRedirect.ts
@@ -1,9 +1,9 @@
 import type {AcceptTeamInvitationMutationReply$data} from '~/__generated__/AcceptTeamInvitationMutationReply.graphql'
-import type {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextHandler, OnNextNavigateContext} from '../../types/relayMutations'
 import getValidRedirectParam from '../../utils/getValidRedirectParam'
 import SendClientSideEvent from '../../utils/SendClientSideEvent'
 
-interface OnNextMeetingId extends OnNextHistoryContext {
+interface OnNextMeetingId extends OnNextNavigateContext {
   meetingId?: string | null
   redirectPath?: string
 }
@@ -13,16 +13,16 @@ const handleAuthenticationRedirect: OnNextHandler<
   OnNextMeetingId
 > = (
   acceptTeamInvitation,
-  {meetingId: locallyRequestedMeetingId, history, atmosphere, redirectPath = '/meetings'}
+  {meetingId: locallyRequestedMeetingId, navigate, atmosphere, redirectPath = '/meetings'}
 ) => {
   SendClientSideEvent(atmosphere, 'User Login')
   const redirectTo = getValidRedirectParam()
   if (redirectTo) {
-    history.push(redirectTo)
+    navigate(redirectTo)
     return
   }
   if (!acceptTeamInvitation?.team) {
-    history.push(redirectPath)
+    navigate(redirectPath)
     return
   }
   const {meetingId: invitedMeetingId, team} = acceptTeamInvitation
@@ -31,9 +31,9 @@ const handleAuthenticationRedirect: OnNextHandler<
   const activeMeeting =
     (meetingId && activeMeetings.find((meeting) => meeting.id === meetingId)) || activeMeetings[0]
   if (activeMeeting) {
-    history.push(`/meet/${activeMeeting.id}`)
+    navigate(`/meet/${activeMeeting.id}`)
   } else {
-    history.push(`/team/${teamId}`)
+    navigate(`/team/${teamId}`)
   }
 }
 export default handleAuthenticationRedirect

--- a/packages/client/mutations/toasts/mapDiscussionMentionedToToast.ts
+++ b/packages/client/mutations/toasts/mapDiscussionMentionedToToast.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import type {mapDiscussionMentionedToToast_notification$data} from '../../__generated__/mapDiscussionMentionedToToast_notification.graphql'
 import type {Snack} from '../../components/Snackbar'
-import type {OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextNavigateContext} from '../../types/relayMutations'
 import findStageById from '../../utils/meetings/findStageById'
 import fromStageIdToUrl from '../../utils/meetings/fromStageIdToUrl'
 import getMeetingPathParams from '../../utils/meetings/getMeetingPathParams'
@@ -42,7 +42,7 @@ graphql`
 
 const mapDiscussionMentionedToToast = (
   notification: mapDiscussionMentionedToToast_notification$data,
-  {history}: OnNextHistoryContext
+  {navigate}: OnNextNavigateContext
 ): Snack | null => {
   if (!notification) return null
   const {id: notificationId, meeting, author, discussion} = notification
@@ -72,7 +72,7 @@ const mapDiscussionMentionedToToast = (
     action: {
       label: 'See the discussion',
       callback: () => {
-        history.push(
+        navigate(
           response ? `${directUrl}?responseId=${encodeURIComponent(response.id)}` : directUrl
         )
       }

--- a/packages/client/mutations/toasts/mapMentionedToToast.ts
+++ b/packages/client/mutations/toasts/mapMentionedToToast.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import type {mapMentionedToToast_notification$data} from '../../__generated__/mapMentionedToToast_notification.graphql'
 import type {Snack} from '../../components/Snackbar'
-import type {OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextNavigateContext} from '../../types/relayMutations'
 import SendClientSideEvent from '../../utils/SendClientSideEvent'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
@@ -20,7 +20,7 @@ graphql`
 
 const mapMentionedToToast = (
   notification: mapMentionedToToast_notification$data,
-  {atmosphere, history}: OnNextHistoryContext
+  {atmosphere, navigate}: OnNextNavigateContext
 ): Snack | null => {
   if (!notification) return null
   const {
@@ -52,7 +52,7 @@ const mapMentionedToToast = (
   const message = `${authorName} mentioned you in ${locationType} in ${meetingName}`
 
   const goThere = () => {
-    history.push(actionUrl)
+    navigate(actionUrl)
   }
 
   return {

--- a/packages/client/mutations/toasts/mapPromptToJoinOrgToToast.ts
+++ b/packages/client/mutations/toasts/mapPromptToJoinOrgToToast.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import type {mapPromptToJoinOrgToToast_notification$data} from '../../__generated__/mapPromptToJoinOrgToToast_notification.graphql'
 import type {Snack} from '../../components/Snackbar'
-import type {OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextNavigateContext} from '../../types/relayMutations'
 import SendClientSideEvent from '../../utils/SendClientSideEvent'
 import RequestToJoinDomainMutation from '../RequestToJoinDomainMutation'
 import makeNotificationToastKey from './makeNotificationToastKey'
@@ -15,7 +15,7 @@ graphql`
 
 const mapPromptToJoinOrgToToast = (
   notification: mapPromptToJoinOrgToToast_notification$data,
-  {atmosphere}: OnNextHistoryContext
+  {atmosphere}: OnNextNavigateContext
 ): Snack => {
   const {id: notificationId, activeDomain} = notification
 

--- a/packages/client/mutations/toasts/mapRequestToJoinOrgToToast.ts
+++ b/packages/client/mutations/toasts/mapRequestToJoinOrgToToast.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import type {mapRequestToJoinOrgToToast_notification$data} from '../../__generated__/mapRequestToJoinOrgToToast_notification.graphql'
 import type {Snack} from '../../components/Snackbar'
-import type {OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextNavigateContext} from '../../types/relayMutations'
 import SendClientSideEvent from '../../utils/SendClientSideEvent'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
@@ -17,7 +17,7 @@ graphql`
 
 const mapRequestToJoinOrgToToast = (
   notification: mapRequestToJoinOrgToToast_notification$data,
-  {atmosphere, history}: OnNextHistoryContext
+  {atmosphere, navigate}: OnNextNavigateContext
 ): Snack => {
   const {id: notificationId, email, domainJoinRequestId} = notification
 
@@ -34,8 +34,8 @@ const mapRequestToJoinOrgToToast = (
     action: {
       label: 'Review',
       callback: () => {
-        history.push(`/organization-join-request/${domainJoinRequestId}`, {
-          backgroundLocation: history.location
+        navigate(`/organization-join-request/${domainJoinRequestId}`, {
+          state: {backgroundLocation: window.location}
         })
       }
     },

--- a/packages/client/mutations/toasts/mapResponseMentionedToToast.ts
+++ b/packages/client/mutations/toasts/mapResponseMentionedToToast.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import type {mapResponseMentionedToToast_notification$data} from '../../__generated__/mapResponseMentionedToToast_notification.graphql'
 import type {Snack} from '../../components/Snackbar'
-import type {OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextNavigateContext} from '../../types/relayMutations'
 import SendClientSideEvent from '../../utils/SendClientSideEvent'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
@@ -23,7 +23,7 @@ graphql`
 
 const mapResponseMentionedToToast = (
   notification: mapResponseMentionedToToast_notification$data,
-  {atmosphere, history}: OnNextHistoryContext
+  {atmosphere, navigate}: OnNextNavigateContext
 ): Snack | null => {
   if (!notification) return null
   const {id: notificationId, meeting, response} = notification
@@ -42,7 +42,7 @@ const mapResponseMentionedToToast = (
     action: {
       label: 'See their response',
       callback: () => {
-        history.push(`/meet/${meetingId}/responses?responseId=${encodeURIComponent(response.id)}`)
+        navigate(`/meet/${meetingId}/responses?responseId=${encodeURIComponent(response.id)}`)
       }
     },
     onShow: () => {

--- a/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
+++ b/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import type {mapResponseRepliedToToast_notification$data} from '../../__generated__/mapResponseRepliedToToast_notification.graphql'
 import type {Snack} from '../../components/Snackbar'
-import type {OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextNavigateContext} from '../../types/relayMutations'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
 graphql`
@@ -23,7 +23,7 @@ graphql`
 
 const mapResponseRepliedToToast = (
   notification: mapResponseRepliedToToast_notification$data,
-  {history}: OnNextHistoryContext
+  {navigate}: OnNextNavigateContext
 ): Snack | null => {
   if (!notification) return null
   const {id: notificationId, meeting, author, response} = notification
@@ -40,7 +40,7 @@ const mapResponseRepliedToToast = (
     action: {
       label: 'See the discussion',
       callback: () => {
-        history.push(`/meet/${meetingId}/responses?responseId=${encodeURIComponent(response.id)}`)
+        navigate(`/meet/${meetingId}/responses?responseId=${encodeURIComponent(response.id)}`)
       }
     }
   }

--- a/packages/client/mutations/toasts/mapTeamsLimitReminderToToast.ts
+++ b/packages/client/mutations/toasts/mapTeamsLimitReminderToToast.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import type {mapTeamsLimitReminderToToast_notification$data} from '../../__generated__/mapTeamsLimitReminderToToast_notification.graphql'
 import type {Snack} from '../../components/Snackbar'
 import {Threshold} from '../../types/constEnums'
-import type {OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextNavigateContext} from '../../types/relayMutations'
 import makeDateString from '../../utils/makeDateString'
 import SendClientSideEvent from '../../utils/SendClientSideEvent'
 import makeNotificationToastKey from './makeNotificationToastKey'
@@ -18,7 +18,7 @@ graphql`
 
 const mapTeamsLimitReminderToToast = (
   notification: mapTeamsLimitReminderToToast_notification$data,
-  {history, atmosphere}: OnNextHistoryContext
+  {navigate, atmosphere}: OnNextNavigateContext
 ): Snack => {
   const {id: notificationId, scheduledLockAt, orgId, orgName} = notification
 
@@ -46,7 +46,7 @@ const mapTeamsLimitReminderToToast = (
         SendClientSideEvent(atmosphere, 'Upgrade CTA Clicked', {
           upgradeCTALocation: 'teamsLimitReminderSnackbar'
         })
-        history.push(`/me/organizations/${orgId}`)
+        navigate(`/me/organizations/${orgId}`)
       }
     }
   }

--- a/packages/client/mutations/toasts/popInvolvementToast.ts
+++ b/packages/client/mutations/toasts/popInvolvementToast.ts
@@ -1,11 +1,11 @@
 import {matchPath} from 'react-router-dom'
 import type {TaskInvolves_notification$data} from '../../__generated__/TaskInvolves_notification.graphql'
-import type {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextHandler, OnNextNavigateContext} from '../../types/relayMutations'
 import {MENTIONEE} from '../../utils/constants'
 
-const popInvolvementToast: OnNextHandler<TaskInvolves_notification$data, OnNextHistoryContext> = (
+const popInvolvementToast: OnNextHandler<TaskInvolves_notification$data, OnNextNavigateContext> = (
   notification,
-  {atmosphere, history}
+  {atmosphere, navigate}
 ) => {
   if (!notification) return
   const {
@@ -36,7 +36,7 @@ const popInvolvementToast: OnNextHandler<TaskInvolves_notification$data, OnNextH
     action: {
       label: 'Check it out!',
       callback: () => {
-        history?.push(`/team/${teamId}`)
+        navigate?.(`/team/${teamId}`)
       }
     }
   })

--- a/packages/client/mutations/toasts/popNotificationToast.ts
+++ b/packages/client/mutations/toasts/popNotificationToast.ts
@@ -4,7 +4,7 @@ import type {
   popNotificationToast_notification$data
 } from '../../__generated__/popNotificationToast_notification.graphql'
 import type {Snack} from '../../components/Snackbar'
-import type {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextHandler, OnNextNavigateContext} from '../../types/relayMutations'
 import SetNotificationStatusMutation from '../SetNotificationStatusMutation'
 import mapDiscussionMentionedToToast from './mapDiscussionMentionedToToast'
 import mapMentionedToToast from './mapMentionedToToast'
@@ -15,7 +15,7 @@ import mapResponseRepliedToToast from './mapResponseRepliedToToast'
 import mapTeamsLimitReminderToToast from './mapTeamsLimitReminderToToast'
 
 const typePicker: Partial<
-  Record<NotificationEnum, (notification: any, context: OnNextHistoryContext) => Snack | null>
+  Record<NotificationEnum, (notification: any, context: OnNextNavigateContext) => Snack | null>
 > = {
   DISCUSSION_MENTIONED: mapDiscussionMentionedToToast,
   RESPONSE_MENTIONED: mapResponseMentionedToToast,
@@ -44,8 +44,8 @@ graphql`
 
 export const popNotificationToastOnNext: OnNextHandler<
   popNotificationToast_notification$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
   const {addedNotification} = payload
   const {type} = addedNotification
   const specificNotificationToastMapper = typePicker[type]
@@ -55,7 +55,7 @@ export const popNotificationToastOnNext: OnNextHandler<
 
   const notificationSnack = specificNotificationToastMapper(addedNotification, {
     atmosphere,
-    history
+    navigate
   })
 
   if (!notificationSnack) {

--- a/packages/client/mutations/toasts/updateNotificationToast.ts
+++ b/packages/client/mutations/toasts/updateNotificationToast.ts
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import type {updateNotificationToast_notification$data} from '../../__generated__/updateNotificationToast_notification.graphql'
-import type {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
+import type {OnNextHandler, OnNextNavigateContext} from '../../types/relayMutations'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
 graphql`
@@ -14,7 +14,7 @@ graphql`
 
 export const updateNotificationToastOnNext: OnNextHandler<
   updateNotificationToast_notification$data,
-  OnNextHistoryContext
+  OnNextNavigateContext
 > = (payload, {atmosphere}) => {
   const {updatedNotification} = payload
 

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -34,7 +34,7 @@ import {updateNotificationToastOnNext} from '../mutations/toasts/updateNotificat
 import {handleArchivePage} from '../mutations/useArchivePageMutation'
 import {handleCreatePage} from '../mutations/useCreatePageMutation'
 import {handleUpdatePage} from '../mutations/useUpdatePageMutation'
-import type {OnNextHandler, OnNextHistoryContext, SharedUpdater} from '../types/relayMutations'
+import type {OnNextHandler, OnNextNavigateContext, SharedUpdater} from '../types/relayMutations'
 import {createSubscription} from './createSubscription'
 
 graphql`
@@ -200,13 +200,13 @@ const subscription = graphql`
 
 type NextHandler = OnNextHandler<
   TNotificationSubscription['response']['notificationSubscription']['AuthTokenPayload'],
-  OnNextHistoryContext
+  OnNextNavigateContext
 >
 
 const stripeFailPaymentNotificationOnNext: OnNextHandler<
   NotificationSubscription_paymentRejected$data,
-  OnNextHistoryContext
-> = (payload, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload, {atmosphere, navigate}) => {
   if (!payload) return
   const {paymentRejectedNotification} = payload
   const {organization} = paymentRejectedNotification
@@ -219,7 +219,7 @@ const stripeFailPaymentNotificationOnNext: OnNextHandler<
     action: {
       label: 'Fix it!',
       callback: () => {
-        history!.push(`/me/organizations/${orgId}`)
+        navigate(`/me/organizations/${orgId}`)
       }
     }
   })
@@ -228,8 +228,8 @@ const stripeFailPaymentNotificationOnNext: OnNextHandler<
 // there's a bug in relay compiler that only shows part of the discriminated union
 const meetingStageTimeLimitOnNext: OnNextHandler<
   NotificationSubscription_meetingStageTimeLimitEnd$data,
-  OnNextHistoryContext
-> = (payload: any, {atmosphere, history}) => {
+  OnNextNavigateContext
+> = (payload: any, {atmosphere, navigate}) => {
   if (!payload || payload.__typename !== 'MeetingStageTimeLimitPayload') return
   const {timeLimitNotification} = payload
   const {meeting} = timeLimitNotification
@@ -242,7 +242,7 @@ const meetingStageTimeLimitOnNext: OnNextHandler<
     action: {
       label: 'Go there',
       callback: () => {
-        history!.push(`/meet/${meetingId}`)
+        navigate(`/meet/${meetingId}`)
       }
     }
   })
@@ -270,7 +270,7 @@ const authTokenNotificationOnNext: NextHandler = (_payload, {atmosphere}) => {
 
 const invalidateSessionsNotificationOnNext: OnNextHandler<
   InvalidateSessionsMutation_notification$data,
-  OnNextHistoryContext
+  OnNextNavigateContext
 > = (_payload, {atmosphere}) => {
   atmosphere.invalidateSession('You’ve been logged out from another device')
 }

--- a/packages/client/subscriptions/createSubscription.ts
+++ b/packages/client/subscriptions/createSubscription.ts
@@ -1,7 +1,6 @@
-import type {RouterProps} from 'react-router'
 import {ConcreteRequest, GraphQLTaggedNode, OperationType, requestSubscription} from 'relay-runtime'
 import type Atmosphere from '../Atmosphere'
-import {OnNextHandler, SharedUpdater} from '../types/relayMutations'
+import {NavigateFn, OnNextHandler, SharedUpdater} from '../types/relayMutations'
 import subscriptionOnNext from './subscriptionOnNext'
 import subscriptionUpdater from './subscriptionUpdater'
 
@@ -17,7 +16,7 @@ export const createSubscription = <TSubscription extends OperationType>(
   const namedAndRegisteredSubscription = (
     atmosphere: Atmosphere,
     variables: TSubscription['variables'],
-    router: {history: RouterProps['history']}
+    router: {navigate: NavigateFn}
   ) => {
     const fieldName = atmosphere.registerSubscription(subscription)
     return requestSubscription<TSubscription>(atmosphere, {

--- a/packages/client/subscriptions/subscriptionOnNext.ts
+++ b/packages/client/subscriptions/subscriptionOnNext.ts
@@ -1,13 +1,12 @@
-import type {RouterProps} from 'react-router'
 import type Atmosphere from '../Atmosphere'
-import type {OnNextHandler} from '../types/relayMutations'
+import type {NavigateFn, OnNextHandler} from '../types/relayMutations'
 
 const subscriptionOnNext =
   (
     subscriptionName: string,
     onNextHandlers: Record<string, OnNextHandler<any, any>>,
     atmosphere: Atmosphere,
-    router: {history: RouterProps['history']}
+    router: {navigate: NavigateFn}
   ) =>
   (result: any) => {
     if (!result) return

--- a/packages/client/types/relayMutations.ts
+++ b/packages/client/types/relayMutations.ts
@@ -1,4 +1,3 @@
-import type {RouterProps} from 'react-router'
 import type {
   commitMutation,
   MutationParameters,
@@ -6,6 +5,11 @@ import type {
   RecordSourceSelectorProxy
 } from 'relay-runtime'
 import type Atmosphere from '../Atmosphere'
+
+export type NavigateFn = (
+  to: string | Partial<{pathname: string; search: string; hash: string}>,
+  options?: {replace?: boolean; state?: any}
+) => void
 
 export type CompletedHandler<TResponse = any> = (
   response: TResponse,
@@ -18,7 +22,7 @@ export type ErrorHandler = (error: Error) => void
 export interface LocalHandlers {
   onError?: ErrorHandler
   onCompleted?: CompletedHandler
-  history?: RouterProps['history']
+  navigate?: NavigateFn
 }
 
 export interface BaseLocalHandlers {
@@ -26,12 +30,12 @@ export interface BaseLocalHandlers {
   onCompleted: CompletedHandler
 }
 
-export interface HistoryLocalHandler extends BaseLocalHandlers {
-  history: RouterProps['history']
+export interface NavigateLocalHandler extends BaseLocalHandlers {
+  navigate: NavigateFn
 }
 
-export interface HistoryMaybeLocalHandler {
-  history: RouterProps['history']
+export interface NavigateMaybeLocalHandler {
+  navigate: NavigateFn
   onError?: ErrorHandler
   onCompleted?: CompletedHandler
 }
@@ -53,8 +57,8 @@ export interface OnNextBaseContext {
   atmosphere: Atmosphere
 }
 
-export interface OnNextHistoryContext extends OnNextBaseContext {
-  history: RouterProps['history']
+export interface OnNextNavigateContext extends OnNextBaseContext {
+  navigate: NavigateFn
 }
 
 export type OnNextHandler<TSubResponse, C = OnNextBaseContext> = (

--- a/packages/client/utils/GoogleClientManager.ts
+++ b/packages/client/utils/GoogleClientManager.ts
@@ -1,9 +1,9 @@
-import type {RouterProps} from 'react-router'
 import type Atmosphere from '../Atmosphere'
 import {AUTH_DIALOG_WIDTH} from '../components/AuthenticationDialog'
 import type {MenuMutationProps} from '../hooks/useMutationProps'
 import LoginWithGoogleMutation from '../mutations/LoginWithGoogleMutation'
 import {LocalStorageKey} from '../types/constEnums'
+import type {NavigateFn} from '../types/relayMutations'
 import GoogleManager from './GoogleManager'
 import getAnonymousId from './getAnonymousId'
 import getOAuthPopupFeatures from './getOAuthPopupFeatures'
@@ -14,7 +14,7 @@ class GoogleClientManager extends GoogleManager {
   static openOAuth(
     atmosphere: Atmosphere,
     mutationProps: MenuMutationProps,
-    history: RouterProps['history'],
+    navigate: NavigateFn,
     pageParams: string,
     invitationToken?: string,
     loginHint?: string,
@@ -68,7 +68,7 @@ class GoogleClientManager extends GoogleManager {
           isInvitation: !!invitationToken,
           params: pageParams
         },
-        {onError, onCompleted: handleComplete, history}
+        {onError, onCompleted: handleComplete, navigate}
       )
       window.removeEventListener('message', handler)
     }

--- a/packages/client/utils/MicrosoftClientManager.ts
+++ b/packages/client/utils/MicrosoftClientManager.ts
@@ -1,9 +1,9 @@
-import type {RouterProps} from 'react-router'
 import type Atmosphere from '../Atmosphere'
 import {AUTH_DIALOG_WIDTH} from '../components/AuthenticationDialog'
 import type {MenuMutationProps} from '../hooks/useMutationProps'
 import LoginWithMicrosoftMutation from '../mutations/LoginWithMicrosoftMutation'
 import {LocalStorageKey} from '../types/constEnums'
+import type {NavigateFn} from '../types/relayMutations'
 import getAnonymousId from './getAnonymousId'
 import getOAuthPopupFeatures from './getOAuthPopupFeatures'
 import MicrosoftManager from './MicrosoftManager'
@@ -14,7 +14,7 @@ class MicrosoftClientManager extends MicrosoftManager {
   static openOAuth(
     atmosphere: Atmosphere,
     mutationProps: MenuMutationProps,
-    history: RouterProps['history'],
+    navigate: NavigateFn,
     pageParams: string,
     invitationToken?: string,
     loginHint?: string,
@@ -70,7 +70,7 @@ class MicrosoftClientManager extends MicrosoftManager {
           isInvitation: !!invitationToken,
           params: pageParams
         },
-        {onError, onCompleted: handleComplete, history}
+        {onError, onCompleted: handleComplete, navigate}
       )
       window.removeEventListener('message', handler)
     }


### PR DESCRIPTION
# Description

This is the final "pre-work" PR before we can flip to react-router `v6`.

This PR converts the mutation/subscription pattern from passing `RouterProps['history']` (an object with `.push()` and `.replace()` methods) to passing a `NavigateFn` (a simple function that matches React Router v6's `useNavigate()` signature), making the codebase v6-ready while still running on v5.

I'm tempted to just merge this back, but I'm going to take a pause here just so @mattkrick can stay in the loop.