### PR TITLE
fix: re-adding meeting series recurrence

### DIFF
--- a/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
+++ b/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
@@ -158,6 +158,20 @@ const updateRecurrenceSettings: MutationResolvers['updateRecurrenceSettings'] = 
     if (!rrule) {
       await stopMeetingSeries(meetingSeries)
       analytics.recurrenceStopped(viewer, meetingSeries)
+    } else if (meetingSeries.cancelledAt) {
+      // Restart a cancelled series: clear cancelledAt and update recurrenceRule atomically
+      await pg
+        .updateTable('MeetingSeries')
+        .set({cancelledAt: null, recurrenceRule: rrule.toString()})
+        .where('id', '=', meetingSeriesId)
+        .execute()
+      const nextMeetingStartDate = getNextRRuleDate(rrule)
+      await pg
+        .updateTable('NewMeeting')
+        .set({scheduledEndTime: nextMeetingStartDate})
+        .where('id', '=', meetingId)
+        .execute()
+      analytics.recurrenceStarted(viewer, meetingSeries)
     } else {
       await updateMeetingSeries(meetingSeries, rrule, dataLoader)
       analytics.recurrenceStarted(viewer, meetingSeries)


### PR DESCRIPTION
# Description

A user reported:

> I tried to edit the recurrence to change which days it occurs on, and those changes did not take effect. Then I removed the recurrence and tried to re-add it and now it does not reoccur at all. I've attempted to do this a couple of time with no effect and no error messages.
> 
> I'm about to try logging out and back in just in case that helps.

It turns out if you cancelled a series and re-added it, the existing logic would just fall through. The code had two states (active series, no series) but reality three needed to be accounted for (active series, cancelled series, no series).

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
