### PR TITLE
feat: Implement server-side validation for document IDs

### DIFF
--- a/packages/client/tiptap/providerManager.ts
+++ b/packages/client/tiptap/providerManager.ts
@@ -40,7 +40,12 @@ class ProviderManager {
       // can remove after debugging server websocket auth on hocuspocus
       token: window.document.cookie,
       onAuthenticationFailed: ({reason}) => {
-        window.indexedDB.deleteDatabase(documentName)
+        console.log('fail', reason)
+        if (reason === 'InvalidDocument') {
+          // The documentName they passed in cannot exist (DBID out of bounds)
+          window.indexedDB.deleteDatabase(documentName)
+          window.location.href = '/'
+        }
         if (reason === 'Unauthenticated') {
           this.atmosphere?.invalidateSession(reason)
         }

--- a/packages/server/hocusPocus.ts
+++ b/packages/server/hocusPocus.ts
@@ -117,8 +117,9 @@ export const hocuspocus = new Hocuspocus({
       return {userId}
     }
     const [dbId] = CipherId.fromClient(documentName)
-    if (dbId === 0) {
+    if (dbId < 1 || dbId > 2 ** 31 - 1) {
       const error = new Error(`Invalid document request from client: ${documentName}`)
+      ;(error as any).reason = 'InvalidDocument'
       logError(error, {userId, tags: {dbId, documentName}})
       throw error
     }


### PR DESCRIPTION
# Description

after a migration that fixed up pageCodes, some users who had the tab open were still on pages with the old page codes.
This redirects them in the case that the server deems that page does not exist.