### PR TITLE
fix: check template permissions when querying directly

### DIFF
--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -646,8 +646,23 @@ const User: ReqResolvers<'User'> = {
     if (!authToken.tms.find((teamId) => tms.includes(teamId))) return null
     return userOnTeam
   },
-  activity: async (_source, {activityId}, {dataLoader}) => {
+  activity: async (_source, {activityId}, {dataLoader, authToken}) => {
+    const viewerId = getUserId(authToken)
+
     const activity = await dataLoader.get('meetingTemplates').load(activityId)
+    if (authToken.rol !== 'su') {
+      if (activity?.scope === 'TEAM' && !authToken.tms.includes(activity.teamId)) {
+        return null
+      }
+      if (activity?.scope === 'ORGANIZATION') {
+        const organizationUser = await dataLoader
+          .get('organizationUsersByUserIdOrgId')
+          .load({userId: viewerId, orgId: activity.orgId})
+        if (!organizationUser) {
+          return null
+        }
+      }
+    }
     return activity || null
   },
   canAccess: async (_source, {entity, id}, {authToken, dataLoader}) => {


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

* Bob and Alice don't share an org
* Bob creates a custom template and shares the link with Alice
* before this change, Alice would see the template details, now she's redirected

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
