### PR TITLE
refactor: Remove fileStoreAsset data loader

### DIFF
--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -2,8 +2,6 @@ import DataLoader from 'dataloader'
 import {type SqlBool, sql} from 'kysely'
 import {PARABOL_AI_USER_ID} from '../../client/utils/constants'
 import type MeetingTemplate from '../database/types/MeetingTemplate'
-import type {PartialPath} from '../fileStorage/FileStoreManager'
-import getFileStoreManager from '../fileStorage/getFileStoreManager'
 import isValid from '../graphql/isValid'
 import type {ReactableEnum} from '../graphql/public/resolverTypes'
 import type {SAMLSource} from '../graphql/public/types/SAML'
@@ -759,36 +757,6 @@ export const favoriteTemplateIds = (parent: RootDataLoader, dependsOn: RegisterD
     }
   )
 }
-
-// This should be removed once we've migrated the DB hyperlinks to using the asset proxy URLs
-export const fileStoreAsset = (parent: RootDataLoader) => {
-  return new DataLoader<string, string, string>(
-    async (urls) => {
-      // Our cloud saas has a public file store, so no need to make a presigned url
-      if (process.env.IS_ENTERPRISE !== 'true') return urls
-      const manager = getFileStoreManager()
-      const {baseUrl} = manager
-      const presignedUrls = await Promise.all(
-        urls.map(async (url) => {
-          // if the image is not hosted by us, ignore it
-          if (!url.startsWith(baseUrl)) return url
-          try {
-            const partialPath = url.slice(baseUrl.length)
-            return await manager.presignUrl(partialPath as PartialPath)
-          } catch (e) {
-            Logger.log('Unable to presign url', url, e)
-            return url
-          }
-        })
-      )
-      return presignedUrls
-    },
-    {
-      ...parent.dataLoaderOptions
-    }
-  )
-}
-
 export const meetingCount = (parent: RootDataLoader, dependsOn: RegisterDependsOn) => {
   dependsOn('newMeetings')
   return new DataLoader<{teamId: string; meetingType: MeetingTypeEnum}, number, string>(

--- a/packages/server/graphql/public/types/MeetingTemplate.ts
+++ b/packages/server/graphql/public/types/MeetingTemplate.ts
@@ -12,9 +12,6 @@ const MeetingTemplate: MeetingTemplateResolvers = {
   team: async ({teamId}, _args, {dataLoader}) => {
     return dataLoader.get('teams').loadNonNull(teamId)
   },
-  illustrationUrl: async ({illustrationUrl}, _args, {dataLoader}) => {
-    return dataLoader.get('fileStoreAsset').load(illustrationUrl)
-  },
   viewerLowestScope: async ({teamId, orgId}, _args, {authToken, dataLoader}) => {
     if (teamId === 'aGhostTeam') return 'PUBLIC'
     const viewerId = getUserId(authToken)

--- a/packages/server/graphql/public/types/NotifyMentioned.ts
+++ b/packages/server/graphql/public/types/NotifyMentioned.ts
@@ -5,10 +5,6 @@ const NotifyMentioned: NotifyMentionedResolvers = {
   retroReflection: async ({retroReflectionId}, _args, {dataLoader}) => {
     if (!retroReflectionId) return null
     return dataLoader.get('retroReflections').loadNonNull(retroReflectionId)
-  },
-  senderPicture: async ({senderPicture}, _args, {dataLoader}) => {
-    if (!senderPicture) return null
-    return dataLoader.get('fileStoreAsset').load(senderPicture)
   }
 }
 

--- a/packages/server/graphql/public/types/NotifyRequestToJoinOrg.ts
+++ b/packages/server/graphql/public/types/NotifyRequestToJoinOrg.ts
@@ -5,10 +5,6 @@ const NotifyRequestToJoinOrg: NotifyRequestToJoinOrgResolvers = {
   __isTypeOf: ({type}) => type === 'REQUEST_TO_JOIN_ORG',
   domainJoinRequestId: ({domainJoinRequestId}) => {
     return DomainJoinRequestId.join(domainJoinRequestId)
-  },
-  picture: async ({picture}, _args, {dataLoader}) => {
-    if (!picture) return null
-    return dataLoader.get('fileStoreAsset').load(picture)
   }
 }
 

--- a/packages/server/graphql/public/types/NotifyTeamsLimitExceeded.ts
+++ b/packages/server/graphql/public/types/NotifyTeamsLimitExceeded.ts
@@ -1,11 +1,7 @@
 import type {NotifyTeamsLimitExceededResolvers} from '../resolverTypes'
 
 const NotifyTeamsLimitExceeded: NotifyTeamsLimitExceededResolvers = {
-  __isTypeOf: ({type}) => type === 'TEAMS_LIMIT_EXCEEDED',
-  orgPicture: async ({orgPicture}, _args, {dataLoader}) => {
-    if (!orgPicture) return null
-    return dataLoader.get('fileStoreAsset').load(orgPicture)
-  }
+  __isTypeOf: ({type}) => type === 'TEAMS_LIMIT_EXCEEDED'
 }
 
 export default NotifyTeamsLimitExceeded

--- a/packages/server/graphql/public/types/NotifyTeamsLimitReminder.ts
+++ b/packages/server/graphql/public/types/NotifyTeamsLimitReminder.ts
@@ -1,11 +1,7 @@
 import type {NotifyTeamsLimitReminderResolvers} from '../resolverTypes'
 
 const NotifyTeamsLimitReminder: NotifyTeamsLimitReminderResolvers = {
-  __isTypeOf: ({type}) => type === 'TEAMS_LIMIT_REMINDER',
-  orgPicture: async ({orgPicture}, _args, {dataLoader}) => {
-    if (!orgPicture) return null
-    return dataLoader.get('fileStoreAsset').load(orgPicture)
-  }
+  __isTypeOf: ({type}) => type === 'TEAMS_LIMIT_REMINDER'
 }
 
 export default NotifyTeamsLimitReminder

--- a/packages/server/graphql/public/types/Organization.ts
+++ b/packages/server/graphql/public/types/Organization.ts
@@ -26,10 +26,6 @@ const Organization: OrganizationResolvers = {
   featureFlag: async ({id: orgId}, {featureName}, {dataLoader}) => {
     return await dataLoader.get('featureFlagByOwnerId').load({ownerId: orgId, featureName})
   },
-  picture: async ({picture}, _args, {dataLoader}) => {
-    if (!picture) return null
-    return dataLoader.get('fileStoreAsset').load(picture)
-  },
   tier: ({tier, trialStartDate}) => {
     return getFeatureTier({tier, trialStartDate})
   },

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -879,13 +879,10 @@ const User: ReqResolvers<'User'> = {
     urlObj.searchParams.append('RelayState', relayState)
     return {url: urlObj.toString()}
   },
-  picture: async ({picture}, _args, {dataLoader}) => {
-    return dataLoader.get('fileStoreAsset').load(picture)
-  },
-  rasterPicture: async ({picture}, _args, {dataLoader}) => {
+  rasterPicture: async ({picture}) => {
     const rasterPicture =
       picture && picture.endsWith('.svg') ? picture.slice(0, -3) + 'png' : picture
-    return dataLoader.get('fileStoreAsset').load(rasterPicture)
+    return rasterPicture
   },
   highestTier: async ({id: userId}, _args, {dataLoader}) => {
     const highestTier = await dataLoader.get('highestTierForUserId').load(userId)


### PR DESCRIPTION
# Description

This was cruft from long ago, and it was breaking PPMIs who used s3 as it presigned URLs instead of pointing the the asset proxy.

