### PR TITLE
fix: linear issue titles in meeting summaries

### DIFF
--- a/packages/server/graphql/mutations/helpers/summaryPage/getPokerTable.ts
+++ b/packages/server/graphql/mutations/helpers/summaryPage/getPokerTable.ts
@@ -83,6 +83,7 @@ export const getPokerRowData = async (
           case 'azureDevOps':
           case 'github':
           case 'gitlab':
+          case 'linear':
             fieldName = 'title'
             break
           case 'jira':


### PR DESCRIPTION
# Description

A user reported that all issue titles were coming up in our meeting summaries as "Unknown Issue." This should fix that.
