### PR TITLE
fix(SCIM): team archivor can be null

### DIFF
--- a/packages/client/components/TeamArchived.tsx
+++ b/packages/client/components/TeamArchived.tsx
@@ -27,13 +27,12 @@ const TeamArchived = (props: Props) => {
   )
   const {archivor, team} = notification
   const {name: teamName} = team
-  const {preferredName: archivorName, picture: archivorPicture} = archivor
+  const {preferredName: archivorName, picture: archivorPicture} = archivor ?? {}
+  const message = archivorName
+    ? `${archivorName} archived the team ${teamName}`
+    : `The team ${teamName} was archived`
   return (
-    <NotificationTemplate
-      avatar={archivorPicture}
-      message={`${archivorName} archived the team ${teamName}`}
-      notification={notification}
-    />
+    <NotificationTemplate avatar={archivorPicture} message={message} notification={notification} />
   )
 }
 

--- a/packages/client/modules/email/components/EmailNotifications/EmailTeamArchived.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailTeamArchived.tsx
@@ -27,11 +27,14 @@ const EmailTeamArchived = (props: Props) => {
   )
   const {archivor, team} = notification
   const {name: teamName} = team
-  const {preferredName: archivorName, rasterPicture: archivorPicture} = archivor
+  const {preferredName: archivorName, rasterPicture: archivorPicture} = archivor ?? {}
+  const message = archivorName
+    ? `${archivorName} archived the team ${teamName}`
+    : `The team ${teamName} was archived`
   return (
     <EmailNotificationTemplate
       avatar={archivorPicture}
-      message={`${archivorName} archived the team ${teamName}`}
+      message={message}
       notificationRef={notification}
     />
   )

--- a/packages/server/graphql/public/typeDefs/NotifyTeamArchived.graphql
+++ b/packages/server/graphql/public/typeDefs/NotifyTeamArchived.graphql
@@ -3,9 +3,9 @@ A notification alerting the user that a team they were on is now archived
 """
 type NotifyTeamArchived implements Notification {
   """
-  the user that archived the team
+  the user that archived the team, can be null if the team was archived via SCIM
   """
-  archivor: User!
+  archivor: User
   team: Team!
 
   """

--- a/packages/server/graphql/public/types/NotifyTeamArchived.ts
+++ b/packages/server/graphql/public/types/NotifyTeamArchived.ts
@@ -3,7 +3,7 @@ import type {NotifyTeamArchivedResolvers} from '../resolverTypes'
 const NotifyTeamArchived: NotifyTeamArchivedResolvers = {
   __isTypeOf: ({type}) => type === 'TEAM_ARCHIVED',
   archivor: ({archivorUserId}, _args, {dataLoader}) => {
-    return dataLoader.get('users').loadNonNull(archivorUserId)
+    return archivorUserId ? dataLoader.get('users').loadNonNull(archivorUserId) : null
   },
 
   team: async ({teamId}, _args, {dataLoader}) => {


### PR DESCRIPTION
# Description



Fixes #12867 
When a team is archived via SCIM, the archivor is null.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
