### PR TITLE
fix: invalidate invites on remove from org

### DIFF
--- a/packages/server/__tests__/inviteToTeam.test.ts
+++ b/packages/server/__tests__/inviteToTeam.test.ts
@@ -358,3 +358,108 @@ test('Accepted invite token cannot be reused after leaving the team', async () =
     }
   })
 })
+
+test('Pending invites are invalidated when user is removed from org', async () => {
+  const [user1, user2] = await Promise.all([signUp(), signUp()])
+  const {cookie: user1Cookie, teamId: team1Id, orgId} = user1
+  const {cookie: user2Cookie, userId: user2Id, email: user2Email} = user2
+
+  // user1 invites user2 to team1 — user2 accepts and joins org1
+  await sendPublic({
+    query: `
+      mutation InviteToTeam($teamId: ID!, $invitees: [Email!]!) {
+        inviteToTeam(teamId: $teamId, invitees: $invitees) {
+          invitees
+        }
+      }
+    `,
+    variables: {teamId: team1Id, invitees: [user2Email]},
+    cookie: user1Cookie
+  })
+
+  const pg = getKysely()
+  const {token: firstToken} = await pg
+    .selectFrom('TeamInvitation')
+    .select('token')
+    .where('email', '=', user2Email)
+    .where('teamId', '=', team1Id)
+    .executeTakeFirstOrThrow()
+
+  await sendPublic({
+    query: `
+      mutation AcceptTeamInvitation($invitationToken: ID!) {
+        acceptTeamInvitation(invitationToken: $invitationToken) {
+          error { message }
+          team { id }
+        }
+      }
+    `,
+    variables: {invitationToken: firstToken},
+    cookie: user2Cookie
+  })
+
+  // user2 is now in org1. user1 creates a second team and invites user2 in one call —
+  // inviteToTeamHelper runs inside addTeam after tms is mutated, so the auth check is satisfied
+  const addTeamResult = await sendPublic({
+    query: `
+      mutation AddTeam($newTeam: NewTeamInput!, $invitees: [Email!]) {
+        addTeam(newTeam: $newTeam, invitees: $invitees) {
+          error { message }
+          team { id }
+        }
+      }
+    `,
+    variables: {newTeam: {name: 'Team 2', orgId, isPublic: false}, invitees: [user2Email]},
+    cookie: user1Cookie
+  })
+
+  const team2Id = addTeamResult.data.addTeam.team.id
+
+  const {token: pendingToken} = await pg
+    .selectFrom('TeamInvitation')
+    .select('token')
+    .where('email', '=', user2Email)
+    .where('teamId', '=', team2Id)
+    .executeTakeFirstOrThrow()
+
+  // user1 (billing leader) removes user2 from org1
+  await sendPublic({
+    query: `
+      mutation RemoveOrgUsers($userIds: [ID!]!, $orgId: ID!) {
+        removeOrgUsers(userIds: $userIds, orgId: $orgId) {
+          ... on RemoveOrgUsersSuccess {
+            removedUserIds
+          }
+          ... on ErrorPayload {
+            error { message }
+          }
+        }
+      }
+    `,
+    variables: {userIds: [user2Id], orgId},
+    cookie: user1Cookie
+  })
+
+  // user2 tries to accept the still-pending invite for team2 — should fail because it was expired on removal
+  const reAcceptResult = await sendPublic({
+    query: `
+      mutation AcceptTeamInvitation($invitationToken: ID!) {
+        acceptTeamInvitation(invitationToken: $invitationToken) {
+          error { message }
+          team { id }
+        }
+      }
+    `,
+    variables: {invitationToken: pendingToken},
+    cookie: user2Cookie
+  })
+
+  expect(reAcceptResult).toMatchObject({
+    data: {
+      acceptTeamInvitation: {
+        error: {message: 'expired'},
+        team: null
+      }
+    }
+  })
+})

--- a/packages/server/graphql/mutations/helpers/removeFromOrg.ts
+++ b/packages/server/graphql/mutations/helpers/removeFromOrg.ts
@@ -57,6 +57,17 @@ const removeFromOrg = async (
       .executeTakeFirstOrThrow(),
     dataLoader.get('users').loadNonNull(userId)
   ])
+
+  // Expire any pending invitations for this user across all teams in the org
+  if (orgTeamIds.length > 0) {
+    await pg
+      .updateTable('TeamInvitation')
+      .set({expiresAt: sql`CURRENT_TIMESTAMP`})
+      .where('email', '=', user.email)
+      .where('teamId', 'in', orgTeamIds)
+      .where('acceptedAt', 'is', null)
+      .execute()
+  }
   dataLoader.clearAll('organizationUsers')
   // need to make sure the org doc is updated before adjusting this
   const {role} = organizationUser

--- a/packages/server/graphql/public/mutations/addTeam.ts
+++ b/packages/server/graphql/public/mutations/addTeam.ts
@@ -1,8 +1,10 @@
 import {SubscriptionChannel, Threshold} from 'parabol-client/types/constEnums'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
+import AuthToken from '../../../database/types/AuthToken'
 import generateUID from '../../../generateUID'
 import removeSuggestedAction from '../../../safeMutations/removeSuggestedAction'
 import {analytics} from '../../../utils/analytics/analytics'
+import {setAuthCookie} from '../../../utils/authCookie'
 import {getUserId, isUserInOrg} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
@@ -72,6 +74,11 @@ const addTeam: MutationResolvers['addTeam'] = async (_source, args, context) => 
   const {tms} = authToken
   // MUTATIVE
   tms.push(teamId)
+  const nextAuthToken = new AuthToken({tms, sub: viewerId, rol: authToken.rol})
+  context.authToken = nextAuthToken
+  if (context.request) {
+    setAuthCookie(context, nextAuthToken)
+  }
   analytics.newTeam(viewer, orgId, teamId, orgTeams.length + 1)
   publish(SubscriptionChannel.NOTIFICATION, viewerId, 'AuthTokenPayload', {
     tms


### PR DESCRIPTION
If a user was removed from an org, they should not be able to join back in via a pending invite.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
