### PR TITLE
fix: set content-disposition: attachment for user assets

### DIFF
--- a/packages/server/fileStorage/FileStoreManager.ts
+++ b/packages/server/fileStorage/FileStoreManager.ts
@@ -20,7 +20,8 @@ export default abstract class FileStoreManager {
 
   protected abstract putFile(
     file: ArrayBufferLike | Buffer<ArrayBufferLike>,
-    fullPath: string
+    fullPath: string,
+    options?: {contentDisposition?: string}
   ): Promise<void>
   abstract putBuildFile(
     file: ArrayBufferLike | Buffer<ArrayBufferLike>,
@@ -32,7 +33,7 @@ export default abstract class FileStoreManager {
   abstract presignUrl(partialPath: PartialPath, expiresIn?: number): Promise<string>
   async putUserFile(file: ArrayBufferLike | Buffer<ArrayBufferLike>, partialPath: PartialPath) {
     const fullPath = this.prependPath(partialPath)
-    await this.putFile(file, fullPath)
+    await this.putFile(file, fullPath, {contentDisposition: 'attachment'})
     return makeAppURL(appOrigin, `/assets/${partialPath}`)
   }
   async putUserAvatar(

--- a/packages/server/fileStorage/GCSManager.ts
+++ b/packages/server/fileStorage/GCSManager.ts
@@ -115,19 +115,49 @@ export default class GCSManager extends FileStoreManager {
     return this.accessToken
   }
 
-  protected async putFile(file: Buffer<ArrayBufferLike>, fullPath: string) {
+  protected async putFile(
+    file: Buffer<ArrayBufferLike>,
+    fullPath: string,
+    options?: {contentDisposition?: string}
+  ) {
+    const {contentDisposition} = options ?? {}
+    const contentType = mime.lookup(fullPath) || 'application/octet-stream'
     const url = new URL(`https://storage.googleapis.com/upload/storage/v1/b/${this.bucket}/o`)
-    url.searchParams.append('uploadType', 'media')
     url.searchParams.append('name', fullPath)
     const accessToken = await this.getAccessToken()
+
+    let body: Buffer | any
+    let uploadContentType: string
+    if (contentDisposition) {
+      // Use multipart upload to set metadata atomically during object creation.
+      // This avoids a separate PATCH request which requires storage.objects.update permission.
+      // https://cloud.google.com/storage/docs/uploading-objects#uploading-an-object-with-metadata
+      // The boundary is a random UUID so it cannot collide with file content.
+      const boundary = crypto.randomUUID()
+      const metadata = JSON.stringify({contentDisposition})
+      body = Buffer.concat([
+        Buffer.from(
+          `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n--${boundary}\r\nContent-Type: ${contentType}\r\n\r\n`
+        ),
+        file as Buffer,
+        Buffer.from(`\r\n--${boundary}--`)
+      ])
+      url.searchParams.append('uploadType', 'multipart')
+      uploadContentType = `multipart/related; boundary="${boundary}"`
+    } else {
+      body = file as any
+      url.searchParams.append('uploadType', 'media')
+      uploadContentType = contentType
+    }
+
     try {
       const r = await fetch(url, {
         method: 'POST',
-        body: file as any,
+        body,
         headers: {
           Authorization: `Bearer ${accessToken}`,
           Accept: 'application/json',
-          'Content-Type': mime.lookup(fullPath) || '',
+          'Content-Type': uploadContentType,
           'User-Agent': 'parabol'
         }
       })
@@ -139,7 +169,7 @@ export default class GCSManager extends FileStoreManager {
       // GCS will cause undici to error randomly with `SocketError: other side closed` `code: 'UND_ERR_SOCKET'`
       if ((e as any).cause?.code === 'UND_ERR_SOCKET') {
         Logger.log('   Retrying GCS Post:', fullPath)
-        await this.putFile(file, fullPath)
+        await this.putFile(file, fullPath, options)
       } else {
         throw e
       }

--- a/packages/server/fileStorage/LocalFileStoreManager.ts
+++ b/packages/server/fileStorage/LocalFileStoreManager.ts
@@ -15,7 +15,11 @@ export default class LocalFileStoreManager extends FileStoreManager {
     }
   }
 
-  protected async putFile(file: ArrayBufferLike, fullPath: string) {
+  protected async putFile(
+    file: ArrayBufferLike,
+    fullPath: string,
+    _options?: {contentDisposition?: string}
+  ) {
     const fsAbsLocation = path.join(process.cwd(), fullPath)
     await fs.promises.mkdir(path.dirname(fsAbsLocation), {recursive: true})
     await fs.promises.writeFile(fsAbsLocation, Buffer.from(file) as any)

--- a/packages/server/fileStorage/S3FileStoreManager.ts
+++ b/packages/server/fileStorage/S3FileStoreManager.ts
@@ -90,12 +90,17 @@ export default class S3Manager extends FileStoreManager {
     })
   }
 
-  protected async putFile(file: ArrayBufferLike, fullPath: string) {
+  protected async putFile(
+    file: ArrayBufferLike,
+    fullPath: string,
+    options?: {contentDisposition?: string}
+  ) {
     const s3Params = {
       Body: Buffer.from(file),
       Bucket: this.bucket,
       Key: fullPath,
-      ContentType: mime.lookup(fullPath) || 'application/octet-stream'
+      ContentType: mime.lookup(fullPath) || 'application/octet-stream',
+      ...(options?.contentDisposition && {ContentDisposition: options.contentDisposition})
     }
     await this.s3.send(new PutObjectCommand(s3Params))
   }


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/security-management/issues/98
Set content-disposition: attachment so the browser would not try to render page attachments when opened directly.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
