### PR TITLE
fix: Remove duplicate `transfer-encoding` headers from Yoga responses.

### DIFF
--- a/packages/server/utils/useRemoveDuplicateTransferEncoding.ts
+++ b/packages/server/utils/useRemoveDuplicateTransferEncoding.ts
@@ -1,0 +1,13 @@
+import type {Plugin} from 'graphql-yoga'
+import type {ServerContext} from '../yoga'
+
+export const useRemoveDuplicateTransferEncoding: Plugin<ServerContext> = {
+  onResponse({response}) {
+    const transferEncoding = response.headers.get('transfer-encoding')
+    if (transferEncoding === 'chunked') {
+      // uWebSockets.js sets this header, so remove it so it only appears once
+      // (graphql-yoga also sets it)
+      response.headers.delete('transfer-encoding')
+    }
+  }
+}

--- a/packages/server/yoga.ts
+++ b/packages/server/yoga.ts
@@ -23,6 +23,7 @@ import {useDatadogTracing} from './utils/useDatadogTracing'
 import {useDisposeDataloader} from './utils/useDisposeDataloader'
 import {useOAuthScopeValidation} from './utils/useOAuthScopeValidation'
 import {usePrivateSchemaForSuperUser} from './utils/usePrivateSchemaForSuperUser'
+import {useRemoveDuplicateTransferEncoding} from './utils/useRemoveDuplicateTransferEncoding'
 
 type OperationResolvers = QueryResolvers & MutationResolvers
 type ExtractArgs<T> = T extends Resolver<any, any, any, infer Args> ? Args : never
@@ -81,6 +82,7 @@ export const yoga = createYoga<ServerContext, UserContext>({
   landingPage: false,
   logging: Logger,
   plugins: [
+    useRemoveDuplicateTransferEncoding,
     useAuditLogs({
       excludeArgs: {
         acceptTeamInvitation: ['invitationToken'],


### PR DESCRIPTION
# Description

hopefully fixes the break on staging