### PR TITLE
fix: allow routine SAML metadata refresh

### DIFF
--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -194,16 +194,20 @@ const loginSAML: MutationResolvers['loginSAML'] = async (
   if (user instanceof Error) return standardError(user)
 
   if (newMetadata) {
-    // Only org admins may update SAML metadata.
-    // Verify before persisting — the email is already validated against the SAML domains above.
-    if (!orgId || !user) {
-      return standardError(new Error('Only org admins can update SAML metadata'))
-    }
-    const organizationUser = await dataLoader
-      .get('organizationUsersByUserIdOrgId')
-      .load({orgId, userId: user.id})
-    if (organizationUser?.role !== 'ORG_ADMIN') {
-      return standardError(new Error('Only org admins can update SAML metadata'))
+    // Only org admins may set a new SAML metadata URL.
+    // Refreshing an existing URL (auto or manual) is allowed on every login.
+    const isNewURL = newMetadataURL && newMetadataURL !== existingMetadataURL
+    if (isNewURL) {
+      // Verify before persisting — the email is already validated against the SAML domains above.
+      if (!orgId || !user) {
+        return standardError(new Error('Only org admins can update SAML metadata'))
+      }
+      const organizationUser = await dataLoader
+        .get('organizationUsersByUserIdOrgId')
+        .load({orgId, userId: user.id})
+      if (organizationUser?.role !== 'ORG_ADMIN') {
+        return standardError(new Error('Only org admins can update SAML metadata'))
+      }
     }
     // Revalidate metadata & persist to DB
     // Generate the URL to verify the metadata, don't persist it as it needs to be generated fresh


### PR DESCRIPTION
Don't restrict a refresh of the existing metadata to org admins.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
