### PR TITLE
fix: upload images in reflections

### DIFF
--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -8,6 +8,7 @@ import {useEffect, useRef, useState} from 'react'
 import type Atmosphere from '../Atmosphere'
 import {LoomExtension} from '../components/TipTapEditor/LoomExtension'
 import {TiptapLinkExtension} from '../components/TipTapEditor/TiptapLinkExtension'
+import {useUploadUserAsset} from '../mutations/useUploadUserAsset'
 import {isEqualWhenSerialized} from '../shared/isEqualWhenSerialized'
 import {mentionConfig, serverTipTapExtensions} from '../shared/tiptap/serverTipTapExtensions'
 import {ClearOnSubmit} from '../tiptap/extensions/ClearOnSubmit'
@@ -35,6 +36,7 @@ export const useTipTapReflectionEditor = (
   const {atmosphere, teamId, readOnly, placeholder, onModEnter} = options
   const [contentJSON] = useState(() => JSON.parse(content))
   const placeholderRef = useRef(placeholder)
+  const [commit] = useUploadUserAsset()
   placeholderRef.current = placeholder
   const editor = useEditor(
     {
@@ -59,7 +61,9 @@ export const useTipTapReflectionEditor = (
         Focus,
         FileUpload.configure({
           scopeKey: teamId,
-          assetScope: 'Team'
+          assetScope: 'Team',
+          highestTier: 'starter',
+          commit
         }),
         ImageBlock.configure({
           editorWidth: ElementWidth.REFLECTION_CARD - 16 * 2,


### PR DESCRIPTION
# Description

Fixes #12927 
Upload is just silently swallowed if there is no `highestTier`. Because in retros everyone is logged in and the starter size should be enough for all reflections, I just hardcoded 'starter'

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
