### PR TITLE
chore: stricter tsHeadline types

### DIFF
--- a/packages/server/postgres/expressions.ts
+++ b/packages/server/postgres/expressions.ts
@@ -29,19 +29,28 @@ export function tsvSimilarity<DB, TB extends keyof DB>(
   return sql<number>`ts_rank_cd(${eb.ref(column)}, ${eb.ref(webQuery)}, 8)`
 }
 
-interface PGHeadlineOptions {
-  StartSel: string
-  StopSel: string
+// Only string literals are accepted to prevent SQL injection via ts_headline options concatenation
+type StringLiteral<T extends string> = string extends T ? never : T
+
+interface PGHeadlineOptions<TStart extends string, TStop extends string, TDelim extends string> {
+  StartSel: StringLiteral<TStart>
+  StopSel: StringLiteral<TStop>
   MaxWords: number
   MaxFragments: number
-  FragmentDelimiter: string
+  FragmentDelimiter: StringLiteral<TDelim>
 }
-export const tsHeadline = <DB, TB extends keyof DB>(
+export const tsHeadline = <
+  DB,
+  TB extends keyof DB,
+  TStart extends string,
+  TStop extends string,
+  TDelim extends string
+>(
   eb: ExpressionBuilder<DB, TB>,
   language: TSVLanguage,
   embedTextColumn: StringReference<DB, TB>,
   webQuery: StringReference<DB, TB>,
-  options: PGHeadlineOptions
+  options: PGHeadlineOptions<TStart, TStop, TDelim>
 ) => {
   const optionStr = Object.entries(options)
     .map(([key, val]) => `${key}=${val}`)


### PR DESCRIPTION

# Description

Fixes https://github.com/ParabolInc/security-management/issues/111
User input here could lead to a SQL injection. Updating types to catch this.


## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
