### PR TITLE
fix: blacklist old authToken on refreshSession

### DIFF
--- a/packages/server/graphql/public/mutations/refreshSession.ts
+++ b/packages/server/graphql/public/mutations/refreshSession.ts
@@ -1,11 +1,12 @@
 import {GraphQLError} from 'graphql'
 import AuthToken from '../../../database/types/AuthToken'
 import {setAuthCookie} from '../../../utils/authCookie'
+import {blacklistJWTSession} from '../../../utils/blacklistJWT'
 import {MutationResolvers} from '../resolverTypes'
 
 const refreshSession: MutationResolvers['refreshSession'] = async (_source, {}, context) => {
   const {authToken, dataLoader} = context
-  const {rol, sub} = authToken!
+  const {rol, sub, jti, exp} = authToken!
 
   if (rol === 'impersonate') {
     throw new GraphQLError('Cannot refresh an impersonation session')
@@ -14,6 +15,10 @@ const refreshSession: MutationResolvers['refreshSession'] = async (_source, {}, 
   const user = await dataLoader.get('users').load(sub)
   if (!user) {
     throw new GraphQLError('User not found')
+  }
+
+  if (jti && exp) {
+    await blacklistJWTSession(jti, exp)
   }
 
   context.authToken = new AuthToken({


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/security-management/issues/118

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
