### PR TITLE
chore: use postUntrusted for webhook calls

### DIFF
--- a/packages/server/graphql/mutations/helpers/notifications/MSTeamsNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MSTeamsNotifier.ts
@@ -23,7 +23,7 @@ const notifyMSTeams = async (
   webhookUrl: string,
   user: User,
   teamId: string,
-  textOrAttachmentsArray: string | unknown[]
+  textOrAttachmentsArray: string
 ) => {
   const manager = new MSTeamsServerManager(webhookUrl)
   const result = await manager.post(textOrAttachmentsArray)

--- a/packages/server/utils/MSTeamsServerManager.ts
+++ b/packages/server/utils/MSTeamsServerManager.ts
@@ -1,5 +1,5 @@
-import {fetch} from '@whatwg-node/fetch'
 import {MAX_REQUEST_TIME} from 'parabol-client/utils/constants'
+import {postUntrusted} from './fetchUntrusted'
 import logError from './logError'
 
 // MS Teams is a server-only integration for now, unlike the Slack integration
@@ -16,40 +16,32 @@ export interface MSTeamsApiResponse {
 
 class MSTeamsServerManager {
   webhookUrl: string
-  headers: any
-  fetch = fetch
   constructor(webhookUrl: string) {
     this.webhookUrl = webhookUrl
   }
 
-  async post(payload: any) {
-    try {
-      const res = await this.fetch(this.webhookUrl, {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json' as const,
-          'Content-Type': 'application/json;charset=utf-8',
-          'User-Agent': 'parabol'
-        },
-        body: payload,
-        signal: AbortSignal.timeout(MAX_REQUEST_TIME)
-      })
-      if (res.status < 200 || res.status >= 300) {
-        if (res.headers.get('content-type') === 'application/json') {
-          const {message: error} = await res.json()
-          return new Error(`${res.status}: ${error}`)
-        } else {
-          return new Error(`${res.status}: ${res.statusText}`)
-        }
-      }
-      return res
-    } catch (error) {
-      if (error instanceof Error) {
-        logError(error)
-        return error
-      }
-      return new Error('MS Teams is not responding')
+  async post(payload: string) {
+    const res = await postUntrusted(this.webhookUrl, {
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json;charset=utf-8'
+      },
+      body: payload,
+      signal: AbortSignal.timeout(MAX_REQUEST_TIME)
+    })
+    if (!res) {
+      const error = new Error('MS Teams webhook request failed')
+      logError(error)
+      return error
     }
+    if (res.status < 200 || res.status >= 300) {
+      if (res.headers.get('content-type') === 'application/json') {
+        const {message: error} = await res.json()
+        return new Error(`${res.status}: ${error}`)
+      }
+      return new Error(`${res.status}: ${res.statusText}`)
+    }
+    return res
   }
 }
 

--- a/packages/server/utils/MattermostServerManager.ts
+++ b/packages/server/utils/MattermostServerManager.ts
@@ -1,7 +1,6 @@
-import {fetch} from '@whatwg-node/fetch'
 import {createSigner, httpbis} from 'http-message-signatures'
 import {MAX_REQUEST_TIME} from 'parabol-client/utils/constants'
-import {Logger} from './Logger'
+import {postUntrusted} from './fetchUntrusted'
 
 // Mattermost is a server-only integration for now, unlike the Slack integration
 
@@ -16,11 +15,9 @@ export interface MattermostApiResponse {
   error?: string
 }
 
-abstract class MattermostManager {
+class MattermostServerManager {
   webhookUrl: string
   secret?: string
-  abstract fetch: typeof fetch
-  headers: any
 
   constructor(webhookUrl: string, secret?: string) {
     this.webhookUrl = webhookUrl
@@ -61,29 +58,23 @@ abstract class MattermostManager {
       headers['Signature'] = signedRequest.headers['Signature']!
       headers['Signature-Input'] = signedRequest.headers['Signature-Input']!
     }
-    try {
-      const res = await this.fetch(url, {
-        method,
-        headers,
-        body,
-        signal: AbortSignal.timeout(MAX_REQUEST_TIME)
-      })
-      if (res.status !== 200) {
-        if (res.headers.get('content-type') === 'application/json') {
-          const {message: error} = await res.json()
-          return new Error(`${res.status}: ${error}`)
-        } else {
-          return new Error(`${res.status}: ${res.statusText}`)
-        }
-      }
-      return res
-    } catch (error) {
-      if (error instanceof Error) {
-        Logger.warn(error)
-        return error
-      }
-      return new Error('Mattermost is not responding')
+
+    const res = await postUntrusted(url, {
+      headers,
+      body,
+      signal: AbortSignal.timeout(MAX_REQUEST_TIME)
+    })
+    if (!res) {
+      return new Error('Mattermost webhook request failed')
     }
+    if (res.status !== 200) {
+      if (res.headers.get('content-type') === 'application/json') {
+        const {message: error} = await res.json()
+        return new Error(`${res.status}: ${error}`)
+      }
+      return new Error(`${res.status}: ${res.statusText}`)
+    }
+    return res
   }
 
   async postMessage(textOrAttachmentsArray: string | unknown[], notificationText?: string) {
@@ -106,13 +97,6 @@ abstract class MattermostManager {
           }
 
     return await this.post(payload)
-  }
-}
-
-class MattermostServerManager extends MattermostManager {
-  fetch = fetch
-  constructor(webhookUrl: string, secret?: string) {
-    super(webhookUrl, secret)
   }
 }
 

--- a/packages/server/utils/fetchUntrusted.ts
+++ b/packages/server/utils/fetchUntrusted.ts
@@ -150,24 +150,36 @@ function createPinnedAgent(protocol: string, addresses: string[]) {
 
 interface PinnedResponse {
   status: number
+  statusText: string
   headers: http.IncomingHttpHeaders
   body: http.IncomingMessage
 }
 
 function pinnedRequest(
+  method: 'GET' | 'POST',
   url: URL,
   agent: http.Agent | https.Agent,
   signal: AbortSignal,
-  extraHeaders?: Record<string, string>
+  extraHeaders?: Record<string, string>,
+  body?: string
 ): Promise<PinnedResponse> {
   const mod = url.protocol === 'https:' ? https : http
   return new Promise((resolve, reject) => {
     const req = mod.request(
       url,
-      {agent, method: 'GET', headers: {'User-Agent': USER_AGENT, ...extraHeaders}, signal},
-      (res) => resolve({status: res.statusCode!, headers: res.headers, body: res})
+      {agent, method, headers: {'User-Agent': USER_AGENT, ...extraHeaders}, signal},
+      (res) =>
+        resolve({
+          status: res.statusCode!,
+          statusText: res.statusMessage!,
+          headers: res.headers,
+          body: res
+        })
     )
     req.on('error', reject)
+    if (body !== undefined) {
+      req.write(body)
+    }
     req.end()
   })
 }
@@ -206,7 +218,13 @@ export const fetchUntrusted = async (
         let fetchTimeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
         try {
           // 4. Request with pinned DNS (with retry for 429 rate-limiting)
-          let response = await pinnedRequest(currentUrl, agent, controller.signal, currentHeaders)
+          let response = await pinnedRequest(
+            'GET',
+            currentUrl,
+            agent,
+            controller.signal,
+            currentHeaders
+          )
 
           for (let attempt = 0; response.status === 429 && attempt < MAX_429_RETRIES; attempt++) {
             clearTimeout(fetchTimeout)
@@ -219,7 +237,13 @@ export const fetchUntrusted = async (
             await new Promise((resolve) => setTimeout(resolve, delay))
             controller = new AbortController()
             fetchTimeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
-            response = await pinnedRequest(currentUrl, agent, controller.signal, currentHeaders)
+            response = await pinnedRequest(
+              'GET',
+              currentUrl,
+              agent,
+              controller.signal,
+              currentHeaders
+            )
           }
 
           if (response.status >= 300 && response.status < 400) {
@@ -303,6 +327,82 @@ export const fetchUntrusted = async (
       }
 
       return outcome
+    }
+  } catch (e) {
+    Logger.log(e)
+    return null
+  }
+}
+
+export interface PostUntrustedResponse {
+  status: number
+  statusText: string
+  headers: {get: (name: string) => string | null}
+  json: () => Promise<any>
+}
+
+const MAX_WEBHOOK_RESPONSE_SIZE = 100_000
+
+export const postUntrusted = async (
+  url: string,
+  options: {
+    headers?: Record<string, string>
+    body: string
+    signal?: AbortSignal
+  }
+): Promise<PostUntrustedResponse | null> => {
+  try {
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch {
+      throw new Error('Invalid URL')
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('Only http/https allowed')
+    }
+
+    const addresses = await resolveAndValidateHostname(parsed.hostname)
+    const agent = createPinnedAgent(parsed.protocol, addresses)
+
+    try {
+      const signal = options.signal ?? AbortSignal.timeout(TIMEOUT_MS)
+      const response = await pinnedRequest(
+        'POST',
+        parsed,
+        agent,
+        signal,
+        options.headers,
+        options.body
+      )
+
+      const chunks: Buffer[] = []
+      let total = 0
+      for await (const chunk of response.body) {
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array)
+        total += buf.byteLength
+        if (total > MAX_WEBHOOK_RESPONSE_SIZE) {
+          response.body.destroy()
+          break
+        }
+        chunks.push(buf)
+      }
+      const rawBody = Buffer.concat(chunks)
+
+      return {
+        status: response.status,
+        statusText: response.statusText,
+        headers: {
+          get: (name: string): string | null => {
+            const val = response.headers[name.toLowerCase()]
+            if (Array.isArray(val)) return val[0] ?? null
+            return val ?? null
+          }
+        },
+        json: async () => JSON.parse(rawBody.toString('utf8'))
+      }
+    } finally {
+      agent.destroy()
     }
   } catch (e) {
     Logger.log(e)


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/security-management/issues/141

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
