### PR TITLE
fix: prevent memory leak and socket exhaustion in publish + fetch paths

### DIFF
--- a/packages/server/atlassianProxyHandler.ts
+++ b/packages/server/atlassianProxyHandler.ts
@@ -33,6 +33,7 @@ export const atlassianProxyHandler = async (
       deadline: new Date(Date.now() + 20_000)
     })
     if (!atlassianRes.ok) {
+      await atlassianRes.body?.cancel()
       await servePlaceholderImage(res)
       return
     }

--- a/packages/server/integrations/helpers/authorizeOAuth2.ts
+++ b/packages/server/integrations/helpers/authorizeOAuth2.ts
@@ -68,6 +68,7 @@ export const authorizeOAuth2 = async <
   })
   const contentTypeHeader = oauth2Response.headers.get('content-type') || ''
   if (!contentTypeHeader.toLowerCase().startsWith('application/json')) {
+    await oauth2Response.body?.cancel()
     return new Error('Received non-JSON OAuth2 Response')
   }
   const tokenJson = (await oauth2Response.json()) as OAuth2Response

--- a/packages/server/integrations/jiraServer/JiraServerOAuth1Manager.ts
+++ b/packages/server/integrations/jiraServer/JiraServerOAuth1Manager.ts
@@ -51,6 +51,7 @@ export default class JiraServerOAuth1Manager {
       }
     })
     if (response.status !== 200) {
+      await response.body?.cancel()
       return new Error(`Requesting OAuth1 request token failed with status ${response.status}`)
     }
 
@@ -94,6 +95,7 @@ export default class JiraServerOAuth1Manager {
       }
     })
     if (response.status !== 200) {
+      await response.body?.cancel()
       return new Error(`Requesting OAuth1 access token failed with status ${response.status}`)
     }
 

--- a/packages/server/integrations/jiraServer/JiraServerRestManager.ts
+++ b/packages/server/integrations/jiraServer/JiraServerRestManager.ts
@@ -139,6 +139,7 @@ export default class JiraServerRestManager implements TaskIntegrationManager {
   async parseJsonResponse<T>(response: Response): Promise<T | Error> {
     const contentType = response.headers.get('content-type') || ''
     if (!contentType.includes('application/json')) {
+      await response.body?.cancel()
       return new Error('Received non-JSON Jira Data Center Response')
     }
     const json = await response.json()

--- a/packages/server/utils/TenorManager.ts
+++ b/packages/server/utils/TenorManager.ts
@@ -56,6 +56,7 @@ export class TenorManager {
         signal: AbortSignal.timeout(MAX_REQUEST_TIME)
       })
       if (res.status !== 200) {
+        await res.body?.cancel()
         return new Error(`${res.status}: ${res.statusText}`)
       }
       const resJSON = await res.json()

--- a/packages/server/utils/atlassian/jiraImages.ts
+++ b/packages/server/utils/atlassian/jiraImages.ts
@@ -51,6 +51,7 @@ export const downloadAndCacheImage = async (
     return null
   }
   if (!res.ok) {
+    await res.body?.cancel()
     Logger.log(`Jira Image Download fail: ${fetchUrl} (${res.status})`)
     return null
   }

--- a/packages/server/utils/fetchUntrusted.ts
+++ b/packages/server/utils/fetchUntrusted.ts
@@ -14,24 +14,37 @@ const USER_AGENT = `Parabol/${__APP_VERSION__} (https://parabol.co)`
 // Per-domain serialization to prevent overwhelming external servers with
 // concurrent requests. When multiple fetches target the same hostname, they
 // queue and execute one at a time. Different hostnames run concurrently.
-const domainLocks = new Map<string, Promise<void>>()
+//
+// Uses an explicit queue instead of chaining .then() on promises so that
+// each queued callback is a single function reference rather than a growing
+// closure chain that pins earlier fn/agent/lock objects in memory until the
+// entire chain settles.
+const domainQueues = new Map<string, (() => void)[]>()
 
 function withDomainLimit<T>(hostname: string, fn: () => Promise<T>): Promise<T> {
-  const prev = domainLocks.get(hostname) ?? Promise.resolve()
-  let releaseLock!: () => void
-  const lock = new Promise<void>((resolve) => {
-    releaseLock = resolve
-  })
-  domainLocks.set(hostname, lock)
-
-  return prev.then(async () => {
-    try {
-      return await fn()
-    } finally {
-      releaseLock()
-      if (domainLocks.get(hostname) === lock) {
-        domainLocks.delete(hostname)
+  return new Promise<T>((resolve, reject) => {
+    const execute = async () => {
+      try {
+        resolve(await fn())
+      } catch (e) {
+        reject(e)
+      } finally {
+        const queue = domainQueues.get(hostname)
+        if (queue && queue.length > 0) {
+          const next = queue.shift()!
+          next()
+        } else {
+          domainQueues.delete(hostname)
+        }
       }
+    }
+
+    const queue = domainQueues.get(hostname)
+    if (queue) {
+      queue.push(execute)
+    } else {
+      domainQueues.set(hostname, [])
+      execute()
     }
   })
 }

--- a/packages/server/utils/fetchWithRetry.ts
+++ b/packages/server/utils/fetchWithRetry.ts
@@ -36,6 +36,7 @@ export default async (url: RequestInfo, options: FetchWithRetryOptions): Promise
       }
 
       const retryAfter = response.headers.get('Retry-After')
+      await response.body?.cancel()
       // if Retry-After specified, use it; else fallback to exponential backoff
       let waitTime = retryAfter ? parseInt(retryAfter, 10) * 1000 : 2 ** attempt * 1000
 

--- a/packages/server/utils/publish.ts
+++ b/packages/server/utils/publish.ts
@@ -20,6 +20,7 @@ class PublishedDataLoaders {
   private async pushToRedis(id: string, topic: string, type: string) {
     const dataLoaderWorker = getInMemoryDataLoader(id)?.dataLoaderWorker
     if (!dataLoaderWorker) {
+      // publish did not happen within SHARED_DATALOADER_TTL
       delete this.promiseLookup[id]
       return
     }

--- a/packages/server/utils/publish.ts
+++ b/packages/server/utils/publish.ts
@@ -20,7 +20,7 @@ class PublishedDataLoaders {
   private async pushToRedis(id: string, topic: string, type: string) {
     const dataLoaderWorker = getInMemoryDataLoader(id)?.dataLoaderWorker
     if (!dataLoaderWorker) {
-      // publish did not happen within SHARED_DATALOADER_TTL
+      delete this.promiseLookup[id]
       return
     }
     const buffer = await serializeDataLoader(dataLoaderWorker)


### PR DESCRIPTION
- Fix unbounded promiseLookup growth in publish.ts by cleaning up orphaned entries when DataLoaders are evicted
- Replace promise-chaining in withDomainLimit with a queue to avoid retaining closures under load
- Ensure all HTTP responses are consumed or cancelled to prevent undici socket leaks across error paths