### PR TITLE
fix: activity library null filter, pat error path

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -284,7 +284,7 @@ export const ActivityLibrary = (props: Props) => {
   const templatesToRender = useMemo(() => {
     if (searchQuery.length > 0) {
       // If there's a search query, combine the filtered templates with the search results
-      const searchResults = templateSearch.viewer.templateSearch
+      const searchResults = templateSearch?.viewer?.templateSearch ?? []
       const doubleMatches = searchResults.filter((searchResult) =>
         filteredTemplates.find((template) => template.id === searchResult.id)
       )

--- a/packages/server/graphql/public/applyScopeDirective.ts
+++ b/packages/server/graphql/public/applyScopeDirective.ts
@@ -40,9 +40,13 @@ export const applyScopeDirective = (schema: GraphQLSchema): GraphQLSchema => {
       field.resolve = async (source, args, context, info) => {
         if (context.authToken?.aud === 'action-pat') {
           // authToken from PAT already created
-          if (context.authToken?.scopes.includes(requiredScope)) {
+          if (context.authToken.scope?.includes(requiredScope)) {
             return originalResolver(source, args, context, info)
           }
+          throw new GraphQLError(
+            `Personal access token is missing required scope: ${requiredScope}`,
+            {extensions: {code: 'FORBIDDEN'}}
+          )
         }
         const authHeader: string | null | undefined = context.request?.headers?.get('authorization')
         const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined


### PR DESCRIPTION
## Problem

  Three users reported Cannot read properties of undefined (reading 'filter') when using the
  Activity Library — triggered by searching activities, selecting meeting types, or typing in the
   search box.

  The crash occurs at ActivityLibrary.tsx:287 where templateSearch.viewer.templateSearch is
  accessed without a null guard. The templateSearch data comes from Relay's
  useRefetchableFragment with fetchPolicy: 'store-only', which returns whatever is in the
  normalized store without fetching or suspending if data is missing. When the templateSearch
  field is absent from the store, .filter() is called on undefined.

 ## Additional bugs found during investigation

  Two bugs were found in applyScopeDirective.ts (introduced in #12977 and #12984):

  1. Property name mismatch (line 43): context.authToken?.scopes accesses a nonexistent property
  (AuthToken uses scope singular). This crashes PAT-authenticated requests.
  2. Authorization bypass (lines 41-46): When a PAT lacks the required scope, execution falls
  through to return originalResolver() instead of throwing — bypassing authorization entirely.

  Changes

  packages/server/graphql/public/applyScopeDirective.ts
  - Fixed scopes -> scope to match the AuthToken class property
  - Added explicit throw GraphQLError with FORBIDDEN when a PAT lacks the required scope (closes
  authorization bypass)

  packages/client/components/ActivityLibrary/ActivityLibrary.tsx
  - Added templateSearch?.viewer?.templateSearch ?? [] null guard to prevent crash when template
  search data is unavailable in the Relay store