### PR TITLE
fix: jwt race on new team

### DIFF
--- a/packages/client/components/ViewerNotOnTeam.tsx
+++ b/packages/client/components/ViewerNotOnTeam.tsx
@@ -41,9 +41,8 @@ const ViewerNotOnTeam = (props: Props) => {
   const {queryRef} = props
   const data = usePreloadedQuery<ViewerNotOnTeamQuery>(query, queryRef)
   const {viewer} = data
-  const {
-    teamInvitation: {teamInvitation, meetingId, teamId, isOnTeam}
-  } = viewer
+  const {teamInvitation: payload} = viewer
+  const {teamInvitation, meetingId, teamId, isOnTeam} = payload ?? {}
   const atmosphere = useAtmosphere()
   const navigate = useNavigate()
   const {onError, onCompleted} = useMutationProps()

--- a/packages/client/modules/newTeam/NewTeam.tsx
+++ b/packages/client/modules/newTeam/NewTeam.tsx
@@ -88,7 +88,11 @@ const NewTeam = (props: Props) => {
   return (
     <NewTeamLayout>
       <NewTeamInner>
-        <NewTeamForm isInitiallyNewOrg={!defaultOrgId} organizationsRef={organizations} />
+        <NewTeamForm
+          isInitiallyNewOrg={!defaultOrgId}
+          defaultOrgId={defaultOrgId}
+          organizationsRef={organizations}
+        />
         {isDesktop && (
           <HelpLayout>
             <HelpBlock>

--- a/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -101,11 +101,12 @@ const controlSize = 'medium'
 
 interface Props {
   isInitiallyNewOrg: boolean
+  defaultOrgId?: string
   organizationsRef: NewTeamForm_organizations$key
 }
 
 const NewTeamForm = (props: Props) => {
-  const {isInitiallyNewOrg, organizationsRef} = props
+  const {isInitiallyNewOrg, defaultOrgId, organizationsRef} = props
 
   graphql`
     fragment NewTeamForm_teams on Team @relay(plural: true) {
@@ -135,7 +136,7 @@ const NewTeamForm = (props: Props) => {
   )
   const [isPublic, setIsPublic] = useState(true)
   const [isNewOrg, setIsNewOrg] = useState(isInitiallyNewOrg)
-  const [orgId, setOrgId] = useState('')
+  const [orgId, setOrgId] = useState(defaultOrgId ?? '')
   const [rawInvitees, setRawInvitees] = useState('')
   const [invitees, setInvitees] = useState([] as string[])
   const [isSubmitted, setIsSubmitted] = useState(false)

--- a/packages/client/modules/team/components/NewTeamOrgPicker.tsx
+++ b/packages/client/modules/team/components/NewTeamOrgPicker.tsx
@@ -57,6 +57,7 @@ const NewTeamOrgPicker = (props: Props) => {
   )
   const sortedOrgs = useMemo(() => sortByTier(organizations), [organizations])
   useEffect(() => {
+    if (orgId) return
     const [firstOrg] = sortedOrgs
     if (firstOrg) {
       onChange(firstOrg.id)

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -670,8 +670,14 @@ const User: ReqResolvers<'User'> = {
   canAccess: async (_source, {entity, id}, {authToken, dataLoader}) => {
     const viewerId = getUserId(authToken)
     switch (entity) {
-      case 'Team':
-        return isTeamMember(authToken, id)
+      case 'Team': {
+        if (isTeamMember(authToken, id)) return true
+        // JWT `tms` can lag immediately after team creation or invitation acceptance,
+        // until the AuthTokenPayload subscription round-trips and refreshes the cookie.
+        // Fall back to a DB lookup so access is correct during that window.
+        const teamMember = await dataLoader.get('teamMembers').load(TeamMemberId.join(id, viewerId))
+        return !!teamMember?.isNotRemoved
+      }
       case 'Meeting': {
         const meeting = await dataLoader.get('newMeetings').load(id)
         if (!meeting) {


### PR DESCRIPTION

- New-team flow fixes
   - /newteam/:defaultOrgId → "Organization Not Found"
   - ViewerNotOnTeam.tsx:45 — TypeError when redirected to new team
