### PR TITLE
chore: cleanup legacy /newteam route

### DIFF
--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -145,7 +145,7 @@ const DashSidebar = (props: Props) => {
             <SearchDialog />
             <LeftDashNavItem Icon={TimelineIcon} href={'/me'} label={'History'} exact />
             <LeftDashNavItem Icon={PlaylistAddCheckIcon} href={'/me/tasks'} label={'Tasks'} />
-            <LeftDashNavItem Icon={AddIcon} href={'/newteam/1'} label={'Add a Team'} />
+            <LeftDashNavItem Icon={AddIcon} href={'/newteam'} label={'Add a Team'} />
           </div>
           <NavMain>
             <NavList viewerRef={viewer} />

--- a/packages/client/components/Dashboard/MobileDashSidebar.tsx
+++ b/packages/client/components/Dashboard/MobileDashSidebar.tsx
@@ -246,7 +246,7 @@ const MobileDashSidebar = (props: Props) => {
             <LeftDashNavItem
               onClick={handleMenuClick}
               Icon={AddIcon}
-              href={'/newteam/1'}
+              href={'/newteam'}
               label={'Add a Team'}
             />
           </NavItemsWrap>

--- a/packages/client/modules/newTeam/NewTeam.tsx
+++ b/packages/client/modules/newTeam/NewTeam.tsx
@@ -84,13 +84,16 @@ const NewTeam = (props: Props) => {
   )
   const {viewer} = data
   const {organizations} = viewer
+  const validDefaultOrgId = organizations.find((org) => org.id === defaultOrgId)
+    ? defaultOrgId
+    : undefined
 
   return (
     <NewTeamLayout>
       <NewTeamInner>
         <NewTeamForm
-          isInitiallyNewOrg={!defaultOrgId}
-          defaultOrgId={defaultOrgId}
+          isInitiallyNewOrg={organizations.length === 0}
+          defaultOrgId={validDefaultOrgId}
           organizationsRef={organizations}
         />
         {isDesktop && (


### PR DESCRIPTION
# Description

Trivial changes to cleanup some of the references to the `/newteam` route from `/newteam/1/` to just `/newteam`