### PR TITLE
fix: sync auth token changes from mutations back to the WS connection

### DIFF
--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -287,7 +287,6 @@ const User: ReqResolvers<'User'> = {
       (await dataLoader.get('organizationUsersByUserIdOrgId').load({userId: viewerId, orgId})) ?? {}
     const isOrgAdmin = role === 'ORG_ADMIN'
     if (!isOrgAdmin && !isTeamMember(authToken, teamId) && !isSuperUser(authToken)) {
-      const viewerId = getUserId(authToken)
       if (!HANDLED_OPS.includes(operation?.name?.value ?? '')) {
         standardError(new Error('Team not found'), {userId: viewerId})
       }
@@ -670,14 +669,8 @@ const User: ReqResolvers<'User'> = {
   canAccess: async (_source, {entity, id}, {authToken, dataLoader}) => {
     const viewerId = getUserId(authToken)
     switch (entity) {
-      case 'Team': {
-        if (isTeamMember(authToken, id)) return true
-        // JWT `tms` can lag immediately after team creation or invitation acceptance,
-        // until the AuthTokenPayload subscription round-trips and refreshes the cookie.
-        // Fall back to a DB lookup so access is correct during that window.
-        const teamMember = await dataLoader.get('teamMembers').load(TeamMemberId.join(id, viewerId))
-        return !!teamMember?.isNotRemoved
-      }
+      case 'Team':
+        return isTeamMember(authToken, id)
       case 'Meeting': {
         const meeting = await dataLoader.get('newMeetings').load(id)
         if (!meeting) {

--- a/packages/server/wsHandler.ts
+++ b/packages/server/wsHandler.ts
@@ -131,7 +131,17 @@ export const wsHandler = makeBehavior<{token?: string}>({
   },
   async onNext(context, _id, payload, {contextValue}, result) {
     const isSubscription = (payload as any).docId.startsWith('s')
-    if (!isSubscription) return result
+    if (!isSubscription) {
+      // Sync auth token changes from mutations back to the WS connection.
+      // Mutations like addTeam, acceptTeamInvitation, joinTeam update
+      // contextValue.authToken with a new tms array. Without this sync,
+      // subsequent queries on the same connection would use stale tms.
+      const mutationToken = (contextValue as ServerContext).authToken
+      if (mutationToken && mutationToken !== context.extra.authToken) {
+        context.extra.authToken = mutationToken
+      }
+      return result
+    }
     const subResult = dehydrateResult(result)
     const notificationSub = subResult.data?.notificationSubscription as
       | {


### PR DESCRIPTION
# Description

Sync auth token changes from mutations back to the WS connection. Mutations like addTeam, acceptTeamInvitation, joinTeam update contextValue.authToken with a new tms array. Without this sync,
subsequent queries on the same connection would use stale tms.
