### PR TITLE
fix: invitation required on extant team after deleting a team

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamRoot.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamRoot.tsx
@@ -8,9 +8,11 @@ import TeamContainer from '../containers/Team/TeamContainer'
 
 const TeamRoot = () => {
   const {teamId} = useParams()
-  const queryRef = useQueryLoaderNow<TeamContainerQuery>(teamContainerQuery, {
-    teamId: teamId!
-  })
+  const queryRef = useQueryLoaderNow<TeamContainerQuery>(
+    teamContainerQuery,
+    {teamId: teamId!},
+    'network-only'
+  )
   return (
     <Suspense fallback={''}>
       {queryRef && <TeamContainer queryRef={queryRef} teamId={teamId!} />}

--- a/packages/client/modules/teamDashboard/components/TeamRoot.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamRoot.tsx
@@ -8,11 +8,9 @@ import TeamContainer from '../containers/Team/TeamContainer'
 
 const TeamRoot = () => {
   const {teamId} = useParams()
-  const queryRef = useQueryLoaderNow<TeamContainerQuery>(
-    teamContainerQuery,
-    {teamId: teamId!},
-    'network-only'
-  )
+  const queryRef = useQueryLoaderNow<TeamContainerQuery>(teamContainerQuery, {
+    teamId: teamId!
+  })
   return (
     <Suspense fallback={''}>
       {queryRef && <TeamContainer queryRef={queryRef} teamId={teamId!} />}

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -1,4 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
+import {commitLocalUpdate} from 'relay-runtime'
 import type {InvalidateSessionsMutation_notification$data} from '~/__generated__/InvalidateSessionsMutation_notification.graphql'
 import type {NotificationSubscription_meetingStageTimeLimitEnd$data} from '~/__generated__/NotificationSubscription_meetingStageTimeLimitEnd.graphql'
 import type {NotificationSubscription_paymentRejected$data} from '~/__generated__/NotificationSubscription_paymentRejected.graphql'
@@ -266,6 +267,11 @@ const addNewFeatureNotificationUpdater: SharedUpdater<any> = (payload, {store}) 
 
 const authTokenNotificationOnNext: NextHandler = (_payload, {atmosphere}) => {
   atmosphere.refreshSession()
+  // The new auth token's tms has changed, so every viewer.canAccess(...) result
+  // cached in the store may be wrong. Mark viewer stale so the next read refetches.
+  commitLocalUpdate(atmosphere, (store) => {
+    store.getRoot().getLinkedRecord('viewer')?.invalidateRecord()
+  })
 }
 
 const invalidateSessionsNotificationOnNext: OnNextHandler<


### PR DESCRIPTION
# Description

When testing, I noticed a little race: the 1-second resubscription delay in wsHandler.ts:149 will cause the team subscription is to be down momentarily. If the user deletes team A, then quickly clicks team B during while the sub is down, the TeamContainerQuery still goes through — but any subscription-delivered data might be lost, causing Relay to render with incomplete data. This results in a "Invitation Required" error on the client.

Moving to network-only on `TeamContainerQuery` fixes this little edge case