### PR TITLE
fix: various handle leak fixes

### DIFF
--- a/packages/client/components/TipTapEditor/ImportDatabaseDialog.tsx
+++ b/packages/client/components/TipTapEditor/ImportDatabaseDialog.tsx
@@ -107,22 +107,25 @@ export const ImportDatabaseDialog = (props: Props) => {
 
     try {
       const pageId = await new Promise<string>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error('Timed out waiting for page link to be created'))
-        }, 30000)
-
-        root.observeDeep((events) => {
-          events.forEach(async (e) => {
+        const observer = (events: any[]) => {
+          events.forEach(async (e: any) => {
             if (isPageLink(e.target) && e.target.getAttribute('title') === title) {
               const pageCode = e.target.getAttribute('pageCode')
               if (pageCode !== -1) {
                 clearTimeout(timeout)
+                root.unobserveDeep(observer)
                 const pageId = `page:${pageCode}`
                 resolve(pageId)
               }
             }
           })
-        })
+        }
+        const timeout = setTimeout(() => {
+          root.unobserveDeep(observer)
+          reject(new Error('Timed out waiting for page link to be created'))
+        }, 30000)
+
+        root.observeDeep(observer)
 
         const databaseNode = schema.nodes.pageLinkBlock!.create({
           pageCode: -1,

--- a/packages/client/hooks/usePageProvider.ts
+++ b/packages/client/hooks/usePageProvider.ts
@@ -10,29 +10,31 @@ import {getPageSlug} from '../tiptap/getPageSlug'
 import {providerManager} from '../tiptap/providerManager'
 import useAtmosphere from './useAtmosphere'
 
-let headerBlockObserver: null | (() => void) = null
-let currentHeaderBlock: Y.XmlElement | null = null
-
-function observeFirstInnerXmlText(frag: Y.XmlFragment, onChange: (headerBlock: Y.XmlText) => void) {
+function observeFirstInnerXmlText(
+  frag: Y.XmlFragment,
+  onChange: (headerBlock: Y.XmlText) => void,
+  currentHeaderBlockRef: React.MutableRefObject<Y.XmlElement | null>,
+  headerBlockObserverRef: React.MutableRefObject<(() => void) | null>
+) {
   const newHeaderBlock = frag.firstChild as Y.XmlElement
-  if (newHeaderBlock === currentHeaderBlock) return
+  if (newHeaderBlock === currentHeaderBlockRef.current) return
 
-  if (currentHeaderBlock && headerBlockObserver) {
-    currentHeaderBlock.unobserveDeep(headerBlockObserver)
-    headerBlockObserver = null
+  if (currentHeaderBlockRef.current && headerBlockObserverRef.current) {
+    currentHeaderBlockRef.current.unobserveDeep(headerBlockObserverRef.current)
+    headerBlockObserverRef.current = null
   }
 
   if (newHeaderBlock) {
-    headerBlockObserver = () => {
+    headerBlockObserverRef.current = () => {
       const newHeaderText = newHeaderBlock.firstChild as Y.XmlText | null
       if (newHeaderText) {
         onChange(newHeaderText)
       }
     }
-    headerBlockObserver()
-    newHeaderBlock.observeDeep(headerBlockObserver)
+    headerBlockObserverRef.current()
+    newHeaderBlock.observeDeep(headerBlockObserverRef.current)
   }
-  currentHeaderBlock = newHeaderBlock
+  currentHeaderBlockRef.current = newHeaderBlock
 }
 
 const updateUrlWithSlug = (
@@ -67,6 +69,8 @@ export const usePageProvider = (pageId: string) => {
   const pageCode = Number(pageId.split(':')[1])
   const prevPageIdRef = useRef<string | undefined>()
   const [isSynced, setIsSynced] = useState(false)
+  const headerBlockObserverRef = useRef<(() => void) | null>(null)
+  const currentHeaderBlockRef = useRef<Y.XmlElement | null>(null)
   // Connect to your Collaboration server
   const provider = useMemo(() => {
     providerManager.unregister(prevPageIdRef.current)
@@ -84,16 +88,34 @@ export const usePageProvider = (pageId: string) => {
     nextProvider.on('synced', () => {
       setIsSynced(true)
     })
-    const frag = nextProvider.document.getXmlFragment('default')
-    frag.observe((event) => {
-      if (event.changes.added.size > 0 || event.changes.deleted.size > 0) {
-        observeFirstInnerXmlText(frag, (headerBlock) => {
-          updateUrlWithSlug(headerBlock, pageCode, navigate, atmosphere)
-        })
-      }
-    })
     return nextProvider
   }, [pageId])
+
+  // Register the fragment observer in useEffect so it gets cleaned up properly
+  useEffect(() => {
+    const frag = provider.document.getXmlFragment('default')
+    const onSlugChange = (headerBlock: Y.XmlText) => {
+      updateUrlWithSlug(headerBlock, pageCode, navigate, atmosphere)
+    }
+
+    // Set up the initial header block observer for already-synced documents
+    observeFirstInnerXmlText(frag, onSlugChange, currentHeaderBlockRef, headerBlockObserverRef)
+
+    const fragObserver = (event: Y.YXmlEvent) => {
+      if (event.changes.added.size > 0 || event.changes.deleted.size > 0) {
+        observeFirstInnerXmlText(frag, onSlugChange, currentHeaderBlockRef, headerBlockObserverRef)
+      }
+    }
+    frag.observe(fragObserver)
+    return () => {
+      frag.unobserve(fragObserver)
+      if (currentHeaderBlockRef.current && headerBlockObserverRef.current) {
+        currentHeaderBlockRef.current.unobserveDeep(headerBlockObserverRef.current)
+        headerBlockObserverRef.current = null
+        currentHeaderBlockRef.current = null
+      }
+    }
+  }, [provider])
 
   useEffect(() => {
     return () => {

--- a/packages/server/graphql/getDataLoader.ts
+++ b/packages/server/graphql/getDataLoader.ts
@@ -1,6 +1,7 @@
 import {getInMemoryDataLoader} from '../dataloader/getInMemoryDataLoader'
 import {getNewDataLoader} from '../dataloader/getNewDataLoader'
 import {getRedisDataLoader} from '../dataloader/getRedisDataLoader'
+import {Logger} from '../utils/Logger'
 
 // WARNING you must call dispose on the returned dataloader when you're done with it
 // This should be done after the request is complete
@@ -11,15 +12,7 @@ const getDataLoader = async (id: string) => {
   if (inMemoryLoader) return inMemoryLoader
   const redisDataLoader = await getRedisDataLoader(id)
   if (redisDataLoader) return redisDataLoader
-  // setTimeout is here for debugging purposes. Can't figure out what we sometimes get errors saying the dataloader isn't found
-  setTimeout(async () => {
-    const eventualDataloader = await getRedisDataLoader(id)
-    if (eventualDataloader) {
-      console.error(`Tried accessing Redis dataloader before it existed: ${id}`)
-    } else {
-      console.error(`Redis dataloader disposed too early: ${id}`)
-    }
-  }, 3000)
+  Logger.error(`DataLoader not found in memory or Redis: ${id}`)
   // Anything past this line is a bug, but we handle bugs gracefully
   const fallback = getNewDataLoader('getDataLoader-fallback')
   fallback.share()

--- a/packages/server/graphql/mutations/helpers/generateGroups.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroups.ts
@@ -14,53 +14,56 @@ const generateGroups = async (reflections: RetroReflection[], teamId: string) =>
   // the existing dataloader was shared before the titles were updated
   const dataLoader = getNewDataLoader(`generateGroups`)
   const operationId = dataLoader.share()
-  dataLoader.dispose()
   const subOptions = {operationId}
-  const {meetingId} = reflections[0]!
-  const team = await dataLoader.get('teams').loadNonNull(teamId)
-  if (!(await canAccessAI(team, dataLoader))) return
-  const manager = new OpenAIServerManager()
-  const promptIds = [...new Set(reflections.map((r) => r.promptId))]
-  const prompts = await Promise.all(
-    promptIds.map((id) => dataLoader.get('reflectPrompts').loadNonNull(id))
-  )
-  const promptMap = new Map(prompts.map((p) => [p.id, p.question]))
-  const input = reflections.map((r) => ({
-    id: r.id,
-    text: r.plaintextContent,
-    prompt: promptMap.get(r.promptId) ?? ''
-  }))
-  const result = await manager.groupReflectionsStructured(input)
-  if (!result) {
-    Logger.warn('OpenAI was unable to group the reflections')
+  try {
+    const {meetingId} = reflections[0]!
+    const team = await dataLoader.get('teams').loadNonNull(teamId)
+    if (!(await canAccessAI(team, dataLoader))) return
+    const manager = new OpenAIServerManager()
+    const promptIds = [...new Set(reflections.map((r) => r.promptId))]
+    const prompts = await Promise.all(
+      promptIds.map((id) => dataLoader.get('reflectPrompts').loadNonNull(id))
+    )
+    const promptMap = new Map(prompts.map((p) => [p.id, p.question]))
+    const input = reflections.map((r) => ({
+      id: r.id,
+      text: r.plaintextContent,
+      prompt: promptMap.get(r.promptId) ?? ''
+    }))
+    const result = await manager.groupReflectionsStructured(input)
+    if (!result) {
+      Logger.warn('OpenAI was unable to group the reflections')
+      await getKysely()
+        .updateTable('NewMeeting')
+        .set({autogroupReflectionGroups: JSON.stringify([])})
+        .where('id', '=', meetingId)
+        .execute()
+      const data = {meetingId}
+      publish(SubscriptionChannel.MEETING, meetingId, 'GenerateGroupsSuccess', data, subOptions)
+      return
+    }
+    const autogroupReflectionGroups: AutogroupReflectionGroupType[] = result.groups.map((g) => ({
+      groupTitle: g.title,
+      reflectionIds: g.reflectionIds
+    }))
+
     await getKysely()
       .updateTable('NewMeeting')
-      .set({autogroupReflectionGroups: JSON.stringify([])})
+      .set({
+        autogroupReflectionGroups: JSON.stringify(autogroupReflectionGroups)
+      })
       .where('id', '=', meetingId)
       .execute()
+    const meeting = await dataLoader.get('newMeetings').loadNonNull(meetingId)
+    const {facilitatorUserId} = meeting
     const data = {meetingId}
+    const user = await dataLoader.get('users').loadNonNull(facilitatorUserId!)
+    analytics.suggestedGroupsGenerated(user, meetingId, teamId)
     publish(SubscriptionChannel.MEETING, meetingId, 'GenerateGroupsSuccess', data, subOptions)
-    return
+    return autogroupReflectionGroups
+  } finally {
+    dataLoader.dispose()
   }
-  const autogroupReflectionGroups: AutogroupReflectionGroupType[] = result.groups.map((g) => ({
-    groupTitle: g.title,
-    reflectionIds: g.reflectionIds
-  }))
-
-  await getKysely()
-    .updateTable('NewMeeting')
-    .set({
-      autogroupReflectionGroups: JSON.stringify(autogroupReflectionGroups)
-    })
-    .where('id', '=', meetingId)
-    .execute()
-  const meeting = await dataLoader.get('newMeetings').loadNonNull(meetingId)
-  const {facilitatorUserId} = meeting
-  const data = {meetingId}
-  const user = await dataLoader.get('users').loadNonNull(facilitatorUserId!)
-  analytics.suggestedGroupsGenerated(user, meetingId, teamId)
-  publish(SubscriptionChannel.MEETING, meetingId, 'GenerateGroupsSuccess', data, subOptions)
-  return autogroupReflectionGroups
 }
 
 export default generateGroups

--- a/packages/server/graphql/mutations/helpers/generateRetroSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateRetroSummary.ts
@@ -16,37 +16,40 @@ export const generateRetroSummary = async (
   prompt?: string
 ): Promise<string | null> => {
   const dataLoader = getNewDataLoader(`generateRetroSummary`)
-  dataLoader.dispose()
-  const meeting = await dataLoader.get('newMeetings').loadNonNull(meetingId)
-  const {teamId} = meeting
+  try {
+    const meeting = await dataLoader.get('newMeetings').loadNonNull(meetingId)
+    const {teamId} = meeting
 
-  const team = await dataLoader.get('teams').loadNonNull(teamId)
-  const isAISummaryAccessible = await canAccessAI(team, dataLoader)
-  if (!isAISummaryAccessible) {
-    return setSummaryToNull(meetingId)
+    const team = await dataLoader.get('teams').loadNonNull(teamId)
+    const isAISummaryAccessible = await canAccessAI(team, dataLoader)
+    if (!isAISummaryAccessible) {
+      return setSummaryToNull(meetingId)
+    }
+
+    const transformedMeeting = await transformRetroToAIFormat(meetingId, dataLoader)
+    if (!transformedMeeting || transformedMeeting.length === 0) {
+      return setSummaryToNull(meetingId)
+    }
+
+    const yamlData = yaml.dump(transformedMeeting, {
+      noCompatMode: true
+    })
+
+    const manager = new OpenAIServerManager()
+    const newSummary = await manager.generateSummary(yamlData, prompt)
+    if (!newSummary) {
+      return setSummaryToNull(meetingId)
+    }
+
+    const pg = getKysely()
+    await pg
+      .updateTable('NewMeeting')
+      .set({summary: newSummary})
+      .where('id', '=', meetingId)
+      .execute()
+
+    return newSummary
+  } finally {
+    dataLoader.dispose()
   }
-
-  const transformedMeeting = await transformRetroToAIFormat(meetingId, dataLoader)
-  if (!transformedMeeting || transformedMeeting.length === 0) {
-    return setSummaryToNull(meetingId)
-  }
-
-  const yamlData = yaml.dump(transformedMeeting, {
-    noCompatMode: true
-  })
-
-  const manager = new OpenAIServerManager()
-  const newSummary = await manager.generateSummary(yamlData, prompt)
-  if (!newSummary) {
-    return setSummaryToNull(meetingId)
-  }
-
-  const pg = getKysely()
-  await pg
-    .updateTable('NewMeeting')
-    .set({summary: newSummary})
-    .where('id', '=', meetingId)
-    .execute()
-
-  return newSummary
 }

--- a/packages/server/graphql/mutations/helpers/summaryPage/publishSummaryPage.ts
+++ b/packages/server/graphql/mutations/helpers/summaryPage/publishSummaryPage.ts
@@ -20,46 +20,56 @@ export const publishSummaryPage = async (
   const dataLoader = getNewDataLoader('publishSummaryPage')
   const context = {...contextWithoutDataLoader, dataLoader}
   dataLoader.share()
-  const userId = getUserId(authToken)
-  const meeting = await dataLoader.get('newMeetings').loadNonNull(meetingId)
-  const {teamId} = meeting
-  const pg = getKysely()
-  // Get or create the meeting TOC page for this team
-  const meetingTOCpageId = await ensureMeetingTOCPage(userId, teamId, dataLoader, mutatorId)
-  const titleBlock = getTitleBlock(meeting)
-  const title = titleBlock.content[0]?.text ?? '<Untitled>'
-  const meetingSummaryPage = await createNewPage({
-    parentPageId: meetingTOCpageId,
-    userId,
-    summaryMeetingId: meetingId,
-    content: {
-      type: 'doc',
-      content: [
-        // we do this here instead of in the stream
-        // because the schema enforces a title
-        // so we need a title before we can insert a thinking block
-        titleBlock,
-        {
-          type: 'thinkingBlock'
-        }
-      ]
+  let streamStarted = false
+  try {
+    const userId = getUserId(authToken)
+    const meeting = await dataLoader.get('newMeetings').loadNonNull(meetingId)
+    const {teamId} = meeting
+    const pg = getKysely()
+    // Get or create the meeting TOC page for this team
+    const meetingTOCpageId = await ensureMeetingTOCPage(userId, teamId, dataLoader, mutatorId)
+    const titleBlock = getTitleBlock(meeting)
+    const title = titleBlock.content[0]?.text ?? '<Untitled>'
+    const meetingSummaryPage = await createNewPage({
+      parentPageId: meetingTOCpageId,
+      userId,
+      summaryMeetingId: meetingId,
+      content: {
+        type: 'doc',
+        content: [
+          // we do this here instead of in the stream
+          // because the schema enforces a title
+          // so we need a title before we can insert a thinking block
+          titleBlock,
+          {
+            type: 'thinkingBlock'
+          }
+        ]
+      }
+    })
+    const documentName = CipherId.toClient(meetingTOCpageId, 'page')
+    await redisHocusPocus.handleEvent('addCanonicalPageLink', documentName, {
+      title,
+      pageCode: CipherId.encrypt(meetingSummaryPage.id),
+      isDatabase: false
+    })
+    const {id: pageId} = meetingSummaryPage
+    await pg
+      .updateTable('NewMeeting')
+      .set({summaryPageId: pageId})
+      .where('id', '=', meetingId)
+      .execute()
+    meeting.summaryPageId = pageId
+    // don't wait for the stream to finish
+    streamStarted = true
+    streamSummaryBlocksToPage(pageId, meetingId, context, info)
+      .catch(Logger.log)
+      .finally(() => dataLoader.dispose())
+    return meetingSummaryPage
+  } catch (e) {
+    if (!streamStarted) {
+      dataLoader.dispose()
     }
-  })
-  const documentName = CipherId.toClient(meetingTOCpageId, 'page')
-  await redisHocusPocus.handleEvent('addCanonicalPageLink', documentName, {
-    title,
-    pageCode: CipherId.encrypt(meetingSummaryPage.id),
-    isDatabase: false
-  })
-  const {id: pageId} = meetingSummaryPage
-  await pg
-    .updateTable('NewMeeting')
-    .set({summaryPageId: pageId})
-    .where('id', '=', meetingId)
-    .execute()
-  meeting.summaryPageId = pageId
-  // don't wait for the stream to finish
-  streamSummaryBlocksToPage(pageId, meetingId, context, info).catch(Logger.log)
-  dataLoader.dispose()
-  return meetingSummaryPage
+    throw e
+  }
 }

--- a/packages/server/graphql/public/broadcastSubscription.ts
+++ b/packages/server/graphql/public/broadcastSubscription.ts
@@ -3,23 +3,39 @@ import getDataLoader from '../getDataLoader'
 import type {InternalContext} from '../graphql'
 
 export const broadcastSubscription = (iter: SubscriptionIterator, context: InternalContext) => {
+  // `done` short-circuits next() once return() or throw() has fired, so no
+  // further iter.next() calls are made and the wrapper's closures release the
+  // upstream iterator on the next GC pass instead of being pinned by an
+  // in-flight pull.
+  let done = false
   return {
     async next() {
-      const sourceIter = await iter.next()
-      if (sourceIter.done) return sourceIter
-      const {mutatorId, operationId} = sourceIter.value
-      if (mutatorId === context.socketId) return this.next()
-      // use the same dataloader that the mutation used to avoid hitting the DB
-      if (operationId) {
-        // operationId could we null if a mutation purposefully wants to send to self (e.g. new auth token)
-        context.dataLoader = await getDataLoader(operationId)
+      if (done) return {done: true as const, value: undefined}
+      // A single subscription can skip many self-origin messages in a row; a
+      // while-loop avoids building an arbitrarily deep recursive promise chain.
+      while (!done) {
+        const sourceIter = await iter.next()
+        if (sourceIter.done) {
+          done = true
+          return sourceIter
+        }
+        const {mutatorId, operationId} = sourceIter.value
+        if (mutatorId === context.socketId) continue
+        // use the same dataloader that the mutation used to avoid hitting the DB
+        if (operationId) {
+          // operationId could be null if a mutation purposefully wants to send to self (e.g. new auth token)
+          context.dataLoader = await getDataLoader(operationId)
+        }
+        return {done: false, value: sourceIter.value.rootValue}
       }
-      return {done: false, value: sourceIter.value.rootValue}
+      return {done: true as const, value: undefined}
     },
     return() {
+      done = true
       return iter.return()
     },
     throw(error: unknown) {
+      done = true
       return iter.throw(error)
     },
     [Symbol.asyncIterator]() {

--- a/packages/server/hocusPocus.ts
+++ b/packages/server/hocusPocus.ts
@@ -20,7 +20,7 @@ import getVerifiedAuthToken from './utils/getVerifiedAuthToken'
 import {Logger} from './utils/Logger'
 import logError from './utils/logError'
 import {publishPageNotification} from './utils/publishPageNotification'
-import {afterLoadDocument} from './utils/tiptap/afterLoadDocument'
+import {afterLoadDocument, afterUnloadDocument} from './utils/tiptap/afterLoadDocument'
 import * as hocusPocusCustomEvents from './utils/tiptap/hocusPocusCustomEvents'
 import {updateAllBacklinkedPageLinkTitles} from './utils/tiptap/hocusPocusHub'
 import {RedisPublisher} from './utils/tiptap/hocusPocusRedisPublisher'
@@ -162,6 +162,7 @@ export const hocuspocus = new Hocuspocus({
     return {userId}
   },
   afterLoadDocument,
+  afterUnloadDocument,
   extensions: [
     new Database({
       // Return a Promise to retrieve data …

--- a/packages/server/utils/tiptap/RedisServerAffinity.ts
+++ b/packages/server/utils/tiptap/RedisServerAffinity.ts
@@ -339,7 +339,8 @@ export class RedisServerAffinity<TCE extends CustomEvents> implements Extension 
       const {promise, resolve, reject} = Promise.withResolvers()
       this.pendingReplies[replyId] = resolve
       setTimeout(() => {
-        reject('TIMEOUT')
+        delete this.pendingReplies[replyId]
+        reject(new Error('TIMEOUT'))
       }, this.customEventTTL)
       return promise as Promise<ReturnType<TCE[TName]>>
     }
@@ -426,6 +427,7 @@ export class RedisServerAffinity<TCE extends CustomEvents> implements Extension 
   }
 
   async onDestroy() {
+    this.pendingReplies = {}
     this.pub.disconnect(false)
     this.sub.disconnect(false)
   }

--- a/packages/server/utils/tiptap/afterLoadDocument.ts
+++ b/packages/server/utils/tiptap/afterLoadDocument.ts
@@ -7,24 +7,33 @@ import {handleAddedPageLinks} from './handleAddedPageLinks'
 import {handleDeletedPageLinks} from './handleDeletedPageLinks'
 import {syncPageUserMentionNames} from './syncPageUserMentionNames'
 
+// Track observers per document so they can be cleaned up on unload
+const documentObservers = new Map<
+  string,
+  {root: (...args: any[]) => void; data: (...args: any[]) => void}
+>()
+
 export const afterLoadDocument: Extension['afterLoadDocument'] = async ({
   document,
   // DO NOT USE CONTEXT FROM HERE it's just the first user that caused the load on this server,
   documentName
 }) => {
+  // Guard against double-load without intervening unload
+  if (documentObservers.has(documentName)) return
   syncPageUserMentionNames(document).catch(Logger.log)
   const [pageId] = CipherId.fromClient(documentName)
   const root = document.getXmlFragment('default')
-  root.observeDeep((events) => {
+  const rootObserver = (events: any[]) => {
     // Ignore any transactions where the page link is "moved" (deleted, then inserted)
     events.forEach((e) => {
       handleAddedPageLinks(e, pageId)
       handleDeletedPageLinks(e, pageId)
     })
-  })
+  }
+  root.observeDeep(rootObserver)
 
   const data = getData(document)
-  data.observeDeep((events, transaction) => {
+  const dataObserver = (events: any[], transaction: any) => {
     const userId = transaction.origin?.context?.userId ?? undefined
     if (!userId) {
       return
@@ -36,7 +45,7 @@ export const afterLoadDocument: Extension['afterLoadDocument'] = async ({
         const isCellLevel = event.path.length === 1
 
         if (isRowLevel) {
-          event.changes.keys.forEach((change, key) => {
+          event.changes.keys.forEach((change: {action: string}, key: string) => {
             if (change.action === 'add') {
               const row = getRowData(document, key)
               if (!row) {
@@ -58,5 +67,14 @@ export const afterLoadDocument: Extension['afterLoadDocument'] = async ({
         }
       })
     })
-  })
+  }
+  data.observeDeep(dataObserver)
+
+  documentObservers.set(documentName, {root: rootObserver, data: dataObserver})
+}
+
+export const afterUnloadDocument: Extension['afterUnloadDocument'] = async ({documentName}) => {
+  // The Y.Doc is already destroyed by the time afterUnloadDocument fires,
+  // so the observers are gone with it. We just need to clean up our tracking map.
+  documentObservers.delete(documentName)
 }

--- a/packages/server/utils/tiptap/handleAddedPageLinks.ts
+++ b/packages/server/utils/tiptap/handleAddedPageLinks.ts
@@ -62,7 +62,10 @@ export const handleAddedPageLinks = (e: Y.YEvent<any>, parentPageId: number) => 
             ]
           }
         }).catch(Logger.error)
-        if (!newPage) return
+        if (!newPage) {
+          node.unobserve(observer)
+          return
+        }
         const pageCode = CipherId.encrypt(newPage.id)
         node.setAttribute('pageCode', pageCode)
       } else {

--- a/packages/server/wsHandler.ts
+++ b/packages/server/wsHandler.ts
@@ -230,9 +230,10 @@ export const wsHandler = makeBehavior<{token?: string}>({
   },
   onComplete: (ctx, id) => {
     const {extra} = ctx
-    const {dataLoaders} = extra
+    const {dataLoaders, resubscribe} = extra
     dataLoaders[id]?.dispose()
     delete dataLoaders[id]
+    delete resubscribe[id]
   },
   onDisconnect: async (ctx) => {
     const {extra} = ctx
@@ -240,6 +241,7 @@ export const wsHandler = makeBehavior<{token?: string}>({
     const {sub: viewerId, tms: teamIds} = authToken
     Object.values(extra.dataLoaders).forEach((dl) => dl.dispose())
     extra.dataLoaders = {}
+    extra.resubscribe = {}
     activeClients.delete(extra.socketId)
     extra.socket.closed = true
 

--- a/packages/server/wsHandler.ts
+++ b/packages/server/wsHandler.ts
@@ -239,6 +239,25 @@ export const wsHandler = makeBehavior<{token?: string}>({
     const {extra} = ctx
     const {authToken, socketId} = extra
     const {sub: viewerId, tms: teamIds} = authToken
+    // Ensure every active subscription iterator is released.
+    // graphql-ws is supposed to .return() each entry in ctx.subscriptions
+    // before firing onDisconnect, but abnormal closes (socket error, uWS aborts,
+    // process-to-client network drops) can leave entries behind. Those iterators
+    // pin the upstream SubscriptionIterator + Redis pub/sub listener and
+    // context.dataLoader, producing the leaked-generator-closure signature we saw
+    // in heap snapshots. Running .return() here is idempotent and safe.
+    await Promise.all(
+      Object.keys(ctx.subscriptions).map(async (id) => {
+        const sub = ctx.subscriptions[id]
+        delete ctx.subscriptions[id]
+        if (!sub || typeof (sub as {return?: unknown}).return !== 'function') return
+        try {
+          await (sub as AsyncIterator<unknown>).return!(undefined)
+        } catch (e) {
+          Logger.log(`wsHandler.onDisconnect: sub ${id} return threw: ${e}`)
+        }
+      })
+    )
     Object.values(extra.dataLoaders).forEach((dl) => dl.dispose())
     extra.dataLoaders = {}
     extra.resubscribe = {}


### PR DESCRIPTION
## Description

  Should resolve #13007 

  When I went a hunting for recently introduced memory leaks via AI-assisted static analysis, Claude
  created an itemized list of things that were not the memory leak but recommended should be addressed.

  - Clean up Y.js observeDeep/observe callbacks on document unload (server) and effect
  cleanup (client).
  - Unobserve one-shot page-link observer when createNewPage fails.
  - Unobserve database-import observer on both resolve and timeout paths.
  - Delete RedisServerAffinity.pendingReplies entry on timeout; clear map on destroy.
  - Delete wsHandler.resubscribe[id] on subscription complete; reset on disconnect.
  - Defer DataLoader.dispose() until after all get() calls in generateRetroSummary and
  generateGroups (via try/finally).
  - Defer publishSummaryPage dispose until the fire-and-forget stream finishes.
  - Replace getDataLoader diagnostic setTimeout with a single Logger.error.
  - Release orphaned subscription iterators in wsHandler.onDisconnect and short-circuit
  broadcastSubscription.next() after return/throw so async-iterator closures don't get
  pinned past socket close.

## Memory leak summary

  After the static-analysis pass I wasn't convinced those fixes alone explained the ~8h OOM cycle, so I
  grabbed two heap snapshots from a live prod pod via the dumpHeap SIGUSR2 path we already have — one at
  ~700MB right after a restart, and another 3h later on the same pod at ~1.9GB.

  The diff showed two distinct leak shapes:

  1. Y.js / HocusPocus document state — Item +94K, ID +98K, EventHandler +92K, YXmlElement +32K, plus 103MB
   of raw JSArrayBufferData backing stores. That's the observer-cleanup and related fixes in the bullets
  above.
  2. Unreleased async iterators — Generator +9.5K, with closure::next / closure::throw / closure::return
  all tied at +11.3K. Three closures at identical counts is the fingerprint of AsyncIterableIterator
  wrappers that never had .return() called. Traced to broadcastSubscription wrappers pinning the upstream
  SubscriptionIterator, its pub/sub listener, and context.dataLoader when a socket disconnect didn't flow
  through graphql-ws's normal cleanup path.

  Measured growth was ~407 MB/h on top of a ~700 MB post-restart floor. Extrapolating to 8h lands almost
  exactly on the 4GB pod limit, which matches the OOM cadence we've been seeing, so I'm fairly confident
  these two fixes cover it.

 ## Testing scenarios

  - Create a new page
  - Create a new database
  - Smoke test a retro, all the way through summary
  - Post-deploy: re-run the same baseline-vs-leaked heap diff on a long-running pod. Generator and
  closure::next/throw/return deltas should collapse to near-zero, and Item / ID / YXmlElement should
  plateau instead of climbing linearly.