### PR TITLE
fix: handle undefined tms in isTeamMember

### DIFF
--- a/packages/server/graphql/public/rules/isTeamMember.ts
+++ b/packages/server/graphql/public/rules/isTeamMember.ts
@@ -30,7 +30,7 @@ export const isTeamMember = <T>(
         return new GraphQLError(`Permission lookup failed on ${dataLoaderName} for ${argVar}`)
     }
 
-    if (!authToken.tms.includes(teamId)) {
+    if (!authToken.tms?.includes(teamId)) {
       return new GraphQLError(`Viewer is not on team`)
     }
     return true

--- a/packages/server/graphql/public/rules/isTeamMemberOfMeeting.ts
+++ b/packages/server/graphql/public/rules/isTeamMemberOfMeeting.ts
@@ -24,7 +24,7 @@ export const isTeamMemberOfMeeting = <T>(
       return new GraphQLError(`Meeting not found`)
     }
     // All team members can join a meeting, so let them interact with it even if no team member exists yet. This allows for creation of reflections beforehand
-    if (!authToken.tms.includes(meeting.teamId)) {
+    if (!authToken.tms?.includes(meeting.teamId)) {
       return new GraphQLError(`Viewer is not on team`)
     }
     return true


### PR DESCRIPTION
# Description

The Apr 2 permissions refactor (5072ad7f30) reimplemented isTeamMember as a graphql-shield rule but dropped the Array.isArray(tms) guard that the old inline helper had. When authToken.tms is undefined (any request with a missing/invalid JWT hits getVerifiedAuthToken's {} as AuthToken fallback), the new rule throws a TypeError and graphql-shield catches the throw, coerces it to false, and composeResolvers.ts:45 renders that as the literal string "Not authorized" — masking the real problem.

This was causing some operations, like creating/updating meeting recurrence to fail.