### PR TITLE
fix: silent coercion between token failure and absence

### DIFF
--- a/packages/server/assetProxyHandler.ts
+++ b/packages/server/assetProxyHandler.ts
@@ -34,7 +34,7 @@ const servePlaceholderImage = async (res: HttpResponse) => {
 }
 
 export const checkAccess = async (
-  authToken: AuthToken,
+  authToken: AuthToken | null,
   scope: AssetScopeEnum,
   scopeCode: string,
   assetType: AssetType | 'idpMetadata.xml'

--- a/packages/server/atlassianProxyHandler.ts
+++ b/packages/server/atlassianProxyHandler.ts
@@ -7,7 +7,7 @@ import {Logger} from './utils/Logger'
 
 export const atlassianProxyHandler = async (
   res: HttpResponse,
-  authToken: AuthToken,
+  authToken: AuthToken | null,
   teamId: string,
   rawFilename: string,
   servePlaceholderImage: (res: HttpResponse) => Promise<void>

--- a/packages/server/graphql/composeResolvers.ts
+++ b/packages/server/graphql/composeResolvers.ts
@@ -23,7 +23,11 @@ type Resolver = ResolverFn<any, any, any, any>
 
 const options = {
   allowExternalErrors: false,
-  debug: false,
+  // debug: true makes graphql-shield re-throw exceptions from rule callbacks
+  // instead of silently coercing them to `false` (which surfaces to clients
+  // as the opaque "Not authorized"). We catch those throws below and log
+  // them with operation context so permission bugs are visible, not hidden.
+  debug: true,
   fallbackRule: allow,
   fallbackError: () => new Error(''),
   hashFunction: hash
@@ -37,21 +41,29 @@ const wrapResolve =
         cache: {}
       }
     }
+    let res: unknown
     try {
-      const res = await rule.resolve(source, args, context, info, options)
-      if (res === true) {
-        return await resolve(source, args, context, info)
-      } else {
-        if (res === false) return new GraphQLError('Not authorized')
-        if (typeof res === 'string') return new GraphQLError(res)
-        return res
-      }
+      res = await rule.resolve(source, args, context, info, options)
     } catch (err) {
-      if (!(err instanceof GraphQLError)) {
-        Logger.log(err)
-      }
-      throw err
+      const error = err instanceof Error ? err : new Error(String(err))
+      Logger.error(`Permission rule threw on ${info.parentType.name}.${info.fieldName}`, error)
+      return new GraphQLError('Internal server error', {
+        extensions: {code: 'INTERNAL_SERVER_ERROR'}
+      })
     }
+    if (res === true) {
+      try {
+        return await resolve(source, args, context, info)
+      } catch (err) {
+        if (!(err instanceof GraphQLError)) {
+          Logger.log(err)
+        }
+        throw err
+      }
+    }
+    if (res === false) return new GraphQLError('Not authorized')
+    if (typeof res === 'string') return new GraphQLError(res)
+    return res
   }
 
 type ResolverMap = {

--- a/packages/server/graphql/public/rules/isTeamMember.ts
+++ b/packages/server/graphql/public/rules/isTeamMember.ts
@@ -30,7 +30,7 @@ export const isTeamMember = <T>(
         return new GraphQLError(`Permission lookup failed on ${dataLoaderName} for ${argVar}`)
     }
 
-    if (!authToken.tms.includes(teamId)) {
+    if (!authToken.tms?.includes(teamId)) {
       return new GraphQLError(`Viewer is not on team`)
     }
     return true

--- a/packages/server/graphql/public/rules/isTeamMemberOfMeeting.ts
+++ b/packages/server/graphql/public/rules/isTeamMemberOfMeeting.ts
@@ -24,7 +24,7 @@ export const isTeamMemberOfMeeting = <T>(
       return new GraphQLError(`Meeting not found`)
     }
     // All team members can join a meeting, so let them interact with it even if no team member exists yet. This allows for creation of reflections beforehand
-    if (!authToken.tms.includes(meeting.teamId)) {
+    if (!authToken.tms?.includes(meeting.teamId)) {
       return new GraphQLError(`Viewer is not on team`)
     }
     return true

--- a/packages/server/graphql/uWSAsyncHandler.ts
+++ b/packages/server/graphql/uWSAsyncHandler.ts
@@ -16,7 +16,7 @@ const uWSAsyncHandler =
     } catch (e) {
       res.writeStatus('503').end()
       const error = e instanceof Error ? e : new Error('uWSAsyncHandler failed')
-      logError(error, {userId: authToken.sub})
+      logError(error, {userId: authToken?.sub})
     }
   }
 

--- a/packages/server/scim/SCIMHandler.ts
+++ b/packages/server/scim/SCIMHandler.ts
@@ -91,7 +91,7 @@ const scimHandler = (handler: Handler) =>
       // Verify the signature if it's not a bearer token
       if (saml.scimAuthenticationType === 'oauthClientCredentials') {
         const authToken = getVerifiedAuthToken(token)
-        if (!authToken.sub) {
+        if (!authToken?.sub) {
           throw new SCIMMY.Types.Error(401, '', 'Unauthorized')
         }
       }

--- a/packages/server/utils/__tests__/getVerifiedAuthToken.test.ts
+++ b/packages/server/utils/__tests__/getVerifiedAuthToken.test.ts
@@ -56,16 +56,16 @@ test('rejects alg=none token crafted with jsonwebtoken sign()', () => {
   const decoded = JSON.parse(Buffer.from(rawPayload!, 'base64url').toString())
   expect(decoded.sub).toBe(VICTIM_USER_ID)
 
-  // The server must reject the token and return an empty AuthToken
+  // The server must reject the token and return null
   const result = getVerifiedAuthToken(maliciousJwt, false)
-  expect(result.sub).toBeUndefined()
+  expect(result).toBeNull()
 })
 
 test('rejects manually constructed base64url alg=none token', () => {
   const maliciousJwt = craftRawAlgNoneToken(VICTIM_USER_ID)
 
   const result = getVerifiedAuthToken(maliciousJwt, false)
-  expect(result.sub).toBeUndefined()
+  expect(result).toBeNull()
 })
 
 test('rejects the encodeUnsignedAuthToken output when used as a server token', () => {
@@ -76,7 +76,7 @@ test('rejects the encodeUnsignedAuthToken output when used as a server token', (
   const unsignedJwt = encodeUnsignedAuthToken(authToken)
 
   const result = getVerifiedAuthToken(unsignedJwt, false)
-  expect(result.sub).toBeUndefined()
+  expect(result).toBeNull()
 })
 
 test('accepts a legitimately signed token for the same userId', () => {
@@ -86,5 +86,5 @@ test('accepts a legitimately signed token for the same userId', () => {
   const validJwt = encodeAuthToken(authToken)
 
   const result = getVerifiedAuthToken(validJwt, false)
-  expect(result.sub).toBe(VICTIM_USER_ID)
+  expect(result?.sub).toBe(VICTIM_USER_ID)
 })

--- a/packages/server/utils/authorization.ts
+++ b/packages/server/utils/authorization.ts
@@ -25,8 +25,8 @@ export const isSuperUser = (authToken: AuthToken) => {
   return userId ? authToken.rol === 'su' : false
 }
 
-export const isTeamMember = (authToken: AuthToken, teamId: string) => {
-  const {tms} = authToken
+export const isTeamMember = (authToken: AuthToken | null, teamId: string) => {
+  const tms = authToken?.tms
   return Array.isArray(tms) && tms.includes(teamId)
 }
 

--- a/packages/server/utils/getVerifiedAuthToken.ts
+++ b/packages/server/utils/getVerifiedAuthToken.ts
@@ -4,9 +4,12 @@ import logError from './logError'
 
 const SERVER_SECRET_BUFFER = Buffer.from(process.env.SERVER_SECRET!, 'base64')
 
-const getVerifiedAuthToken = (jwt: string | undefined | null, logErrors = true) => {
+const getVerifiedAuthToken = (
+  jwt: string | undefined | null,
+  logErrors = true
+): AuthToken | null => {
   if (!jwt) {
-    return {} as AuthToken
+    return null
   }
   try {
     return verify(jwt, SERVER_SECRET_BUFFER, {
@@ -17,7 +20,7 @@ const getVerifiedAuthToken = (jwt: string | undefined | null, logErrors = true) 
       const error = e instanceof Error ? e : new Error('Verify auth token failed')
       logError(error, {tags: {jwt}})
     }
-    return {} as AuthToken
+    return null
   }
 }
 

--- a/packages/server/wsHandler.ts
+++ b/packages/server/wsHandler.ts
@@ -85,11 +85,11 @@ export const wsHandler = makeBehavior<{token?: string}>({
     if (!authToken) {
       const token = connectionParams?.token
       if (typeof token === 'string') {
-        authToken = getVerifiedAuthToken(token)
-        const {sub: viewerId} = authToken
-        if (!viewerId) return false
-        const isBlacklistedJWT = await checkBlacklistJWT(authToken)
+        const verifiedToken = getVerifiedAuthToken(token)
+        if (!verifiedToken?.sub) return false
+        const isBlacklistedJWT = await checkBlacklistJWT(verifiedToken)
         if (isBlacklistedJWT) return false
+        authToken = verifiedToken
       }
     }
     if (!authToken) return false
@@ -314,23 +314,24 @@ wsHandler.upgrade = async (res, req, context) => {
   let freshToken: AuthToken | null = null
   if (typeof token === 'string') {
     const authToken = getVerifiedAuthToken(token)
-    const {sub: viewerId} = authToken
-    const [isBlacklistedJWT, user] = viewerId
-      ? await Promise.all([
-          checkBlacklistJWT(authToken),
-          getKysely()
-            .selectFrom('User')
-            .select(['id', 'inactive', 'lastSeenAt', 'email', 'tms'])
-            .where('id', '=', viewerId)
-            .where('isRemoved', '=', false)
-            .executeTakeFirst()
-        ])
-      : [true, null]
+    const viewerId = authToken?.sub
+    const [isBlacklistedJWT, user] =
+      authToken && viewerId
+        ? await Promise.all([
+            checkBlacklistJWT(authToken),
+            getKysely()
+              .selectFrom('User')
+              .select(['id', 'inactive', 'lastSeenAt', 'email', 'tms'])
+              .where('id', '=', viewerId)
+              .where('isRemoved', '=', false)
+              .executeTakeFirst()
+          ])
+        : [true, null]
 
     if (isAborted) {
       return
     }
-    if (isBlacklistedJWT || !user) {
+    if (!authToken || isBlacklistedJWT || !user) {
       // We cannot reject here with a 401 because it will be swallowed by the browser and the client cannot distinguish it from other connection errors
       // Let us reject after we've established the connection
       // Setting an empty token here to not allow passing an additional token via the connectionParams in onConnect

--- a/packages/types/augments/index.d.ts
+++ b/packages/types/augments/index.d.ts
@@ -2,6 +2,7 @@
 // if a declaration files calls import, then it is regarded as an ESModule and the scope
 // of the declaration is limited to that module, instead of being hoisted globally
 type ParabolGraphQLErrorCodes =
+  | 'INTERNAL_SERVER_ERROR'
   | 'MAX_PAGE_DEPTH_REACHED'
   | 'NOT_FOUND'
   | 'SESSION_INVALIDATED'


### PR DESCRIPTION
# Description

I fixed a [little regression](https://github.com/ParabolInc/parabol/pull/13002) where users were unable to create/update meeting recurrence. The root cause was `getVerifiedAuthToken` was typed to always return `AuthToken` when in fact, it may return `{}`.

Two updates are in this PR:
- getVerifiedAuthToken is now typed to possibly return `{}`, and all callers are updated to handle that (fixing other bugs)
- Better observability when this class of failures occur:
   - Next time a rule throws the server will log Permission rule threw on
  Mutation.startRetrospective <stack trace> instead of just emitting "Not authorized".
   - We now return INTERNAL_SERVER_ERROR instead of "Not authorized"
