### PR TITLE
fix: recurring meeting regression

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -8,7 +8,7 @@
     "scalars": {
       "DateTime": "Date",
       "File": "File",
-      "RRule": "RRuleSet"
+      "RRule": "string"
     }
   },
   "generates": {
@@ -38,7 +38,6 @@
           "RemoveAuthIdentitySuccess": "./types/RemoveAuthIdentitySuccess#RemoveAuthIdentitySuccessSource",
           "RemoveFeatureFlagOwnerSuccess": "./types/RemoveFeatureFlagOwnerSuccess#RemoveFeatureFlagOwnerSuccessSource",
           "RetrospectiveMeeting": "../../postgres/types/Meeting#RetrospectiveMeeting as RetrospectiveMeetingDB",
-          "RRule": "rrule-rust#RRuleSet",
           "SAML": "../public/types/SAML#SAMLSource",
           "SetIsFreeMeetingTemplateSuccess": "./types/SetIsFreeMeetingTemplateSuccess#SetIsFreeMeetingTemplateSuccessSource",
           "SignupsPayload": "./types/SignupsPayload#SignupsPayloadSource",
@@ -265,7 +264,6 @@
           "RetrospectiveMeeting": "../../postgres/types/Meeting#RetrospectiveMeeting as RetrospectiveMeetingDB",
           "RetrospectiveMeetingMember": "../../postgres/types/Meeting.d#RetroMeetingMember as RetroMeetingMemberDB",
           "RetrospectiveMeetingSettings": "../../postgres/types/index#RetrospectiveMeetingSettings as RetrospectiveMeetingSettingsDB",
-          "RRule": "rrule-rust#RRuleSet",
           "SAML": "./types/SAML#SAMLSource",
           "SearchResultEdge": "./types/SearchResultEdge#SearchResultEdgeSource",
           "SelectTemplatePayload": "./types/SelectTemplatePayload#SelectTemplatePayloadSource",

--- a/packages/server/graphql/public/mutations/startRetrospective.ts
+++ b/packages/server/graphql/public/mutations/startRetrospective.ts
@@ -1,5 +1,6 @@
 import {GraphQLError} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import {RRuleSet} from 'rrule-rust'
 import getKysely from '../../../postgres/getKysely'
 import updateMeetingTemplateLastUsedAt from '../../../postgres/queries/updateMeetingTemplateLastUsedAt'
 import {analytics} from '../../../utils/analytics/analytics'
@@ -17,12 +18,13 @@ import {startNewMeetingSeries} from './updateRecurrenceSettings'
 
 const startRetrospective: MutationResolvers['startRetrospective'] = async (
   _source,
-  {teamId, name, rrule, gcalInput, ignoreSuggestedUpgrade},
+  {teamId, name, rrule: rruleString, gcalInput, ignoreSuggestedUpgrade},
   {authToken, socketId: mutatorId, dataLoader}
 ) => {
   const pg = getKysely()
   const operationId = dataLoader.share()
   const subOptions = {mutatorId, operationId}
+  const rrule = rruleString ? RRuleSet.parse(rruleString) : null
   // AUTH
   const viewerId = getUserId(authToken)
 

--- a/packages/server/graphql/public/mutations/startTeamPrompt.ts
+++ b/packages/server/graphql/public/mutations/startTeamPrompt.ts
@@ -1,5 +1,6 @@
 import {GraphQLError} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import {RRuleSet} from 'rrule-rust'
 import getKysely from '../../../postgres/getKysely'
 import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId} from '../../../utils/authorization'
@@ -18,11 +19,12 @@ const MEETING_START_DELAY_MS = 3000
 
 const startTeamPrompt: MutationResolvers['startTeamPrompt'] = async (
   _source,
-  {teamId, name, rrule, gcalInput, ignoreSuggestedUpgrade},
+  {teamId, name, rrule: rruleString, gcalInput, ignoreSuggestedUpgrade},
   {authToken, dataLoader, socketId: mutatorId}
 ) => {
   const operationId = dataLoader.share()
   const subOptions = {mutatorId, operationId}
+  const rrule = rruleString ? RRuleSet.parse(rruleString) : null
 
   // AUTH
   const viewerId = getUserId(authToken)

--- a/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
+++ b/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
@@ -124,13 +124,14 @@ const updateGCalRecurrenceRule = (oldRule: RRuleSet, newRule: RRuleSet | null | 
 
 const updateRecurrenceSettings: MutationResolvers['updateRecurrenceSettings'] = async (
   _source,
-  {meetingId, name, rrule},
+  {meetingId, name, rrule: rruleString},
   {authToken, dataLoader, socketId: mutatorId}
 ) => {
   const pg = getKysely()
   const viewerId = getUserId(authToken)
   const operationId = dataLoader.share()
   const subOptions = {mutatorId, operationId}
+  const rrule = rruleString ? RRuleSet.parse(rruleString) : null
 
   // VALIDATION
   const [meeting, viewer] = await Promise.all([

--- a/packages/server/graphql/public/types/RRule.ts
+++ b/packages/server/graphql/public/types/RRule.ts
@@ -2,7 +2,8 @@ import {Kind} from 'graphql'
 import {Frequency, RRuleSet} from 'rrule-rust'
 import type {RRuleScalarConfig} from '../resolverTypes'
 
-const isRRuleValid = (rrule: RRuleSet) => {
+const validateRRule = (raw: string) => {
+  const rrule = RRuleSet.parse(raw)
   const {tzid, rrules} = rrule
   const [firstRule] = rrules
   if (!firstRule || rrules.length > 1) {
@@ -33,6 +34,7 @@ const isRRuleValid = (rrule: RRuleSet) => {
   } catch {
     throw new Error('RRULE time zone is invalid')
   }
+  return raw
 }
 
 const RRuleScalarType: RRuleScalarConfig = {
@@ -42,20 +44,16 @@ const RRuleScalarType: RRuleScalarConfig = {
     if (typeof value !== 'string') {
       throw new Error(`RRule is not a string, it is a: ${typeof value}`)
     }
-    const rrule = RRuleSet.parse(value)
-    isRRuleValid(rrule)
-    return rrule
+    return validateRRule(value)
   },
   serialize(value: unknown) {
-    return (value as RRuleSet).toString()
+    return String(value)
   },
   parseLiteral(ast) {
     if (ast.kind !== Kind.STRING) {
       throw new Error(`RRule is not a string, it is a: ${ast.kind}`)
     }
-    const rrule = RRuleSet.parse(ast.value)
-    isRRuleValid(rrule)
-    return rrule
+    return validateRRule(ast.value)
   }
 }
 


### PR DESCRIPTION
## Description

Fixes a regression where scheduling a recurring meeting failed with Failed to unwrap exclusive
reference of RRule type from napi value.

Root cause: the RRule GraphQL scalar was returning an RRuleSet instance (a napi-wrapped handle from
rrule-rust) as the parsed arg value. When graphql-shield hashed the resolver args for permission-rule
caching, object-hash deep-walked into the wrapper's internal .rust native reference and hit Rust's
exclusive-borrow semantics. The error surfaced recently because #13006 turned on debug: true — before
that, the napi panic was silently coerced to "permission denied".

Instead of patching the hash layer defensively, the scalar now validates and returns the raw RRULE
string. GraphQL args stay as plain data (hashable, serializable, loggable) and each mutation parses
once at its entry point before passing the typed handle to the existing helpers.

## Changes

- RRule scalar: validate via RRuleSet.parse, return the original string
- codegen.json: map RRule to string
- startRetrospective, startTeamPrompt, updateRecurrenceSettings: parse rrule once at mutation entry
- Helper signatures (startNewMeetingSeries, createGcalEvent, etc.) unchanged — napi objects stay
internal

## Test plan

- [x] Start a recurring retro — succeeds, series is created
- [x] Start a recurring team prompt — succeeds
- [x] Update an existing meeting's recurrence rule — succeeds
- [x] Stop a recurring series (rrule: null) — succeeds
- [x] Invalid RRULE strings still rejected at the scalar layer with the existing error messages
- [x] gcal event creation still receives the rule and sets recurrence correctly