### PR TITLE
fix: unable to end meetings started by recurrence

### DIFF
--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -63,6 +63,7 @@ const query = graphql`
         id
         meetingType
         facilitatorUserId
+        endedAt
         meetingSeries {
           cancelledAt
         }
@@ -84,9 +85,10 @@ const MeetingCardOptionsMenu = (props: Props) => {
   const {id: viewerId, team, meeting} = viewer
   const {massInvitation} = team!
   const {id: token} = massInvitation
-  const {id: meetingId, meetingType, facilitatorUserId, meetingSeries} = meeting!
+  const {id: meetingId, meetingType, facilitatorUserId, endedAt, meetingSeries} = meeting!
   const isViewerFacilitator = facilitatorUserId === viewerId
-  const canEndMeeting = meetingType === 'teamPrompt' || isViewerFacilitator
+  const canManageMeeting = meetingType === 'teamPrompt' || isViewerFacilitator
+  const canEndMeeting = canManageMeeting && !endedAt
   const atmosphere = useAtmosphere()
   const {onCompleted, onError} = useMutationProps()
   const navigate = useNavigate()
@@ -140,7 +142,7 @@ const MeetingCardOptionsMenu = (props: Props) => {
           })
         }}
       />
-      {canEndMeeting && hasRecurrenceEnabled && (
+      {canManageMeeting && hasRecurrenceEnabled && (
         <MenuItem
           key='edit-recurrence'
           label={

--- a/packages/client/ui/Dialog/DialogActions.tsx
+++ b/packages/client/ui/Dialog/DialogActions.tsx
@@ -2,5 +2,5 @@ import type * as React from 'react'
 import {twMerge} from 'tailwind-merge'
 
 export const DialogActions = ({className, ...props}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={twMerge('mt-6 flex justify-end space-x-2', className)} {...props} />
+  <div className={twMerge('mt-6 flex justify-end gap-2', className)} {...props} />
 )


### PR DESCRIPTION
# Description

Client code was not using `endedAt` properly to filter out meetings in recurring meeting series.

Also fixed a little spacing issue.

