### PR TITLE
fix: Pages intermittent newlines

### DIFF
--- a/packages/client/hooks/usePageProvider.ts
+++ b/packages/client/hooks/usePageProvider.ts
@@ -1,3 +1,4 @@
+import type {HocuspocusProvider} from '@hocuspocus/provider'
 import {generateJSON, generateText} from '@tiptap/react'
 import {useEffect, useMemo, useRef, useState} from 'react'
 import {type NavigateFunction, useNavigate} from 'react-router'
@@ -68,28 +69,34 @@ export const usePageProvider = (pageId: string) => {
   const navigate = useNavigate()
   const pageCode = Number(pageId.split(':')[1])
   const prevPageIdRef = useRef<string | undefined>()
-  const [isSynced, setIsSynced] = useState(false)
+  const [syncedProvider, setSyncedProvider] = useState<HocuspocusProvider | null>(null)
   const headerBlockObserverRef = useRef<(() => void) | null>(null)
   const currentHeaderBlockRef = useRef<Y.XmlElement | null>(null)
   // Connect to your Collaboration server
   const provider = useMemo(() => {
     providerManager.unregister(prevPageIdRef.current)
-    setIsSynced(false)
     prevPageIdRef.current = pageId
-
-    // if we've already opened a provider, use that
-    const existingProvider = providerManager.use(pageId)
-    if (existingProvider) {
-      setIsSynced(true)
-      return existingProvider
-    }
-
-    const nextProvider = providerManager.register(pageId)
-    nextProvider.on('synced', () => {
-      setIsSynced(true)
-    })
-    return nextProvider
+    const existing = providerManager.use(pageId)
+    return existing ?? providerManager.register(pageId)
   }, [pageId])
+
+  // Gate the editor on the provider's actual sync state, not on cache presence:
+  // a cached-but-pre-sync provider lets the editor mount on an empty Y.Doc and
+  // commit its schema-default content as a local CRDT write, which the server's
+  // later state then merges behind rather than replaces.
+  useEffect(() => {
+    if (provider.synced) {
+      setSyncedProvider(provider)
+      return
+    }
+    const handler = () => setSyncedProvider(provider)
+    provider.on('synced', handler)
+    return () => {
+      provider.off('synced', handler)
+    }
+  }, [provider])
+
+  const isSynced = syncedProvider === provider
 
   // Register the fragment observer in useEffect so it gets cleaned up properly
   useEffect(() => {

--- a/packages/client/modules/pages/useEditablePage.ts
+++ b/packages/client/modules/pages/useEditablePage.ts
@@ -1,9 +1,19 @@
 import type {HocuspocusProvider} from '@hocuspocus/provider'
 import type {Editor} from '@tiptap/core'
 import {useEffect, useState} from 'react'
+import type * as Y from 'yjs'
+import {XmlElement} from 'yjs'
+
+const hasThinkingBlock = (doc: Y.Doc) => {
+  const frag = doc.getXmlFragment('default')
+  return frag
+    .toArray()
+    .some((node) => node instanceof XmlElement && node.nodeName === 'thinkingBlock')
+}
 
 export const useEditablePage = (provider: HocuspocusProvider, editor: Editor) => {
   const [authorizedScope, setAuthorizedScope] = useState(provider.authorizedScope)
+  const [isStreaming, setIsStreaming] = useState(() => hasThinkingBlock(provider.document))
 
   useEffect(() => {
     const handler = ({scope}: {scope: string}) => setAuthorizedScope(scope)
@@ -13,7 +23,20 @@ export const useEditablePage = (provider: HocuspocusProvider, editor: Editor) =>
     }
   }, [provider])
 
-  const isEditable = authorizedScope !== 'readonly'
+  // Lock edits while the server is streaming summary blocks. The thinkingBlock
+  // is inserted at publish time and removed once streaming finishes; its
+  // presence is the authoritative signal that edits must not land yet.
+  useEffect(() => {
+    const frag = provider.document.getXmlFragment('default')
+    const check = () => setIsStreaming(hasThinkingBlock(provider.document))
+    check()
+    frag.observe(check)
+    return () => {
+      frag.unobserve(check)
+    }
+  }, [provider])
+
+  const isEditable = authorizedScope !== 'readonly' && !isStreaming
 
   useEffect(() => {
     if (editor.isEditable !== isEditable) {

--- a/packages/server/graphql/mutations/helpers/summaryPage/streamSummaryBlocksToPage.ts
+++ b/packages/server/graphql/mutations/helpers/summaryPage/streamSummaryBlocksToPage.ts
@@ -33,48 +33,60 @@ export const streamSummaryBlocksToPage = async (
   const documentName = CipherId.toClient(pageId, 'page')
   const unlock = await redisHocusPocus.lockDocument(documentName)
   const conn = await hocuspocus.openDirectConnection(documentName, {})
-  let lastBlock: XmlElement
-  for await (const rawContent of contentGenerator) {
-    if (!rawContent) continue
-    const content = rawContent.filter(Boolean)
-    if (content.length === 0) continue
-    try {
-      const tempYDoc = TiptapTransformer.toYdoc(
-        {
-          type: 'doc',
-          content
-        },
-        undefined,
-        serverTipTapExtensions
-      )
-      const blocks = tempYDoc
-        .getXmlFragment('default')
-        .toArray()
-        .map((block) => cloneBlock(block as XmlElement))
+  try {
+    for await (const rawContent of contentGenerator) {
+      if (!rawContent) continue
+      const content = rawContent.filter(Boolean)
+      if (content.length === 0) continue
+      try {
+        const tempYDoc = TiptapTransformer.toYdoc(
+          {
+            type: 'doc',
+            content
+          },
+          undefined,
+          serverTipTapExtensions
+        )
+        const blocks = tempYDoc
+          .getXmlFragment('default')
+          .toArray()
+          .map((block) => cloneBlock(block as XmlElement))
 
-      await conn.transact((doc) => {
-        const frag = doc.getXmlFragment('default')
-        lastBlock = lastBlock || frag.firstChild
-        frag.insertAfter(lastBlock, blocks)
-        lastBlock = blocks.at(-1)!
-      })
-    } catch (e) {
-      console.error('Invalid block generated', e, JSON.stringify(content))
-    }
-    // not necessary, just to make it look like it is streaming lol
-    await sleep(100)
-  }
-  await conn.transact((doc) => {
-    // remove the thinking block now that we're done
-    const frag = doc.getXmlFragment('default')
-    for (let i = frag.length - 1; i >= 0; i--) {
-      const node = frag.get(i) as XmlElement
-      if (node.nodeName === 'thinkingBlock') {
-        frag.delete(i)
-        break
+        await conn.transact((doc) => {
+          const frag = doc.getXmlFragment('default')
+          // Anchor insertion to the thinkingBlock so user edits at the top of the
+          // doc (e.g. a stray Enter in the auto-focused title) can't displace the
+          // stream target.
+          const thinkingIdx = frag
+            .toArray()
+            .findIndex((n) => n instanceof XmlElement && n.nodeName === 'thinkingBlock')
+          if (thinkingIdx === -1) {
+            frag.push(blocks)
+          } else {
+            frag.insert(thinkingIdx, blocks)
+          }
+        })
+      } catch (e) {
+        console.error('Invalid block generated', e, JSON.stringify(content))
       }
+      // not necessary, just to make it look like it is streaming lol
+      await sleep(100)
     }
-  })
-  await conn.disconnect()
-  unlock()
+  } finally {
+    // Always remove the thinkingBlock and release the connection/lock, even if
+    // the generator threw. Leaving a thinkingBlock in the doc would pin the
+    // client editor to read-only (see useEditablePage.ts).
+    await conn.transact((doc) => {
+      const frag = doc.getXmlFragment('default')
+      for (let i = frag.length - 1; i >= 0; i--) {
+        const node = frag.get(i)
+        if (node instanceof XmlElement && node.nodeName === 'thinkingBlock') {
+          frag.delete(i)
+          break
+        }
+      }
+    })
+    await conn.disconnect()
+    unlock()
+  }
 }


### PR DESCRIPTION
# Description

While testing I ran into a regression #12571, then found another case where newlines are inadvertently added to Pages docs. It turns out the latter case is a byproduct of React 18 strict mode.

Fixes are straightforward enough. Going to merge and aim to deploy.