### PR TITLE
fix: volume mount for local pg

### DIFF
--- a/docker/stacks/development/docker-compose.yml
+++ b/docker/stacks/development/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - "postgres-data:/var/lib/postgresql/data"
+      - "postgres-data:/var/lib/postgresql"
     networks:
       - parabol-network
   pgadmin:


### PR DESCRIPTION
# Description

pg data now mounts an /PG_VERSION for upgrade reasons