### PR TITLE
refactor: improve fetch retry logic and ensure response bodies are canceled

### DIFF
--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -73,7 +73,7 @@ export default abstract class AtlassianManager {
       })
       const {headers} = res
       if (res.status === 429) {
-        await res.arrayBuffer().catch(() => {})
+        await res.body?.cancel()
         const retryAfterSeconds = headers.get('Retry-After') ?? '3'
         return new RateLimitError(
           'got jira rate limit error',
@@ -82,7 +82,7 @@ export default abstract class AtlassianManager {
       }
       const contentType = headers.get('content-type') || ''
       if (!contentType.includes('application/json')) {
-        await res.arrayBuffer().catch(() => {})
+        await res.body?.cancel()
         return new Error('Received non-JSON Atlassian Response')
       }
       const json = (await res.json()) as AtlassianError | JiraNoAccessError | JiraGetError | T

--- a/packages/server/utils/AtlassianServerManager.ts
+++ b/packages/server/utils/AtlassianServerManager.ts
@@ -320,7 +320,7 @@ class AtlassianServerManager extends AtlassianManager {
       const {headers} = res
       const contentType = headers.get('content-type') || ''
       if (!contentType.includes('application/json')) {
-        await res.arrayBuffer().catch(() => {})
+        await res.body?.cancel()
         return new Error('Received non-JSON Atlassian Response')
       }
       const json = (await res.json()) as AtlassianError | JiraNoAccessError | JiraGetError | T

--- a/packages/server/utils/atlassian/jiraImages.ts
+++ b/packages/server/utils/atlassian/jiraImages.ts
@@ -58,7 +58,10 @@ export const downloadAndCacheImage = async (
 
   const contentType = res.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase()
   const ext = contentType ? mime.extension(contentType) : null
-  if (!ext) return null
+  if (!ext) {
+    await res.body?.cancel()
+    return null
+  }
 
   const hash = createImageUrlHash(fetchUrl)
   const partialPath = `Team/${teamId}/assets/${hash}.${ext}` as PartialPath
@@ -66,6 +69,7 @@ export const downloadAndCacheImage = async (
   const fileStoreManager = getFileStoreManager()
   const exists = await fileStoreManager.checkExists(partialPath)
   if (exists) {
+    await res.body?.cancel()
     return makeAppURL(appOrigin, `/assets/${partialPath}`)
   }
 

--- a/packages/server/utils/fetchWithRetry.ts
+++ b/packages/server/utils/fetchWithRetry.ts
@@ -2,68 +2,73 @@ import {fetch} from '@whatwg-node/fetch'
 import {Logger} from './Logger'
 
 interface FetchWithRetryOptions extends RequestInit {
-  deadline: Date // Deadline for the request to complete
+  deadline: Date // Deadline for all attempts combined
   debug?: boolean // Enable debug tracing
-  retryStatusCodes?: number[] // Array of status codes to retry on
+  retryStatusCodes?: number[] // Status codes that trigger a retry
 }
 
-export default async (url: RequestInfo, options: FetchWithRetryOptions): Promise<Response> => {
+export default async function fetchWithRetry(
+  url: RequestInfo,
+  options: FetchWithRetryOptions
+): Promise<Response> {
   const {deadline, debug = false, retryStatusCodes = [429], ...fetchOptions} = options
   let attempt = 0
-  const controller = new AbortController()
-  fetchOptions.signal = controller.signal
 
-  const timeout = deadline.getTime() - Date.now()
-  if (timeout <= 0) {
+  if (Date.now() >= deadline.getTime()) {
     throw new Error('Deadline has already passed')
   }
 
-  const timeoutId = setTimeout(() => controller.abort(), timeout)
+  while (Date.now() < deadline.getTime()) {
+    attempt++
+    // Recompute remaining time on every attempt so the signal is fresh
+    const remainingMs = deadline.getTime() - Date.now()
 
-  try {
-    while (Date.now() < deadline.getTime()) {
-      attempt++
-
-      if (debug) {
-        Logger.log(`Attempt ${attempt}: Fetching ${JSON.stringify(url)}`)
-      }
-
-      const response = await fetch(url, fetchOptions)
-
-      if (!retryStatusCodes.includes(response.status)) {
-        clearTimeout(timeoutId)
-        return response
-      }
-
-      const retryAfter = response.headers.get('Retry-After')
-      await response.body?.cancel()
-      // if Retry-After specified, use it; else fallback to exponential backoff
-      let waitTime = retryAfter ? parseInt(retryAfter, 10) * 1000 : 2 ** attempt * 1000
-
-      // cap waitTime to prevent exceeding the deadline
-      waitTime = Math.min(waitTime, deadline.getTime() - Date.now())
-
-      if (debug) {
-        Logger.log(
-          `Waiting ${waitTime / 1000} seconds before retrying due to status ${response.status}...`
-        )
-      }
-      await new Promise((resolve) => setTimeout(resolve, waitTime))
-    }
-
-    throw new Error('Deadline exceeded')
-  } catch (error) {
-    clearTimeout(timeoutId)
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error('Request aborted due to deadline')
-    }
     if (debug) {
-      Logger.warn(`Attempt ${attempt} failed: ${error}`)
+      Logger.log(`Attempt ${attempt}: Fetching ${JSON.stringify(url)}`)
     }
-    const currentTime = Date.now()
-    if (currentTime >= deadline.getTime()) {
-      throw new Error('Deadline exceeded before a successful request')
+
+    let response: Response
+    try {
+      response = await fetch(url, {
+        ...fetchOptions,
+        signal: AbortSignal.timeout(remainingMs)
+      })
+    } catch (error) {
+      const isAbort =
+        error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')
+      if (isAbort || Date.now() >= deadline.getTime()) {
+        throw new Error('Request aborted: deadline exceeded')
+      }
+      if (debug) {
+        Logger.warn(`Attempt ${attempt} failed with error: ${error}`)
+      }
+      throw error
     }
-    throw error // Re-throw the error if it's not related to deadline exceeding
+
+    if (!retryStatusCodes.includes(response.status)) {
+      return response
+    }
+
+    // Drain the body so the socket is released back to the pool
+    await response.body?.cancel()
+
+    const retryAfterHeader = response.headers.get('Retry-After')
+    const retryAfterMs = retryAfterHeader !== null ? parseInt(retryAfterHeader, 10) * 1000 : NaN
+    const backoffMs = Number.isFinite(retryAfterMs) ? retryAfterMs : 2 ** attempt * 1000
+
+    // Never wait past the deadline
+    const waitMs = Math.min(backoffMs, deadline.getTime() - Date.now())
+
+    if (waitMs <= 0) {
+      break
+    }
+
+    if (debug) {
+      Logger.log(`Attempt ${attempt} got ${response.status}. Retrying in ${waitMs / 1000}s...`)
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, waitMs))
   }
+
+  throw new Error('Deadline exceeded before a successful response')
 }


### PR DESCRIPTION
# Description

fixes the memory leak (i hope!).
the fetch agent was storing a ton of TLSSocket types that originated from atlassian's media server, so i bet whenever that image already existed in our system, we left the body unread.

