### PR TITLE
fix: log missing adhoc query costs and move docId assignment

### DIFF
--- a/packages/server/utils/useArmor.ts
+++ b/packages/server/utils/useArmor.ts
@@ -12,6 +12,7 @@ import type {ServerContext} from '../yoga'
 import {getUserId} from './authorization'
 import {BoundedCache} from './BoundedCache'
 import getRedis, {type RedisPipelineResponse} from './getRedis'
+import {Logger} from './Logger'
 
 const queryCostCache = new BoundedCache<string, number>(100)
 
@@ -116,7 +117,11 @@ export const useArmor = (): Plugin<ServerContext & {dataLoader: DataLoaderWorker
       const isSuperUser = authTokenRole === 'su'
       if (docId || isSuperUser) return
       const apiCost = contextCost || queryCostCache.get(print(args.document))
-      if (!apiCost) throw new GraphQLError('API Cost for adhoc query not determined')
+      if (!apiCost) {
+        // can remove after 5/20/26 to provide a decent test window
+        Logger.error('API Cost for adhoc query not determined')
+        throw new GraphQLError('API Cost for adhoc query not determined')
+      }
       const viewerId = getUserId(authToken)
       if (!viewerId) throw new GraphQLError('No auth token for PAT')
       const [tier, usage] = await Promise.all([

--- a/packages/server/wsHandler.ts
+++ b/packages/server/wsHandler.ts
@@ -181,11 +181,11 @@ export const wsHandler = makeBehavior<{token?: string; docId?: string}>({
     const {ip, authToken, socketId, resubscribe} = extra
     const {schema, execute, subscribe, parse, contextFactory} = yoga.getEnveloped(ctx)
     const docId = extractPersistedOperationId(params as any)
+    // armor requires a docId to know this isn't an adhoc query
+    ;(ctx as any).docId = docId
     let document = documentCache.get(docId!)
     if (!document) {
       const query = await getPersistedOperation(docId!)
-      // armor requires a docId to allow skipping validation
-      ;(ctx as any).docId = docId
       document = parse(query)
       documentCache.set(docId, document)
     }


### PR DESCRIPTION
# Description

I broke prod bad because it thought in-app persisted queries were adhoc requests.
This was because requests coming from websockets only attached a docId when it saw a query for the first time.
This meant called a request 2+ times would result in an error for all subsequent calls.
