### PR TITLE
chore: disable Datadog session recording and user interaction tracking

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -67,8 +67,8 @@ if (datadogEnabled) {
     site: 'datadoghq.com',
     service: datadogService,
     version: __APP_VERSION__,
-    sessionSampleRate: 100,
-    trackUserInteractions: true,
+    sessionSampleRate: 0,
+    trackUserInteractions: false,
     defaultPrivacyLevel: 'allow'
   })
   datadogRum.startSessionReplayRecording()

--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -67,7 +67,8 @@ if (datadogEnabled) {
     site: 'datadoghq.com',
     service: datadogService,
     version: __APP_VERSION__,
-    sessionSampleRate: 0,
+    sessionSampleRate: 100,
+    sessionReplaySampleRate: 0,
     trackUserInteractions: false,
     defaultPrivacyLevel: 'allow'
   })


### PR DESCRIPTION
# Description

disable session tracking to keep our dd bills down, but i re-enabled dd overall so we at least get client errors