### PR TITLE
feat: Expose GraphQL Schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@graphql-codegen/typescript": "5.0.9",
     "@graphql-codegen/typescript-operations": "5.0.9",
     "@graphql-codegen/typescript-resolvers": "5.1.7",
+    "@graphql-tools/utils": "^11.1.0",
     "@parcel/watcher": "^2.5.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.16",
     "@sucrase/webpack-loader": "^2.0.0",

--- a/packages/client/modules/admin/containers/Graphql/GraphqlContainer.tsx
+++ b/packages/client/modules/admin/containers/Graphql/GraphqlContainer.tsx
@@ -1,7 +1,7 @@
 // There's some bug where I can't import .css directly from graphiql. Probably ESM related
 import './monkeyPatchMonacoEnvironment'
 import './style.css'
-import {createGraphiQLFetcher} from '@graphiql/toolkit'
+import {createGraphiQLFetcher, type FetcherOpts, type FetcherParams} from '@graphiql/toolkit'
 import {GraphiQL} from 'graphiql'
 import {useCallback, useEffect, useState} from 'react'
 import {Link} from 'react-router'
@@ -27,10 +27,24 @@ const GraphqlContainer = () => {
   const [showModal, setShowModal] = useState(!isSuperUser && !accessToken)
 
   const fetcher = useCallback(
-    createGraphiQLFetcher({
-      url: '/graphql',
-      headers: accessToken ? {authorization: `Bearer ${accessToken}`} : undefined
-    }),
+    (() => {
+      const baseFetcher = createGraphiQLFetcher({
+        url: '/graphql',
+        headers: accessToken ? {authorization: `Bearer ${accessToken}`} : undefined
+      })
+      return (params: FetcherParams, opts?: FetcherOpts) => {
+        const isIntrospection =
+          params.operationName === 'IntrospectionQuery' ||
+          params.query.includes('__schema') ||
+          params.query.includes('__type')
+        if (isIntrospection && !isSuperUser) {
+          return fetch('/graphql/schema.json')
+            .then((res) => res.json())
+            .then((data) => ({data}))
+        }
+        return baseFetcher(params, opts)
+      }
+    })(),
     [accessToken]
   )
 

--- a/packages/server/schemaProxyHandler.ts
+++ b/packages/server/schemaProxyHandler.ts
@@ -1,0 +1,23 @@
+import type {HttpRequest, HttpResponse} from 'uWebSockets.js'
+import ms from 'ms'
+import type {PartialPath} from './fileStorage/FileStoreManager'
+import getFileStoreManager from './fileStorage/getFileStoreManager'
+import uWSAsyncHandler from './graphql/uWSAsyncHandler'
+import {redisStoreOrNetwork} from './utils/redisStoreOrNetwork'
+
+const SCHEMA_PATH = '/build/schema.graphql' as PartialPath
+
+export const schemaProxyHandler = uWSAsyncHandler(async (res: HttpResponse, _req: HttpRequest) => {
+  const manager = getFileStoreManager()
+  const expiresIn = ms('1h') / 1000
+  const url = await redisStoreOrNetwork(
+    `presignedURL:${SCHEMA_PATH}`,
+    () => manager.presignUrl(SCHEMA_PATH, expiresIn),
+    expiresIn - ms('30m') / 1000
+  )
+  res
+    .writeStatus('307')
+    .writeHeader('Location', url)
+    .writeHeader('Cache-Control', `public, max-age=${expiresIn}`)
+    .end()
+})

--- a/packages/server/schemaProxyHandler.ts
+++ b/packages/server/schemaProxyHandler.ts
@@ -5,19 +5,27 @@ import getFileStoreManager from './fileStorage/getFileStoreManager'
 import uWSAsyncHandler from './graphql/uWSAsyncHandler'
 import {redisStoreOrNetwork} from './utils/redisStoreOrNetwork'
 
-const SCHEMA_PATH = '/build/schema.graphql' as PartialPath
+const SUPPORTED_NAMES = new Set(['schema.graphql', 'schema.json'])
 
-export const schemaProxyHandler = uWSAsyncHandler(async (res: HttpResponse, _req: HttpRequest) => {
+export const schemaProxyHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpRequest) => {
+  const url = req.getUrl()
+  const name = url.slice('/graphql/'.length)
+  if (!SUPPORTED_NAMES.has(name)) {
+    res.writeStatus('404 Not Found').end()
+    return
+  }
+  const schemaPath = `/build/${name}` as PartialPath
   const manager = getFileStoreManager()
   const expiresIn = ms('1h') / 1000
-  const url = await redisStoreOrNetwork(
-    `presignedURL:${SCHEMA_PATH}`,
-    () => manager.presignUrl(SCHEMA_PATH, expiresIn),
+
+  const presignedUrl = await redisStoreOrNetwork(
+    `presignedURL:${schemaPath}`,
+    () => manager.presignUrl(schemaPath, expiresIn),
     expiresIn - ms('30m') / 1000
   )
   res
     .writeStatus('307')
-    .writeHeader('Location', url)
+    .writeHeader('Location', presignedUrl)
     .writeHeader('Cache-Control', `public, max-age=${expiresIn}`)
     .end()
 })

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -15,6 +15,7 @@ import {metricsHandler} from './metricsHandler'
 import authorizeHandler from './oauth2/authorizeHandler'
 import tokenHandler from './oauth2/tokenHandler'
 import PWAHandler from './PWAHandler'
+import {schemaProxyHandler} from './schemaProxyHandler'
 import {registerSCIMHandlers} from './scim/SCIMHandler'
 import selfHostedHandler from './selfHostedHandler'
 import {createStaticFileHandler} from './staticFileHandler'
@@ -66,6 +67,7 @@ const app = uws
   .get('/self-hosted/*', selfHostedHandler)
   .get('/assets/*', assetProxyHandler)
   .get('/build/*', buildProxyHandler)
+  .get('/graphql/schema.graphql', schemaProxyHandler)
   .get('/health', yoga)
   .get('/ready', yoga)
   .post('/stripe', stripeWebhookHandler)

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -67,7 +67,7 @@ const app = uws
   .get('/self-hosted/*', selfHostedHandler)
   .get('/assets/*', assetProxyHandler)
   .get('/build/*', buildProxyHandler)
-  .get('/graphql/schema.graphql', schemaProxyHandler)
+  .get('/graphql/*', schemaProxyHandler)
   .get('/health', yoga)
   .get('/ready', yoga)
   .post('/stripe', stripeWebhookHandler)

--- a/packages/server/utils/updateGQLSchema.ts
+++ b/packages/server/utils/updateGQLSchema.ts
@@ -6,6 +6,7 @@
 
 import {readFile, writeFile} from 'node:fs/promises'
 import {mergeSchemas} from '@graphql-tools/schema'
+import {printSchemaWithDirectives} from '@graphql-tools/utils'
 import {printSchema} from 'graphql'
 import path from 'path'
 import getProjectRoot from '../../../scripts/webpack/utils/getProjectRoot'
@@ -30,6 +31,7 @@ const updateGQLSchema = async () => {
   const GQL_ROOT = path.join(projectRoot, 'packages/server/graphql')
   const publicSchemaPath = path.join(GQL_ROOT, 'public/schema.graphql')
   const privateSchemaPath = path.join(GQL_ROOT, 'private/schema.graphql')
+  const parabolSDLPath = path.join(projectRoot, 'build/schema.graphql')
   const publicTypeDefs = mergeSchemas({
     schemas: [],
     typeDefs
@@ -43,7 +45,8 @@ const updateGQLSchema = async () => {
 
   await Promise.all([
     writeIfChanged(publicSchemaPath, printSchema(publicSchema)),
-    writeIfChanged(privateSchemaPath, printSchema(privateSchema))
+    writeIfChanged(privateSchemaPath, printSchema(privateSchema)),
+    writeIfChanged(parabolSDLPath, printSchemaWithDirectives(publicTypeDefs))
   ])
 }
 

--- a/packages/server/utils/updateGQLSchema.ts
+++ b/packages/server/utils/updateGQLSchema.ts
@@ -6,8 +6,12 @@
 
 import {readFile, writeFile} from 'node:fs/promises'
 import {mergeSchemas} from '@graphql-tools/schema'
-import {printSchemaWithDirectives} from '@graphql-tools/utils'
-import {printSchema} from 'graphql'
+import {
+  filterSchema,
+  getDocumentNodeFromSchema,
+  printSchemaWithDirectives
+} from '@graphql-tools/utils'
+import {buildASTSchema, introspectionFromSchema, printSchema} from 'graphql'
 import path from 'path'
 import getProjectRoot from '../../../scripts/webpack/utils/getProjectRoot'
 import {typeDefs as privateTypeDefs} from '../graphql/private/importedTypeDefs'
@@ -32,21 +36,29 @@ const updateGQLSchema = async () => {
   const publicSchemaPath = path.join(GQL_ROOT, 'public/schema.graphql')
   const privateSchemaPath = path.join(GQL_ROOT, 'private/schema.graphql')
   const parabolSDLPath = path.join(projectRoot, 'build/schema.graphql')
-  const publicTypeDefs = mergeSchemas({
+  const parabolJSONPath = path.join(projectRoot, 'build/schema.json')
+  const rawPublicTypeDefs = mergeSchemas({
     schemas: [],
     typeDefs
   })
+  const publicTypeDefs = filterSchema({
+    schema: rawPublicTypeDefs,
+    typeFilter: (typeName) => !typeName.startsWith('_x')
+  })
 
-  const publicSchema = nestLinear(nestGitLab(nestGitHub(publicTypeDefs).schema).schema).schema
+  const publicSchema = nestLinear(nestGitLab(nestGitHub(rawPublicTypeDefs).schema).schema).schema
   const privateSchema = mergeSchemas({
     schemas: [publicSchema],
     typeDefs: [privateTypeDefs]
   })
 
+  const schemaWithDirectives = buildASTSchema(getDocumentNodeFromSchema(publicTypeDefs))
+  const introspectionJSON = JSON.stringify(introspectionFromSchema(schemaWithDirectives), null, 2)
   await Promise.all([
     writeIfChanged(publicSchemaPath, printSchema(publicSchema)),
     writeIfChanged(privateSchemaPath, printSchema(privateSchema)),
-    writeIfChanged(parabolSDLPath, printSchemaWithDirectives(publicTypeDefs))
+    writeIfChanged(parabolSDLPath, printSchemaWithDirectives(publicTypeDefs)),
+    writeIfChanged(parabolJSONPath, introspectionJSON)
   ])
 }
 

--- a/packages/server/utils/updateGQLSchema.ts
+++ b/packages/server/utils/updateGQLSchema.ts
@@ -4,7 +4,7 @@
   To reduce watched file callback, we only want to write the file if there's a change
 */
 
-import {readFile, writeFile} from 'node:fs/promises'
+import {mkdir, readFile, writeFile} from 'node:fs/promises'
 import {mergeSchemas} from '@graphql-tools/schema'
 import {
   filterSchema,
@@ -27,6 +27,7 @@ const writeIfChanged = async (dataPath: string, data: string) => {
   } catch {
     // file does not exist
   }
+  await mkdir(path.dirname(dataPath), {recursive: true})
   return writeFile(dataPath, data)
 }
 

--- a/packages/server/utils/useSchemaLink.ts
+++ b/packages/server/utils/useSchemaLink.ts
@@ -1,0 +1,8 @@
+import type {Plugin} from 'graphql-yoga'
+import type {ServerContext} from '../yoga'
+
+export const useSchemaLink: Plugin<ServerContext> = {
+  onResponse({response}) {
+    response.headers.set('Link', '</graphql/schema.graphql>; rel="describedby"')
+  }
+}

--- a/packages/server/yoga.ts
+++ b/packages/server/yoga.ts
@@ -27,6 +27,7 @@ import {useDatadogTracing} from './utils/useDatadogTracing'
 import {useDisposeDataloader} from './utils/useDisposeDataloader'
 import {usePrivateSchemaForSuperUser} from './utils/usePrivateSchemaForSuperUser'
 import {useRemoveDuplicateTransferEncoding} from './utils/useRemoveDuplicateTransferEncoding'
+import {useSchemaLink} from './utils/useSchemaLink'
 
 type OperationResolvers = QueryResolvers & MutationResolvers
 type ExtractArgs<T> = T extends Resolver<any, any, any, infer Args> ? Args : never
@@ -91,6 +92,7 @@ export const yoga = createYoga<ServerContext, UserContext>({
   logging: Logger,
   plugins: [
     useRemoveDuplicateTransferEncoding,
+    useSchemaLink,
     useDisposeDataloader,
     useAPIAccess(),
     useArmor(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       '@graphql-codegen/typescript-resolvers':
         specifier: 5.1.7
         version: 5.1.7(graphql@16.13.1)
+      '@graphql-tools/utils':
+        specifier: ^11.0.1
+        version: 11.1.0(graphql@16.13.1)
       '@parcel/watcher':
         specifier: ^2.5.1
         version: 2.5.1
@@ -2970,12 +2973,6 @@ packages:
   '@graphql-tools/url-loader@9.0.6':
     resolution: {integrity: sha512-QdJI3f7ANDMYfYazRgJzzybznjOrQAOuDXweC9xmKgPZoTqNxEAsatiy69zcpTf6092taJLyrqRH6R7xUTzf4A==}
     engines: {node: '>=20.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-tools/utils@11.0.1':
-    resolution: {integrity: sha512-pNyCOb95ab/z3zkkiPwIPYxigX7IcpyFVcgD1XACDEvg/7yGnKCESx3k/XHEeneKYx/aWKGzEh/uuf6M6Q8HOw==}
-    engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
@@ -14459,7 +14456,7 @@ snapshots:
   '@envelop/extended-validation@7.0.0(@envelop/core@5.4.0)(graphql@16.13.1)':
     dependencies:
       '@envelop/core': 5.4.0
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       tslib: 2.8.1
 
@@ -14728,7 +14725,7 @@ snapshots:
       '@graphql-tools/json-file-loader': 8.0.26(graphql@16.13.1)
       '@graphql-tools/load': 8.1.8(graphql@16.13.1)
       '@graphql-tools/url-loader': 9.0.6(@types/node@22.19.1)(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@inquirer/prompts': 7.10.1(@types/node@22.19.1)
       '@whatwg-node/fetch': 0.10.13
       chalk: 4.1.2
@@ -14775,7 +14772,7 @@ snapshots:
       '@graphql-codegen/typescript-operations': 5.0.9(graphql@16.13.1)
       '@graphql-codegen/visitor-plugin-common': 6.2.4(graphql@16.13.1)
       '@graphql-tools/documents': 1.0.1(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.1)
       graphql: 16.13.1
       tslib: 2.6.3
@@ -14784,7 +14781,7 @@ snapshots:
     dependencies:
       '@graphql-codegen/plugin-helpers': 6.1.1(graphql@16.13.1)
       '@graphql-tools/schema': 10.0.31(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       tslib: 2.6.3
 
@@ -14792,14 +14789,14 @@ snapshots:
     dependencies:
       '@graphql-codegen/plugin-helpers': 6.1.1(graphql@16.13.1)
       '@graphql-codegen/visitor-plugin-common': 6.2.4(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       auto-bind: 4.0.0
       graphql: 16.13.1
       tslib: 2.6.3
 
   '@graphql-codegen/plugin-helpers@6.1.1(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       change-case-all: 1.0.15
       common-tags: 1.8.2
       graphql: 16.13.1
@@ -14810,7 +14807,7 @@ snapshots:
   '@graphql-codegen/schema-ast@5.0.1(graphql@16.13.1)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 6.1.1(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       tslib: 2.6.3
 
@@ -14837,7 +14834,7 @@ snapshots:
       '@graphql-codegen/plugin-helpers': 6.1.1(graphql@16.13.1)
       '@graphql-codegen/typescript': 5.0.9(graphql@16.13.1)
       '@graphql-codegen/visitor-plugin-common': 6.2.4(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       auto-bind: 4.0.0
       graphql: 16.13.1
       tslib: 2.6.3
@@ -14856,7 +14853,7 @@ snapshots:
       '@graphql-codegen/plugin-helpers': 6.1.1(graphql@16.13.1)
       '@graphql-tools/optimize': 2.0.0(graphql@16.13.1)
       '@graphql-tools/relay-operation-optimizer': 7.1.1(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
       dependency-graph: 1.0.0
@@ -14869,7 +14866,7 @@ snapshots:
 
   '@graphql-tools/apollo-engine-loader@8.0.28(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@whatwg-node/fetch': 0.10.13
       graphql: 16.13.1
       sync-fetch: 0.6.0
@@ -14877,7 +14874,7 @@ snapshots:
 
   '@graphql-tools/batch-execute@10.0.5(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
       graphql: 16.13.1
@@ -14893,7 +14890,7 @@ snapshots:
 
   '@graphql-tools/batch-execute@9.0.19(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
       graphql: 16.13.1
@@ -14902,7 +14899,7 @@ snapshots:
   '@graphql-tools/code-file-loader@8.1.28(graphql@16.13.1)':
     dependencies:
       '@graphql-tools/graphql-tag-pluck': 8.3.27(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       globby: 11.1.0
       graphql: 16.13.1
       tslib: 2.8.1
@@ -14915,7 +14912,7 @@ snapshots:
       '@graphql-tools/batch-execute': 9.0.19(graphql@16.13.1)
       '@graphql-tools/executor': 1.4.13(graphql@16.13.1)
       '@graphql-tools/schema': 10.0.31(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
@@ -14928,7 +14925,7 @@ snapshots:
       '@graphql-tools/batch-execute': 10.0.5(graphql@16.13.1)
       '@graphql-tools/executor': 1.5.1(graphql@16.13.1)
       '@graphql-tools/schema': 10.0.31(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
@@ -14954,13 +14951,13 @@ snapshots:
   '@graphql-tools/executor-common@1.0.6(graphql@16.13.1)':
     dependencies:
       '@envelop/core': 5.5.1
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
 
   '@graphql-tools/executor-graphql-ws@3.1.4(graphql@16.13.1)':
     dependencies:
       '@graphql-tools/executor-common': 1.0.6(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@whatwg-node/disposablestack': 0.0.6
       graphql: 16.13.1
       graphql-ws: 6.0.6(graphql@16.13.1)(ws@8.19.0)
@@ -14978,7 +14975,7 @@ snapshots:
     dependencies:
       '@graphql-hive/signal': 2.0.0
       '@graphql-tools/executor-common': 1.0.6(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/disposablestack': 0.0.6
       '@whatwg-node/fetch': 0.10.13
@@ -14991,7 +14988,7 @@ snapshots:
 
   '@graphql-tools/executor-legacy-ws@1.1.25(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@types/ws': 8.18.1
       graphql: 16.13.1
       isomorphic-ws: 5.0.0(ws@8.19.0)
@@ -15003,7 +15000,7 @@ snapshots:
 
   '@graphql-tools/executor@1.4.13(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.1)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/disposablestack': 0.0.6
@@ -15013,7 +15010,7 @@ snapshots:
 
   '@graphql-tools/executor@1.5.1(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.1)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/disposablestack': 0.0.6
@@ -15024,7 +15021,7 @@ snapshots:
   '@graphql-tools/git-loader@8.0.32(graphql@16.13.1)':
     dependencies:
       '@graphql-tools/graphql-tag-pluck': 8.3.27(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       is-glob: 4.0.3
       micromatch: 4.0.8
@@ -15037,7 +15034,7 @@ snapshots:
     dependencies:
       '@graphql-tools/executor-http': 3.1.0(@types/node@22.19.1)(graphql@16.13.1)
       '@graphql-tools/graphql-tag-pluck': 8.3.27(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.13.1
@@ -15050,7 +15047,7 @@ snapshots:
   '@graphql-tools/graphql-file-loader@8.1.12(graphql@16.13.1)':
     dependencies:
       '@graphql-tools/import': 7.1.12(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       globby: 11.1.0
       graphql: 16.13.1
       tslib: 2.8.1
@@ -15063,7 +15060,7 @@ snapshots:
       '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.28.5)
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -15071,14 +15068,14 @@ snapshots:
 
   '@graphql-tools/import@7.1.12(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       resolve-from: 5.0.0
       tslib: 2.8.1
 
   '@graphql-tools/json-file-loader@8.0.26(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       globby: 11.1.0
       graphql: 16.13.1
       tslib: 2.8.1
@@ -15087,7 +15084,7 @@ snapshots:
   '@graphql-tools/load@8.1.8(graphql@16.13.1)':
     dependencies:
       '@graphql-tools/schema': 10.0.31(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       p-limit: 3.1.0
       tslib: 2.8.1
@@ -15100,7 +15097,7 @@ snapshots:
 
   '@graphql-tools/merge@9.1.7(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       tslib: 2.8.1
 
@@ -15112,14 +15109,14 @@ snapshots:
   '@graphql-tools/relay-operation-optimizer@7.1.1(graphql@16.13.1)':
     dependencies:
       '@ardatan/relay-compiler': 13.0.0(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       tslib: 2.8.1
 
   '@graphql-tools/schema@10.0.31(graphql@16.13.1)':
     dependencies:
       '@graphql-tools/merge': 9.1.7(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       tslib: 2.8.1
 
@@ -15136,7 +15133,7 @@ snapshots:
       '@graphql-tools/executor-graphql-ws': 3.1.4(graphql@16.13.1)
       '@graphql-tools/executor-http': 3.1.0(@types/node@22.19.1)(graphql@16.13.1)
       '@graphql-tools/executor-legacy-ws': 1.1.25(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@graphql-tools/wrap': 11.1.9(graphql@16.13.1)
       '@types/ws': 8.18.1
       '@whatwg-node/fetch': 0.10.13
@@ -15154,14 +15151,6 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  '@graphql-tools/utils@11.0.1(graphql@16.13.1)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.1)
-      '@whatwg-node/promise-helpers': 1.3.2
-      cross-inspect: 1.0.1
-      graphql: 16.13.1
-      tslib: 2.8.1
-
   '@graphql-tools/utils@11.1.0(graphql@16.13.1)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.1)
@@ -15174,7 +15163,7 @@ snapshots:
     dependencies:
       '@graphql-tools/delegate': 10.2.23(graphql@16.13.1)
       '@graphql-tools/schema': 10.0.31(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.13.1
       tslib: 2.8.1
@@ -15183,7 +15172,7 @@ snapshots:
     dependencies:
       '@graphql-tools/delegate': 12.0.9(graphql@16.13.1)
       '@graphql-tools/schema': 10.0.31(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.13.1
       tslib: 2.8.1
@@ -15198,7 +15187,7 @@ snapshots:
 
   '@graphql-yoga/plugin-defer-stream@3.16.2(graphql-yoga@5.16.2(graphql@16.13.1))(graphql@16.13.1)':
     dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       graphql: 16.13.1
       graphql-yoga: 5.16.2(graphql@16.13.1)
 
@@ -20844,7 +20833,7 @@ snapshots:
       '@graphql-tools/load': 8.1.8(graphql@16.13.1)
       '@graphql-tools/merge': 9.1.7(graphql@16.13.1)
       '@graphql-tools/url-loader': 9.0.6(@types/node@22.19.1)(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       graphql: 16.13.1
       jiti: 2.6.1
@@ -20916,7 +20905,7 @@ snapshots:
       '@envelop/instrumentation': 1.0.0
       '@graphql-tools/executor': 1.4.13(graphql@16.13.1)
       '@graphql-tools/schema': 10.0.31(graphql@16.13.1)
-      '@graphql-tools/utils': 11.0.1(graphql@16.13.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.1)
       '@graphql-yoga/logger': 2.0.1
       '@graphql-yoga/subscription': 5.0.5
       '@whatwg-node/fetch': 0.10.13

--- a/scripts/RelayPersistServer.ts
+++ b/scripts/RelayPersistServer.ts
@@ -7,19 +7,14 @@ import clientConfig from '../relay.config'
 
 export default class RelayPersistServer {
   server: Server
+  ready: Promise<void>
   queryMapPath = path.join(__dirname, '../queryMap.json')
   queryMap: Record<string, string>
   constructor(port = 2999) {
     this.server = http.createServer(this.requestListener)
-    this.server.listen(port)
-    this.server.on('error', (err) => {
-      if ((err as any).code === 'EADDRINUSE') {
-        console.error(`Port ${port} in use, retrying...`)
-        setTimeout(() => {
-          this.server.close()
-          this.server.listen(port)
-        }, 1000)
-      }
+    this.ready = new Promise<void>((resolve, reject) => {
+      this.server.listen(port, resolve)
+      this.server.on('error', reject)
     })
     let flushArtifacts = false
     try {

--- a/scripts/generateGraphQLArtifacts.js
+++ b/scripts/generateGraphQLArtifacts.js
@@ -11,6 +11,12 @@ const {Logger} = require('../packages/server/utils/Logger')
 const generateGraphQLArtifacts = async () => {
   await runSchemaUpdater(true)
   const persistServer = new RelayPersistServer()
+  const serverStarted = await persistServer.ready
+    .then(() => true)
+    .catch((err) => {
+      if (err.code !== 'EADDRINUSE') throw err
+      return false
+    })
   const runCompiler = (cwd) =>
     new Promise((resolve) => {
       const relayCompiler = cp.exec(relayCompilerPath, {cwd}).on('exit', resolve)
@@ -24,7 +30,7 @@ const generateGraphQLArtifacts = async () => {
   Logger.log('codegen complete')
   await runCompiler(process.cwd())
   Logger.log('relay compiler client complete')
-  persistServer.close()
+  if (serverStarted) persistServer.close()
 }
 
 if (require.main === module) {

--- a/scripts/relayWatch.js
+++ b/scripts/relayWatch.js
@@ -18,15 +18,26 @@ const relayWatch = async () => {
   const schemaUpdater = runSchemaUpdater(!schemaExists)
   // don't wait if a schema exists. startup fast with a stale schema
   if (!schemaExists) await schemaUpdater
-  const _persistServer = new RelayPersistServer()
+  const persistServer = new RelayPersistServer()
+  await persistServer.ready.catch(() => {
+    console.error(
+      `Port 2999 is already in use. A previous relay watch process may still be running. Kill it and retry.`
+    )
+    process.exit(1)
+  })
   const compiler = cp
     .spawn(relayCompilerPath, ['--watch'], {
       stdio: ['inherit', 'pipe', 'inherit']
     })
     // if relay compiler gets killed, kill this process
     .on('exit', process.exit)
-  // when this process gets killed, kill relay compiler, too
-  process.on('exit', () => compiler.kill())
+  const cleanup = () => {
+    persistServer.close()
+    compiler.kill()
+    process.exit()
+  }
+  process.on('SIGINT', cleanup)
+  process.on('SIGTERM', cleanup)
   await new Promise((resolve) => {
     compiler.stdout.on('data', (data) => {
       // pipe relay messages to the parent process. We can finetune this to keep it quiet

--- a/scripts/webpack/dev.client.config.js
+++ b/scripts/webpack/dev.client.config.js
@@ -70,7 +70,10 @@ module.exports = {
         target: `http://localhost:3002`
       },
       {
-        context: (path, req) => path === '/graphql' && req.method === 'POST',
+        context: (path, req) =>
+          path === '/graphql'
+            ? req.method === 'POST'
+            : path.startsWith('/graphql/') && path.length > '/graphql/'.length,
         target: `http://localhost:${SOCKET_PORT}`
       },
       {

--- a/scripts/webpack/prod.client.config.js
+++ b/scripts/webpack/prod.client.config.js
@@ -106,7 +106,13 @@ module.exports = (config) => {
         publicPath: '__PUBLIC_PATH__'
       }),
       new CleanWebpackPlugin({
-        cleanOnceBeforeBuildPatterns: ['**/*', '!*worker.js', '!workerManifest.d.ts', '!schema.graphql']
+        cleanOnceBeforeBuildPatterns: [
+          '**/*',
+          '!*worker.js',
+          '!workerManifest.d.ts',
+          '!schema.graphql',
+          '!schema.json'
+        ]
       }),
       new webpack.DefinePlugin({
         __CLIENT__: true,

--- a/scripts/webpack/prod.client.config.js
+++ b/scripts/webpack/prod.client.config.js
@@ -106,7 +106,7 @@ module.exports = (config) => {
         publicPath: '__PUBLIC_PATH__'
       }),
       new CleanWebpackPlugin({
-        cleanOnceBeforeBuildPatterns: ['**/*', '!*worker.js', '!workerManifest.d.ts']
+        cleanOnceBeforeBuildPatterns: ['**/*', '!*worker.js', '!workerManifest.d.ts', '!schema.graphql']
       }),
       new webpack.DefinePlugin({
         __CLIENT__: true,


### PR DESCRIPTION
# Description

Exposes /graphql/schema.json and /graphql/schema.graphql.
These assets are stored in our bucket and the routes redirect to them to keep load off our server.
Introspective queries also get intercepted and redirected to schema.json to keep load off the server.
All post requests include a link describedby header pointing the schema so users & LLMs can find the schema after they issue a request.

