### PR TITLE
fix: avatar images in emails

### DIFF
--- a/packages/server/graphql/public/mutations/requestPageAccess.ts
+++ b/packages/server/graphql/public/mutations/requestPageAccess.ts
@@ -87,7 +87,9 @@ const requestPageAccess: MutationResolvers['requestPageAccess'] = async (
   const {html, subject, body} = pageAccessRequestEmailCreator({
     requesterName: viewer.preferredName,
     requesterEmail: viewer.email,
-    requesterAvatar: viewer.picture,
+    requesterAvatar: viewer.picture.startsWith('/')
+      ? `${appOrigin}${viewer.picture}`
+      : viewer.picture,
     reason,
     pageName: page.title ?? 'Untitled',
     pageLink,

--- a/packages/server/graphql/public/mutations/updatePageAccess.ts
+++ b/packages/server/graphql/public/mutations/updatePageAccess.ts
@@ -318,7 +318,9 @@ const updatePageAccess: MutationResolvers['updatePageAccess'] = async (
       const {html, subject, body} = pageSharedEmailCreator({
         ownerName: trustworthy ? viewer.preferredName : null,
         ownerEmail: viewer.email,
-        ownerAvatar: viewer.picture,
+        ownerAvatar: viewer.picture.startsWith('/')
+          ? `${appOrigin}${viewer.picture}`
+          : viewer.picture,
         pageName: trustworthy ? (page.title ?? 'Untitled') : null,
         pageLink,
         role,


### PR DESCRIPTION
A migration from November 2025 (urlsToProxy.ts) intentionally stripped the CDN origin from all stored asset URLs, converting them to relative /assets/... paths for the new asset proxy. The web app handles these fine, but the two page-sharing email templates (PageSharedInvite and PageAccessRequest) were passing viewer.picture straight into <img src=...> without making the URL absolute.

# Description

Fixes #12449 
