### PR TITLE
fix: can reset retro with updates phase

### DIFF
--- a/packages/server/__tests__/resetRetroMeetingToGroupStage.test.ts
+++ b/packages/server/__tests__/resetRetroMeetingToGroupStage.test.ts
@@ -45,6 +45,11 @@ const startRetro = async (teamId: string, cookie: string) => {
                   id
                   isNavigableByFacilitator
                 }
+                ... on ReflectPhase {
+                  reflectPrompts {
+                    id
+                  }
+                }
               }
             }
           }
@@ -60,23 +65,28 @@ const startRetro = async (teamId: string, cookie: string) => {
   return res.data.startRetrospective.meeting
 }
 
-const navigateToPhase = async (meetingId: string, stageId: string, cookie: string) => {
+interface Phase {
+  phaseType: string
+  stages: {id: string; isNavigableByFacilitator: boolean}[]
+  reflectPrompts?: {id: string}[]
+}
+
+const navigate = async (
+  meetingId: string,
+  completedStageId: string,
+  facilitatorStageId: string,
+  cookie: string
+) => {
   return sendPublic({
     query: `
-      mutation Navigate($meetingId: ID!, $stageId: ID!) {
-        navigateToMeetingStage(meetingId: $meetingId, stageId: $stageId, facilitatorStageId: $stageId) {
-          ... on NavigateToMeetingStagePayload {
-            meeting {
-              id
-              phases {
-                phaseType
-                stages {
-                  id
-                  isComplete
-                  isNavigableByFacilitator
-                }
-              }
-            }
+      mutation Nav($meetingId: ID!, $completedStageId: ID, $facilitatorStageId: ID) {
+        navigateMeeting(
+          meetingId: $meetingId,
+          completedStageId: $completedStageId,
+          facilitatorStageId: $facilitatorStageId
+        ) {
+          ... on NavigateMeetingPayload {
+            meeting { id }
           }
           ... on ErrorPayload {
             error { message }
@@ -84,7 +94,32 @@ const navigateToPhase = async (meetingId: string, stageId: string, cookie: strin
         }
       }
     `,
-    variables: {meetingId, stageId},
+    variables: {meetingId, completedStageId, facilitatorStageId},
+    cookie
+  })
+}
+
+const createReflection = async (meetingId: string, promptId: string, cookie: string) => {
+  return sendPublic({
+    query: `
+      mutation CreateReflection($input: CreateReflectionInput!) {
+        createReflection(input: $input) {
+          ... on CreateReflectionPayload {
+            reflectionId
+          }
+          ... on ErrorPayload {
+            error { message }
+          }
+        }
+      }
+    `,
+    variables: {
+      input: {
+        meetingId,
+        promptId,
+        content: '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"test reflection"}]}]}'
+      }
+    },
     cookie
   })
 }
@@ -118,6 +153,11 @@ const resetRetroMeeting = async (meetingId: string, cookie: string) => {
   })
 }
 
+const getStageId = (phases: Phase[], phaseType: string) => {
+  const phase = phases.find((p) => p.phaseType === phaseType)!
+  return phase.stages[0]!.id
+}
+
 test('resetRetroMeetingToGroupStage succeeds when retro has updates phase', async () => {
   const {userId, cookie} = await signUp()
   const {id: teamId} = (await getUserTeams(userId))[0]
@@ -125,22 +165,28 @@ test('resetRetroMeetingToGroupStage succeeds when retro has updates phase', asyn
   await enableUpdatesPhase(teamId, cookie)
 
   const meeting = await startRetro(teamId, cookie)
-  expect(meeting.phases.map((p: {phaseType: string}) => p.phaseType)).toContain('updates')
+  const phases = meeting.phases as Phase[]
+  expect(phases.map((p) => p.phaseType)).toContain('updates')
 
-  const phases = meeting.phases as {
-    phaseType: string
-    stages: {id: string; isNavigableByFacilitator: boolean}[]
-  }[]
-  const votePhase = phases.find((p) => p.phaseType === 'vote')!
-  const discussPhase = phases.find((p) => p.phaseType === 'discuss')!
+  const meetingId = meeting.id
+  const reflectPhase = phases.find((p) => p.phaseType === 'reflect')!
+  const promptId = reflectPhase.reflectPrompts![0]!.id
 
-  // navigate to vote (completes group)
-  await navigateToPhase(meeting.id, votePhase.stages[0]!.id, cookie)
-  // navigate to discuss (completes vote)
-  await navigateToPhase(meeting.id, discussPhase.stages[0]!.id, cookie)
+  // Walk through each phase sequentially: checkin → TEAM_HEALTH → updates → reflect
+  await navigate(meetingId, getStageId(phases, 'checkin'), getStageId(phases, 'TEAM_HEALTH'), cookie)
+  await navigate(meetingId, getStageId(phases, 'TEAM_HEALTH'), getStageId(phases, 'updates'), cookie)
+  await navigate(meetingId, getStageId(phases, 'updates'), getStageId(phases, 'reflect'), cookie)
 
-  // reset — this should NOT throw "Unhandled phaseType: updates"
-  const resetRes = await resetRetroMeeting(meeting.id, cookie)
+  // Create a reflection to unlock the GROUP phase
+  await createReflection(meetingId, promptId, cookie)
+
+  // Continue: reflect → group → vote → discuss
+  await navigate(meetingId, getStageId(phases, 'reflect'), getStageId(phases, 'group'), cookie)
+  await navigate(meetingId, getStageId(phases, 'group'), getStageId(phases, 'vote'), cookie)
+  await navigate(meetingId, getStageId(phases, 'vote'), getStageId(phases, 'discuss'), cookie)
+
+  // Reset — this should NOT throw "Unhandled phaseType: updates"
+  const resetRes = await resetRetroMeeting(meetingId, cookie)
 
   expect(resetRes.data.resetRetroMeetingToGroupStage.meeting).toBeTruthy()
   expect(

--- a/packages/server/__tests__/resetRetroMeetingToGroupStage.test.ts
+++ b/packages/server/__tests__/resetRetroMeetingToGroupStage.test.ts
@@ -83,7 +83,7 @@ test('resetRetroMeetingToGroupStage succeeds when retro has updates phase', asyn
     .where('id', '=', meetingId)
     .executeTakeFirstOrThrow()
 
-  const phases = JSON.parse(meetingRow.phases as string)
+  const phases = meetingRow.phases as {stages: Record<string, unknown>[]}[]
   for (const phase of phases) {
     for (const stage of phase.stages) {
       stage.isNavigable = true

--- a/packages/server/__tests__/resetRetroMeetingToGroupStage.test.ts
+++ b/packages/server/__tests__/resetRetroMeetingToGroupStage.test.ts
@@ -1,0 +1,151 @@
+import {getUserTeams, sendPublic, signUp} from './common'
+
+const enableUpdatesPhase = async (teamId: string, cookie: string) => {
+  const settingsRes = await sendPublic({
+    query: `
+      query MeetingSettingsQuery($teamId: ID!) {
+        viewer {
+          team(teamId: $teamId) {
+            meetingSettings(meetingType: retrospective) {
+              id
+              phaseTypes
+            }
+          }
+        }
+      }
+    `,
+    variables: {teamId},
+    cookie
+  })
+  const settingsId = settingsRes.data.viewer.team.meetingSettings.id
+  await sendPublic({
+    query: `
+      mutation EnableUpdates($id: ID!) {
+        setMeetingSettings(settingsId: $id, reviewPastTasksEnabled: true) {
+          ... on SetMeetingSettingsPayload { settingsId }
+        }
+      }
+    `,
+    variables: {id: settingsId},
+    cookie
+  })
+}
+
+const startRetro = async (teamId: string, cookie: string) => {
+  const res = await sendPublic({
+    query: `
+      mutation StartRetro($teamId: ID!) {
+        startRetrospective(teamId: $teamId) {
+          ... on StartRetrospectiveSuccess {
+            meeting {
+              id
+              phases {
+                phaseType
+                stages {
+                  id
+                  isNavigableByFacilitator
+                }
+              }
+            }
+          }
+          ... on ErrorPayload {
+            error { message }
+          }
+        }
+      }
+    `,
+    variables: {teamId},
+    cookie
+  })
+  return res.data.startRetrospective.meeting
+}
+
+const navigateToPhase = async (meetingId: string, stageId: string, cookie: string) => {
+  return sendPublic({
+    query: `
+      mutation Navigate($meetingId: ID!, $stageId: ID!) {
+        navigateToMeetingStage(meetingId: $meetingId, stageId: $stageId, facilitatorStageId: $stageId) {
+          ... on NavigateToMeetingStagePayload {
+            meeting {
+              id
+              phases {
+                phaseType
+                stages {
+                  id
+                  isComplete
+                  isNavigableByFacilitator
+                }
+              }
+            }
+          }
+          ... on ErrorPayload {
+            error { message }
+          }
+        }
+      }
+    `,
+    variables: {meetingId, stageId},
+    cookie
+  })
+}
+
+const resetRetroMeeting = async (meetingId: string, cookie: string) => {
+  return sendPublic({
+    query: `
+      mutation ResetRetro($meetingId: ID!) {
+        resetRetroMeetingToGroupStage(meetingId: $meetingId) {
+          ... on ResetRetroMeetingToGroupStagePayload {
+            meeting {
+              id
+              phases {
+                phaseType
+                stages {
+                  id
+                  isComplete
+                  isNavigableByFacilitator
+                }
+              }
+            }
+          }
+          ... on ErrorPayload {
+            error { message }
+          }
+        }
+      }
+    `,
+    variables: {meetingId},
+    cookie
+  })
+}
+
+test('resetRetroMeetingToGroupStage succeeds when retro has updates phase', async () => {
+  const {userId, cookie} = await signUp()
+  const {id: teamId} = (await getUserTeams(userId))[0]
+
+  await enableUpdatesPhase(teamId, cookie)
+
+  const meeting = await startRetro(teamId, cookie)
+  expect(meeting.phases.map((p: {phaseType: string}) => p.phaseType)).toContain('updates')
+
+  const phases = meeting.phases as {
+    phaseType: string
+    stages: {id: string; isNavigableByFacilitator: boolean}[]
+  }[]
+  const votePhase = phases.find((p) => p.phaseType === 'vote')!
+  const discussPhase = phases.find((p) => p.phaseType === 'discuss')!
+
+  // navigate to vote (completes group)
+  await navigateToPhase(meeting.id, votePhase.stages[0]!.id, cookie)
+  // navigate to discuss (completes vote)
+  await navigateToPhase(meeting.id, discussPhase.stages[0]!.id, cookie)
+
+  // reset — this should NOT throw "Unhandled phaseType: updates"
+  const resetRes = await resetRetroMeeting(meeting.id, cookie)
+
+  expect(resetRes.data.resetRetroMeetingToGroupStage.meeting).toBeTruthy()
+  expect(
+    resetRes.data.resetRetroMeetingToGroupStage.meeting.phases.map(
+      (p: {phaseType: string}) => p.phaseType
+    )
+  ).toContain('updates')
+})

--- a/packages/server/__tests__/resetRetroMeetingToGroupStage.test.ts
+++ b/packages/server/__tests__/resetRetroMeetingToGroupStage.test.ts
@@ -1,3 +1,4 @@
+import getKysely from '../postgres/getKysely'
 import {getUserTeams, sendPublic, signUp} from './common'
 
 const enableUpdatesPhase = async (teamId: string, cookie: string) => {
@@ -8,7 +9,6 @@ const enableUpdatesPhase = async (teamId: string, cookie: string) => {
           team(teamId: $teamId) {
             meetingSettings(meetingType: retrospective) {
               id
-              phaseTypes
             }
           }
         }
@@ -43,12 +43,6 @@ const startRetro = async (teamId: string, cookie: string) => {
                 phaseType
                 stages {
                   id
-                  isNavigableByFacilitator
-                }
-                ... on ReflectPhase {
-                  reflectPrompts {
-                    id
-                  }
                 }
               }
             }
@@ -65,64 +59,53 @@ const startRetro = async (teamId: string, cookie: string) => {
   return res.data.startRetrospective.meeting
 }
 
-interface Phase {
-  phaseType: string
-  stages: {id: string; isNavigableByFacilitator: boolean}[]
-  reflectPrompts?: {id: string}[]
-}
+test('resetRetroMeetingToGroupStage succeeds when retro has updates phase', async () => {
+  const {userId, cookie} = await signUp()
+  const {id: teamId} = (await getUserTeams(userId))[0]!
 
-const navigate = async (
-  meetingId: string,
-  completedStageId: string,
-  facilitatorStageId: string,
-  cookie: string
-) => {
-  return sendPublic({
-    query: `
-      mutation Nav($meetingId: ID!, $completedStageId: ID, $facilitatorStageId: ID) {
-        navigateMeeting(
-          meetingId: $meetingId,
-          completedStageId: $completedStageId,
-          facilitatorStageId: $facilitatorStageId
-        ) {
-          ... on NavigateMeetingPayload {
-            meeting { id }
-          }
-          ... on ErrorPayload {
-            error { message }
-          }
-        }
-      }
-    `,
-    variables: {meetingId, completedStageId, facilitatorStageId},
-    cookie
-  })
-}
+  await enableUpdatesPhase(teamId, cookie)
 
-const createReflection = async (meetingId: string, promptId: string, cookie: string) => {
-  return sendPublic({
-    query: `
-      mutation CreateReflection($input: CreateReflectionInput!) {
-        createReflection(input: $input) {
-          ... on CreateReflectionPayload {
-            reflectionId
-          }
-          ... on ErrorPayload {
-            error { message }
-          }
-        }
-      }
-    `,
-    variables: {
-      input: {
-        meetingId,
-        promptId,
-        content: '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"test reflection"}]}]}'
-      }
-    },
-    cookie
-  })
-}
+  const meeting = await startRetro(teamId, cookie)
+  expect(meeting).toBeTruthy()
+  const phaseTypes = meeting.phases.map((p: {phaseType: string}) => p.phaseType)
+  expect(phaseTypes).toContain('updates')
+  expect(phaseTypes).toContain('group')
+
+  const meetingId = meeting.id as string
+
+  // Directly mark the group stage as complete and navigable in the DB.
+  // This avoids the complex multi-step navigation flow and focuses the test
+  // on what we're actually fixing: the reset switch statement handling 'updates'.
+  const pg = getKysely()
+  const meetingRow = await pg
+    .selectFrom('NewMeeting')
+    .select('phases')
+    .where('id', '=', meetingId)
+    .executeTakeFirstOrThrow()
+
+  const phases = JSON.parse(meetingRow.phases as string)
+  for (const phase of phases) {
+    for (const stage of phase.stages) {
+      stage.isNavigable = true
+      stage.isNavigableByFacilitator = true
+      stage.isComplete = true
+    }
+  }
+  await pg
+    .updateTable('NewMeeting')
+    .set({phases: JSON.stringify(phases)})
+    .where('id', '=', meetingId)
+    .execute()
+
+  const resetRes = await resetRetroMeeting(meetingId, cookie)
+
+  expect(resetRes.data.resetRetroMeetingToGroupStage.meeting).toBeTruthy()
+  expect(
+    resetRes.data.resetRetroMeetingToGroupStage.meeting.phases.map(
+      (p: {phaseType: string}) => p.phaseType
+    )
+  ).toContain('updates')
+})
 
 const resetRetroMeeting = async (meetingId: string, cookie: string) => {
   return sendPublic({
@@ -134,11 +117,6 @@ const resetRetroMeeting = async (meetingId: string, cookie: string) => {
               id
               phases {
                 phaseType
-                stages {
-                  id
-                  isComplete
-                  isNavigableByFacilitator
-                }
               }
             }
           }
@@ -152,46 +130,3 @@ const resetRetroMeeting = async (meetingId: string, cookie: string) => {
     cookie
   })
 }
-
-const getStageId = (phases: Phase[], phaseType: string) => {
-  const phase = phases.find((p) => p.phaseType === phaseType)!
-  return phase.stages[0]!.id
-}
-
-test('resetRetroMeetingToGroupStage succeeds when retro has updates phase', async () => {
-  const {userId, cookie} = await signUp()
-  const {id: teamId} = (await getUserTeams(userId))[0]
-
-  await enableUpdatesPhase(teamId, cookie)
-
-  const meeting = await startRetro(teamId, cookie)
-  const phases = meeting.phases as Phase[]
-  expect(phases.map((p) => p.phaseType)).toContain('updates')
-
-  const meetingId = meeting.id
-  const reflectPhase = phases.find((p) => p.phaseType === 'reflect')!
-  const promptId = reflectPhase.reflectPrompts![0]!.id
-
-  // Walk through each phase sequentially: checkin → TEAM_HEALTH → updates → reflect
-  await navigate(meetingId, getStageId(phases, 'checkin'), getStageId(phases, 'TEAM_HEALTH'), cookie)
-  await navigate(meetingId, getStageId(phases, 'TEAM_HEALTH'), getStageId(phases, 'updates'), cookie)
-  await navigate(meetingId, getStageId(phases, 'updates'), getStageId(phases, 'reflect'), cookie)
-
-  // Create a reflection to unlock the GROUP phase
-  await createReflection(meetingId, promptId, cookie)
-
-  // Continue: reflect → group → vote → discuss
-  await navigate(meetingId, getStageId(phases, 'reflect'), getStageId(phases, 'group'), cookie)
-  await navigate(meetingId, getStageId(phases, 'group'), getStageId(phases, 'vote'), cookie)
-  await navigate(meetingId, getStageId(phases, 'vote'), getStageId(phases, 'discuss'), cookie)
-
-  // Reset — this should NOT throw "Unhandled phaseType: updates"
-  const resetRes = await resetRetroMeeting(meetingId, cookie)
-
-  expect(resetRes.data.resetRetroMeetingToGroupStage.meeting).toBeTruthy()
-  expect(
-    resetRes.data.resetRetroMeetingToGroupStage.meeting.phases.map(
-      (p: {phaseType: string}) => p.phaseType
-    )
-  ).toContain('updates')
-})

--- a/packages/server/graphql/public/mutations/resetRetroMeetingToGroupStage.ts
+++ b/packages/server/graphql/public/mutations/resetRetroMeetingToGroupStage.ts
@@ -1,5 +1,5 @@
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import {CHECKIN, DISCUSS, GROUP, REFLECT, VOTE} from '../../../../client/utils/constants'
+import {CHECKIN, DISCUSS, GROUP, REFLECT, UPDATES, VOTE} from '../../../../client/utils/constants'
 import DiscussPhase from '../../../database/types/DiscussPhase'
 import GenericMeetingPhase from '../../../database/types/GenericMeetingPhase'
 import getKysely from '../../../postgres/getKysely'
@@ -50,6 +50,7 @@ const resetRetroMeetingToGroupStage: MutationResolvers['resetRetroMeetingToGroup
     switch (phase.phaseType) {
       case CHECKIN:
       case 'TEAM_HEALTH':
+      case UPDATES:
       case REFLECT:
         return phase
       case GROUP: {

--- a/packages/server/postgres/types/NewMeetingPhase.d.ts
+++ b/packages/server/postgres/types/NewMeetingPhase.d.ts
@@ -174,6 +174,7 @@ export interface UpdatesPhase extends GenericMeetingPhase {
 export type RetroMeetingPhase =
   | CheckInPhase
   | TeamHealthPhase
+  | UpdatesPhase
   | ReflectPhase
   | GroupPhase
   | VotePhase


### PR DESCRIPTION
# Description

Fixes issue where users could not reset retro meetings with updates phased enabled. It caused [this crash.](https://app.datadoghq.com/error-tracking/unified?query=env%3Aproduction&issueId=be049672-531b-11f1-8ad8-da7ad0900002&from_ts=1779718183000&to_ts=1779804583000&live=false&monitor_id=177403783&monitor_sub_type=.new%28%29&link_source=monitor_notif)

