### PR TITLE
fix: support no teams in create meeting

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -532,10 +532,11 @@ export default class Atmosphere extends Environment {
       }
     })
   }
-  refreshSession() {
+  refreshSession(onCompleted?: () => void) {
     commitMutation<AtmosphereSignOutMutation>(this, {
       mutation: refreshSessionMutation,
-      variables: {}
+      variables: {},
+      onCompleted
     })
   }
   close() {

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -142,11 +142,15 @@ export const CreateNewActivity = (props: Props) => {
     freeCustomRetroTemplatesRemaining,
     freeCustomPokerTemplatesRemaining
   } = viewer
+  const sortedTeams = sortByTier(teams)
   const [selectedTeam, setSelectedTeam] = useState(
-    teams.find((team) => team.id === preferredTeamId) ?? sortByTier(teams)[0]!
+    teams.find((team) => team.id === preferredTeamId) ?? sortedTeams[0]
   )
+
   const {submitting, error, submitMutation, onError, onCompleted} = useMutationProps()
   const navigate = useNavigate()
+
+  if (!selectedTeam) return null
   const freeCustomTemplatesRemaining =
     selectedActivity.type === 'retrospective'
       ? freeCustomRetroTemplatesRemaining

--- a/packages/client/components/EmailPasswordAuthForm.tsx
+++ b/packages/client/components/EmailPasswordAuthForm.tsx
@@ -82,12 +82,11 @@ const validateEmail = (email: string) => {
     .matches(emailRegex, 'Please enter a valid email address')
 }
 
-const validatePassword = (password: string, {email}: {email: string}) => {
+const validatePassword = (password: string) => {
   return new Legitity(password)
     .required('Please enter a password')
     .min(Security.MIN_PASSWORD_LENGTH, `${Security.MIN_PASSWORD_LENGTH} character minimum`)
     .max(1000, `That's a book, not a password`)
-    .test((value) => passwordStrength(value, email))
 }
 
 const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
@@ -241,6 +240,11 @@ const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
       return
     }
     if (signInWithSSOSucceeded || passwordRes.error) return
+    const strengthError = passwordStrength(passwordRes.value, email)
+    if (strengthError) {
+      fields.password.setError(strengthError)
+      return
+    }
     const {value: password} = passwordRes
     submitMutation()
     if (isSignin) {

--- a/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
+++ b/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
@@ -43,7 +43,6 @@ const validatePassword = (password: string) => {
     .required('Please enter a password')
     .min(Security.MIN_PASSWORD_LENGTH, `${Security.MIN_PASSWORD_LENGTH} character minimum`)
     .max(1000, `That's a book, not a password`)
-    .test((value) => passwordStrength(value))
 }
 
 const SetNewPassword = () => {
@@ -71,6 +70,11 @@ const SetNewPassword = () => {
     setDirtyField()
     const {password: passwordRes} = validateField()
     if (passwordRes.error) return
+    const strengthError = passwordStrength(passwordRes.value)
+    if (strengthError) {
+      fields.password.setError(strengthError)
+      return
+    }
     const {value: newPassword} = passwordRes
     submitMutation()
     ResetPasswordMutation(

--- a/packages/client/components/VerifyEmail.tsx
+++ b/packages/client/components/VerifyEmail.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react'
+import {useEffect, useRef} from 'react'
 import {useNavigate, useParams} from 'react-router'
 import useCanonical from '~/hooks/useCanonical'
 import VerifyEmailMutation from '~/mutations/VerifyEmailMutation'
@@ -18,8 +18,11 @@ const VerifyEmail = () => {
   const {verificationToken, invitationToken} = useParams()
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, error, submitMutation} = useMutationProps()
+  const calledRef = useRef(false)
   useCanonical('verify-email')
   useEffect(() => {
+    if (calledRef.current) return
+    calledRef.current = true
     submitMutation()
     VerifyEmailMutation(
       atmosphere,

--- a/packages/client/mutations/VerifyEmailMutation.ts
+++ b/packages/client/mutations/VerifyEmailMutation.ts
@@ -34,7 +34,7 @@ const VerifyEmailMutation: StandardMutation<TSignUpWithPasswordMutation, Navigat
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, verifyEmail} = res
       onCompleted({verifyEmail}, errors)
-      if (!errors) {
+      if (!errors && !verifyEmail.error) {
         handleSuccessfulLogin(atmosphere, verifyEmail)
         const redirectPath = '/meetings'
 

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -266,11 +266,14 @@ const addNewFeatureNotificationUpdater: SharedUpdater<any> = (payload, {store}) 
 }
 
 const authTokenNotificationOnNext: NextHandler = (_payload, {atmosphere}) => {
-  atmosphere.refreshSession()
-  // The new auth token's tms has changed, so every viewer.canAccess(...) result
-  // cached in the store may be wrong. Mark viewer stale so the next read refetches.
-  commitLocalUpdate(atmosphere, (store) => {
-    store.getRoot().getLinkedRecord('viewer')?.invalidateRecord()
+  // Invalidate viewer only after refreshSession completes so the server has already
+  // updated extra.authToken to the new token. Invalidating immediately would trigger
+  // a Relay refetch while the old token's jti is being blacklisted mid-mutation,
+  // causing useCheckBlacklist to null out authToken on the concurrent query.
+  atmosphere.refreshSession(() => {
+    commitLocalUpdate(atmosphere, (store) => {
+      store.getRoot().getLinkedRecord('viewer')?.invalidateRecord()
+    })
   })
 }
 

--- a/packages/server/graphql/public/types/AuthTokenPayload.ts
+++ b/packages/server/graphql/public/types/AuthTokenPayload.ts
@@ -8,7 +8,12 @@ export type AuthTokenPayloadSource = {
 
 const AuthTokenPayload: AuthTokenPayloadResolvers = {
   id: ({tms}, _args, {authToken}) => {
-    return encodeUnsignedAuthToken(new AuthToken({...authToken, tms}))
+    // Omit jti so a fresh one is generated. The WS handler (wsHandler.onNext) sets
+    // extra.authToken to the decoded token, and refreshSession then blacklists the
+    // cookie's jti. If we carried jti over, both would be the same value and the WS
+    // would hold a blacklisted token.
+    const {jti: _jti, ...rest} = authToken!
+    return encodeUnsignedAuthToken(new AuthToken({...rest, tms}))
   }
 }
 

--- a/packages/server/wsHandler.ts
+++ b/packages/server/wsHandler.ts
@@ -138,7 +138,14 @@ export const wsHandler = makeBehavior<{token?: string; docId?: string}>({
       // contextValue.authToken with a new tms array. Without this sync,
       // subsequent queries on the same connection would use stale tms.
       const mutationToken = (contextValue as ServerContext).authToken
-      if (mutationToken && mutationToken !== context.extra.authToken) {
+      const initialToken = (contextValue as any)._wsAuthTokenAtStart as AuthToken | undefined
+      // Only sync if the mutation itself changed authToken (not just extra.authToken being
+      // updated externally by an AuthTokenPayload subscription event after this op started).
+      if (
+        mutationToken &&
+        mutationToken !== initialToken &&
+        mutationToken !== context.extra.authToken
+      ) {
         context.extra.authToken = mutationToken
       }
       return result
@@ -227,7 +234,8 @@ export const wsHandler = makeBehavior<{token?: string; docId?: string}>({
         rateLimiter,
         ip,
         authToken,
-        socketId
+        socketId,
+        _wsAuthTokenAtStart: authToken
       },
       rootValue: {
         execute,


### PR DESCRIPTION
# Description

- in the create activity view, do not assume they are on a team
- when creating a password, don't do the expensive password validation onChange or onBlur, only onSubmit. It slows down keystrokes
- after archiving a team, update the authToken on the websocket (correctly, it was setting it back to the blacklisted version)
- verifyEmail should only get called once