### PR TITLE
fix: poker scale menu stays open on edits

### DIFF
--- a/packages/client/modules/meeting/components/PokerTemplateScalePicker.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateScalePicker.tsx
@@ -1,14 +1,12 @@
-import styled from '@emotion/styled'
 import {ExpandMore} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
+import {useState} from 'react'
 import {useFragment} from 'react-relay'
 import type {PokerTemplateScalePicker_dimension$key} from '../../../__generated__/PokerTemplateScalePicker_dimension.graphql'
-import {MenuPosition} from '../../../hooks/useCoords'
-import useMenu from '../../../hooks/useMenu'
-import useTooltip from '../../../hooks/useTooltip'
-import textOverflow from '../../../styles/helpers/textOverflow'
-import {PALETTE} from '../../../styles/paletteV3'
-import {FONT_FAMILY} from '../../../styles/typographyV2'
+import {Menu} from '../../../ui/Menu/Menu'
+import {Tooltip} from '../../../ui/Tooltip/Tooltip'
+import {TooltipContent} from '../../../ui/Tooltip/TooltipContent'
+import {TooltipTrigger} from '../../../ui/Tooltip/TooltipTrigger'
 import lazyPreload from '../../../utils/lazyPreload'
 
 const SelectScaleDropdown = lazyPreload(
@@ -18,47 +16,6 @@ const SelectScaleDropdown = lazyPreload(
       './SelectScaleDropdown'
     )
 )
-
-const DropdownIcon = styled(ExpandMore)({
-  color: PALETTE.SLATE_700,
-  marginTop: 7,
-  marginBottom: 5,
-  marginRight: 16,
-  height: 18,
-  width: 18
-})
-
-const DropdownBlock = styled('div')<{disabled: boolean; readOnly: boolean}>(
-  ({disabled, readOnly}) => ({
-    background: disabled && !readOnly ? PALETTE.SLATE_200 : '#fff',
-    border: readOnly ? undefined : `1px solid ${PALETTE.SLATE_400}`,
-    borderRadius: '30px',
-    cursor: readOnly ? undefined : disabled ? 'not-allowed' : 'pointer',
-    display: 'flex',
-    fontSize: 13,
-    lineHeight: '20px',
-    minWidth: 144,
-    userSelect: 'none'
-  })
-)
-
-const MenuToggleInner = styled('div')({
-  alignItems: 'center',
-  display: 'flex',
-  flex: 1,
-  flexWrap: 'wrap',
-  minWidth: 0,
-  marginLeft: 16
-})
-
-const MenuToggleLabel = styled('div')({
-  ...textOverflow,
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  fontWeight: 600,
-  lineHeight: '20px',
-  textAlign: 'center',
-  margin: 'auto'
-})
 
 interface Props {
   dimension: PokerTemplateScalePicker_dimension$key
@@ -81,41 +38,46 @@ const PokerTemplateScalePicker = (props: Props) => {
     dimensionRef
   )
   const {selectedScale} = dimension
-  const {togglePortal, menuPortal, originRef, menuProps} = useMenu<HTMLDivElement>(
-    MenuPosition.LOWER_RIGHT,
-    {
-      isDropdown: true,
-      id: 'scaleDropdown',
-      loadingWidth: 300
-    }
+  const [open, setOpen] = useState(false)
+
+  const trigger = (
+    <div
+      onMouseEnter={SelectScaleDropdown.preload}
+      className={`flex min-w-36 select-none rounded-full text-[13px] leading-5 ${
+        readOnly
+          ? 'bg-white'
+          : !isOwner
+            ? 'cursor-not-allowed border border-slate-400 bg-slate-200'
+            : 'cursor-pointer border border-slate-400 bg-white'
+      }`}
+    >
+      <div className='ml-4 flex min-w-0 flex-1 flex-wrap items-center'>
+        <div className='m-auto truncate text-center font-semibold leading-5'>
+          {selectedScale.name}
+        </div>
+      </div>
+      {!readOnly && (
+        <ExpandMore className='mt-[7px] mr-4 mb-[5px] h-[18px] w-[18px] text-slate-700' />
+      )}
+    </div>
   )
-  const {
-    openTooltip,
-    tooltipPortal,
-    closeTooltip,
-    originRef: tooltipRef
-  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER, {
-    disabled: isOwner || readOnly
-  })
+
+  if (readOnly) return trigger
+
+  if (!isOwner) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+        <TooltipContent side='bottom'>Must be the template owner to change</TooltipContent>
+      </Tooltip>
+    )
+  }
+
   return (
-    <>
-      <DropdownBlock
-        onMouseEnter={SelectScaleDropdown.preload}
-        onClick={isOwner && !readOnly ? togglePortal : undefined}
-        disabled={!isOwner}
-        readOnly={!!readOnly}
-        ref={isOwner ? originRef : tooltipRef}
-        onMouseOver={openTooltip}
-        onMouseLeave={closeTooltip}
-      >
-        <MenuToggleInner>
-          <MenuToggleLabel>{selectedScale.name}</MenuToggleLabel>
-        </MenuToggleInner>
-        {!readOnly && <DropdownIcon />}
-      </DropdownBlock>
-      {menuPortal(<SelectScaleDropdown menuProps={menuProps} dimension={dimension} />)}
-      {tooltipPortal(<div>Must be the template owner to change</div>)}
-    </>
+    <Menu trigger={trigger} open={open} onOpenChange={setOpen}>
+      <SelectScaleDropdown dimension={dimension} onClose={() => setOpen(false)} />
+    </Menu>
   )
 }
+
 export default PokerTemplateScalePicker

--- a/packages/client/modules/meeting/components/ScaleActions.tsx
+++ b/packages/client/modules/meeting/components/ScaleActions.tsx
@@ -19,11 +19,10 @@ interface Props {
   scale: ScaleActions_scale$key
   scaleCount: number
   teamId: string
-  closeMenu: () => void
 }
 
 const ScaleActions = (props: Props) => {
-  const {scale: scaleRef, scaleCount, teamId, closeMenu} = props
+  const {scale: scaleRef, scaleCount, teamId} = props
   const scale = useFragment(
     graphql`
       fragment ScaleActions_scale on TemplateScale {
@@ -52,9 +51,9 @@ const ScaleActions = (props: Props) => {
         {onError, onCompleted}
       )
     }
-    closeMenu()
   }
-  const editScale = () => {
+  const editScale = (e: React.MouseEvent) => {
+    e.stopPropagation()
     commitLocalUpdate(atmosphere, (store) => {
       store.get(teamId)?.setValue(scaleId, 'editingScaleId')
     })

--- a/packages/client/modules/meeting/components/ScaleDropdownMenuItem.tsx
+++ b/packages/client/modules/meeting/components/ScaleDropdownMenuItem.tsx
@@ -1,14 +1,9 @@
-import styled from '@emotion/styled'
 import {Public} from '@mui/icons-material'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import graphql from 'babel-plugin-relay/macro'
-import {forwardRef} from 'react'
 import {useFragment} from 'react-relay'
-import textOverflow from '~/styles/helpers/textOverflow'
-import {PALETTE} from '~/styles/paletteV3'
-import {FONT_FAMILY} from '~/styles/typographyV2'
 import type {ScaleDropdownMenuItem_dimension$key} from '../../../__generated__/ScaleDropdownMenuItem_dimension.graphql'
 import type {ScaleDropdownMenuItem_scale$key} from '../../../__generated__/ScaleDropdownMenuItem_scale.graphql'
-import MenuItem from '../../../components/MenuItem'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useMutationProps from '../../../hooks/useMutationProps'
 import UpdatePokerTemplateDimensionScaleMutation from '../../../mutations/UpdatePokerTemplateDimensionScaleMutation'
@@ -22,55 +17,7 @@ interface Props {
   closePortal: () => void
 }
 
-const ScaleDetails = styled('div')({
-  display: 'flex',
-  justifyContent: 'space-between',
-  minWidth: '300px'
-})
-
-const ScaleNameAndValues = styled('div')({
-  display: 'block',
-  flexDirection: 'column',
-  maxWidth: '200px',
-  paddingTop: 12,
-  paddingLeft: 16,
-  paddingBottom: 12,
-  flexGrow: 1
-})
-
-const ScaleName = styled('div')({
-  ...textOverflow,
-  color: PALETTE.SLATE_700,
-  display: 'flex',
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  fontSize: 16,
-  fontWeight: 600,
-  lineHeight: '24px',
-  alignItems: 'center'
-})
-
-const ScaleValues = styled('div')({
-  ...textOverflow,
-  color: PALETTE.SLATE_600,
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  fontSize: 12,
-  lineHeight: '16px'
-})
-
-const ScaleActionButtonGroup = styled('div')({
-  paddingLeft: '8px',
-  paddingRight: '8px',
-  marginTop: 'auto',
-  marginBottom: 'auto'
-})
-
-const StarterIcon = styled(Public)({
-  height: 18,
-  width: 18,
-  marginLeft: 4
-})
-
-const ScaleDropdownMenuItem = forwardRef((props: Props, ref) => {
+const ScaleDropdownMenuItem = (props: Props) => {
   const {scale: scaleRef, dimension: dimensionRef, closePortal, scaleCount} = props
   const dimension = useFragment(
     graphql`
@@ -107,7 +54,7 @@ const ScaleDropdownMenuItem = forwardRef((props: Props, ref) => {
   const atmosphere = useAtmosphere()
   const {submitMutation, submitting, onError, onCompleted} = useMutationProps()
 
-  const setScale = (scaleId: any) => () => {
+  const setScale = () => {
     if (submitting || scaleId === selectedScaleId) return
     submitMutation()
     UpdatePokerTemplateDimensionScaleMutation(
@@ -119,30 +66,23 @@ const ScaleDropdownMenuItem = forwardRef((props: Props, ref) => {
   }
 
   return (
-    <MenuItem
-      ref={ref}
-      onClick={setScale(scaleId)}
-      label={
-        <ScaleDetails>
-          <ScaleNameAndValues>
-            <ScaleName>
-              {scaleName}
-              {isStarter && <StarterIcon />}
-            </ScaleName>
-            <ScaleValues>{scaleValueString(values)}</ScaleValues>
-          </ScaleNameAndValues>
-          <ScaleActionButtonGroup>
-            <ScaleActions
-              scale={scale}
-              scaleCount={scaleCount}
-              teamId={dimension.team.id}
-              closeMenu={closePortal}
-            />
-          </ScaleActionButtonGroup>
-        </ScaleDetails>
-      }
-    />
+    <DropdownMenu.Item
+      className='mx-1 flex min-w-[300px] cursor-pointer justify-between rounded-md outline-hidden hover:bg-slate-100 focus:bg-slate-100'
+      data-scale-id={scaleId}
+      onClick={setScale}
+    >
+      <div className='flex max-w-[200px] grow flex-col px-4 py-3'>
+        <div className='flex items-center truncate font-semibold text-base text-slate-700 leading-6'>
+          {scaleName}
+          {isStarter && <Public className='ml-1 h-[18px] w-[18px]' />}
+        </div>
+        <div className='truncate text-slate-600 text-xs leading-4'>{scaleValueString(values)}</div>
+      </div>
+      <div className='my-auto px-2'>
+        <ScaleActions scale={scale} scaleCount={scaleCount} teamId={dimension.team.id} />
+      </div>
+    </DropdownMenu.Item>
   )
-})
+}
 
 export default ScaleDropdownMenuItem

--- a/packages/client/modules/meeting/components/SelectScaleDropdown.tsx
+++ b/packages/client/modules/meeting/components/SelectScaleDropdown.tsx
@@ -1,48 +1,23 @@
-import styled from '@emotion/styled'
 import {Add} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
-import {useMemo} from 'react'
+import {useRef} from 'react'
 import {useFragment} from 'react-relay'
 import type {SelectScaleDropdown_dimension$key} from '../../../__generated__/SelectScaleDropdown_dimension.graphql'
-import LinkButton from '../../../components/LinkButton'
-import Menu from '../../../components/Menu'
-import MenuItem from '../../../components/MenuItem'
-import MenuItemHR from '../../../components/MenuItemHR'
 import useAtmosphere from '../../../hooks/useAtmosphere'
-import type {MenuProps} from '../../../hooks/useMenu'
 import useMutationProps from '../../../hooks/useMutationProps'
 import AddPokerTemplateScaleMutation from '../../../mutations/AddPokerTemplateScaleMutation'
-import {FONT_FAMILY} from '../../../styles/typographyV2'
+import UpdatePokerTemplateDimensionScaleMutation from '../../../mutations/UpdatePokerTemplateDimensionScaleMutation'
 import {Threshold} from '../../../types/constEnums'
+import {MenuContent} from '../../../ui/Menu/MenuContent'
 import ScaleDropdownMenuItem from './ScaleDropdownMenuItem'
 
 interface Props {
-  menuProps: MenuProps
+  onClose: () => void
   dimension: SelectScaleDropdown_dimension$key
 }
 
-const AddScaleLink = styled(LinkButton)({
-  display: 'flex',
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  fontWeight: 600,
-  fontSize: 16,
-  justifyContent: 'flex-start',
-  lineHeight: '24px',
-  padding: '12px 16px',
-  width: '100%'
-})
-
-const AddScaleLinkPlus = styled(Add)({
-  display: 'block',
-  margin: '0 8px 0 0'
-})
-
-const StyledMenu = styled(Menu)({
-  maxHeight: 320
-})
-
 const SelectScaleDropdown = (props: Props) => {
-  const {menuProps, dimension: dimensionRef} = props
+  const {onClose, dimension: dimensionRef} = props
   const dimension = useFragment(
     graphql`
       fragment SelectScaleDropdown_dimension on TemplateDimension {
@@ -67,18 +42,13 @@ const SelectScaleDropdown = (props: Props) => {
     `,
     dimensionRef
   )
-  const {closePortal} = menuProps
-  const {selectedScale, team} = dimension
-  const {id: seletedScaleId} = selectedScale
+  const {id: dimensionId, team} = dimension
   const {id: teamId, scales} = team
   const sortedScales = scales.toSorted((a, b) => {
     return a.isStarter !== b.isStarter ? (a.isStarter ? 1 : -1) : a.name.localeCompare(b.name)
   })
-  const defaultActiveIdx = useMemo(
-    () => sortedScales.findIndex(({id}) => id === seletedScaleId),
-    [dimension]
-  )
 
+  const menuRef = useRef<HTMLDivElement>(null)
   const atmosphere = useAtmosphere()
   const {onError, onCompleted, submitting, submitMutation} = useMutationProps()
 
@@ -90,17 +60,30 @@ const SelectScaleDropdown = (props: Props) => {
       {teamId},
       {
         onError,
-        onCompleted
+        onCompleted: (res, errors) => {
+          onCompleted(res, errors)
+          const newScaleId = res?.addPokerTemplateScale?.scale?.id
+          if (!newScaleId) return
+          UpdatePokerTemplateDimensionScaleMutation(
+            atmosphere,
+            {dimensionId, scaleId: newScaleId},
+            {onError, onCompleted: () => {}}
+          )
+          requestAnimationFrame(() => {
+            menuRef.current
+              ?.querySelector(`[data-scale-id="${newScaleId}"]`)
+              ?.scrollIntoView({behavior: 'smooth', block: 'nearest'})
+          })
+        }
       }
     )
-    closePortal()
   }
 
   return (
-    <StyledMenu
-      ariaLabel={'Select the scale for this dimension'}
-      {...menuProps}
-      defaultActiveIdx={defaultActiveIdx}
+    <MenuContent
+      ref={menuRef}
+      aria-label='Select the scale for this dimension'
+      className='max-h-80'
     >
       {sortedScales.map((scale) => (
         <ScaleDropdownMenuItem
@@ -108,22 +91,21 @@ const SelectScaleDropdown = (props: Props) => {
           scale={scale}
           dimension={dimension}
           scaleCount={sortedScales.length}
-          closePortal={closePortal}
+          closePortal={onClose}
         />
       ))}
-      <MenuItemHR key='HR1' />
+      <hr className='my-2 border-0 border-slate-400 border-t' />
       {sortedScales.length < Threshold.MAX_POKER_TEMPLATE_SCALES && (
-        <MenuItem
-          key='create'
-          label={
-            <AddScaleLink palette='blue' onClick={addScale} waiting={submitting}>
-              <AddScaleLinkPlus />
-              Create a Scale
-            </AddScaleLink>
-          }
-        />
+        <button
+          className='flex w-full cursor-pointer items-center px-4 py-3 font-semibold text-base text-sky-500 hover:text-sky-600 disabled:cursor-not-allowed disabled:opacity-50'
+          onClick={addScale}
+          disabled={submitting}
+        >
+          <Add className='mr-2 block' />
+          Create a Scale
+        </button>
       )}
-    </StyledMenu>
+    </MenuContent>
   )
 }
 


### PR DESCRIPTION
# Description

Clicking edit/create new scale should not close the menu when it opens a dialog. the dialog should open on top of the menu.

This fixes the behavior to save users a couple clicks.