### PR TITLE
feat: AI estimates on jira issues

### DIFF
--- a/packages/client/components/EstimatePhaseArea.tsx
+++ b/packages/client/components/EstimatePhaseArea.tsx
@@ -96,6 +96,7 @@ const EstimatePhaseArea = (props: Props) => {
         index={stageIdx}
         onChangeIndex={onChangeIdx}
         style={innerStyle(isDesktop, hasSingleDimension)}
+        slideClassName='px-1'
       >
         {dimensionStages.map((stage, idx) => (
           <div

--- a/packages/client/hooks/useTipTapCommentEditor.ts
+++ b/packages/client/hooks/useTipTapCommentEditor.ts
@@ -10,6 +10,7 @@ import {LoomExtension} from '../components/TipTapEditor/LoomExtension'
 import {TiptapLinkExtension} from '../components/TipTapEditor/TiptapLinkExtension'
 import {mentionConfig} from '../shared/tiptap/serverTipTapExtensions'
 import {ClearOnSubmit} from '../tiptap/extensions/ClearOnSubmit'
+import {PopoverMention} from '../tiptap/extensions/popoverMention/PopoverMention'
 import {MentionTaskTag} from '../utils/MentionTaskTag'
 import {tiptapEmojiConfig} from '../utils/tiptapEmojiConfig'
 import {tiptapMentionConfig} from '../utils/tiptapMentionConfig'
@@ -50,6 +51,7 @@ export const useTipTapCommentEditor = (
             return placeholderRef.current || 'Edit your comment'
           }
         }),
+        PopoverMention,
         MentionTaskTag.configure(tiptapTagConfig),
         Mention.configure(
           atmosphere && teamId ? tiptapMentionConfig(atmosphere, teamId) : mentionConfig

--- a/packages/client/shared/tiptap/extensions/PopoverMentionBase.ts
+++ b/packages/client/shared/tiptap/extensions/PopoverMentionBase.ts
@@ -1,0 +1,47 @@
+import {mergeAttributes, Node} from '@tiptap/core'
+
+export interface PopoverMentionAttrs {
+  // the visible inline text
+  label: string
+  // a stringified TipTap document rendered in a popover when the label is hovered
+  content: string
+}
+
+// An inline token that renders `label` and reveals a TipTap document in a hover popover.
+export const PopoverMentionBase = Node.create({
+  name: 'popoverMention',
+
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return {
+      label: {
+        default: '',
+        parseHTML: (el) => el.getAttribute('data-label') ?? '',
+        renderHTML: (attrs) => ({'data-label': attrs.label})
+      },
+      content: {
+        default: ''
+      }
+    }
+  },
+
+  parseHTML() {
+    return [{tag: `span[data-type="${this.name}"]`}]
+  },
+
+  renderHTML({HTMLAttributes, node}) {
+    return [
+      'span',
+      mergeAttributes({'data-type': this.name}, HTMLAttributes),
+      (node.attrs as PopoverMentionAttrs).label
+    ]
+  },
+
+  renderText({node}) {
+    return (node.attrs as PopoverMentionAttrs).label
+  }
+})

--- a/packages/client/shared/tiptap/serverTipTapExtensions.ts
+++ b/packages/client/shared/tiptap/serverTipTapExtensions.ts
@@ -17,6 +17,7 @@ import {FileBlockBase} from './extensions/FileBlockBase'
 import {FileUploadBase} from './extensions/FileUploadBase'
 import {InsightsBlockBase} from './extensions/InsightsBlockBase'
 import {PageLinkBlockBase} from './extensions/PageLinkBlockBase'
+import {PopoverMentionBase} from './extensions/PopoverMentionBase'
 import {ResponseBlockBase} from './extensions/ResponseBlockBase'
 import {TaskBlockBase} from './extensions/TaskBlockBase'
 import {ThinkingBlockBase} from './extensions/ThinkingBlockBase'
@@ -71,6 +72,7 @@ export const serverTipTapExtensions: Extensions = [
   MentionTaskTag,
   PageUserMention,
   InsightsBlockBase,
+  PopoverMentionBase,
   UniqueID,
   PageLinkBlockBase,
   Database,

--- a/packages/client/tiptap/extensions/popoverMention/PopoverMention.ts
+++ b/packages/client/tiptap/extensions/popoverMention/PopoverMention.ts
@@ -1,0 +1,10 @@
+import {ReactNodeViewRenderer} from '@tiptap/react'
+import {PopoverMentionBase} from '../../../shared/tiptap/extensions/PopoverMentionBase'
+import {PopoverMentionView} from './PopoverMentionView'
+
+export const PopoverMention = PopoverMentionBase.extend({
+  addNodeView() {
+    // By convention, components rendered here are named with a *View suffix
+    return ReactNodeViewRenderer(PopoverMentionView)
+  }
+})

--- a/packages/client/tiptap/extensions/popoverMention/PopoverMentionView.tsx
+++ b/packages/client/tiptap/extensions/popoverMention/PopoverMentionView.tsx
@@ -1,0 +1,32 @@
+import {Content, Portal, Root, Trigger} from '@radix-ui/react-tooltip'
+import {EditorContent, type NodeViewProps, NodeViewWrapper} from '@tiptap/react'
+import {useTipTapTaskEditor} from '../../../hooks/useTipTapTaskEditor'
+import type {PopoverMentionAttrs} from '../../../shared/tiptap/extensions/PopoverMentionBase'
+
+export const PopoverMentionView = (props: NodeViewProps) => {
+  const {label, content} = props.node.attrs as PopoverMentionAttrs
+  // the popover renders the stored TipTap document as a read-only block
+  const {editor} = useTipTapTaskEditor(content, {readOnly: true})
+  return (
+    <NodeViewWrapper as='span' className='inline'>
+      <Root>
+        <Trigger asChild>
+          <span className='cursor-help font-semibold text-sky-500 underline decoration-dotted underline-offset-2'>
+            {label}
+          </span>
+        </Trigger>
+        {content && editor ? (
+          <Portal>
+            <Content
+              side='top'
+              sideOffset={4}
+              className='z-20 max-h-80 max-w-sm animate-scale-in overflow-auto rounded-sm bg-white p-3 text-left text-slate-700 text-sm shadow-lg [&_h1]:mb-1 [&_h1]:font-semibold [&_h1]:text-base [&_h2]:text-sm [&_h3]:text-sm'
+            >
+              <EditorContent editor={editor} />
+            </Content>
+          </Portal>
+        ) : null}
+      </Root>
+    </NodeViewWrapper>
+  )
+}

--- a/packages/server/graphql/mutations/helpers/generatePokerAIEstimate.ts
+++ b/packages/server/graphql/mutations/helpers/generatePokerAIEstimate.ts
@@ -1,0 +1,198 @@
+import {generateText, type JSONContent} from '@tiptap/core'
+import JiraProjectKeyId from 'parabol-client/shared/gqlIds/JiraProjectKeyId'
+import convertADFToTipTap, {type AdfNode} from 'parabol-client/shared/tiptap/convertADFToTipTap'
+import {markdownToTipTap} from 'parabol-client/shared/tiptap/markdownToTipTap'
+import {SprintPokerDefaults, SubscriptionChannel} from 'parabol-client/types/constEnums'
+import {PARABOL_AI_USER_ID} from 'parabol-client/utils/constants'
+import {serverTipTapExtensions} from '../../../../client/shared/tiptap/serverTipTapExtensions'
+import {getNewDataLoader} from '../../../dataloader/getNewDataLoader'
+import getKysely from '../../../postgres/getKysely'
+import type {EstimateStage} from '../../../postgres/types/NewMeetingPhase'
+import AtlassianServerManager from '../../../utils/AtlassianServerManager'
+import OpenAIServerManager from '../../../utils/OpenAIServerManager'
+import publish from '../../../utils/publish'
+import {createAIComment} from './addAIGeneratedContentToThreads'
+
+const MAX_REFERENCE_ISSUES = 10
+
+// Flatten a Jira ADF description into plaintext for the AI prompt
+const adfToPlaintext = (description: AdfNode | null | undefined) => {
+  if (!description) return ''
+  const tiptap = convertADFToTipTap(description)
+  return generateText(tiptap, serverTipTapExtensions).trim()
+}
+
+// Build a stringified TipTap doc (issue title as the first node + description) for the hover popover
+const buildPopoverContent = (description: AdfNode | null | undefined, title: string) => {
+  const adf = description ?? {type: 'doc', content: []}
+  return JSON.stringify(convertADFToTipTap(adf, title))
+}
+
+const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+// Walk the markdown-derived TipTap tree and replace bare issue-key text (e.g. "PROJ-123")
+// with popoverMention nodes that carry the issue's content doc for the hover popover.
+const injectIssueKeyMentions = (
+  nodes: JSONContent[],
+  regex: RegExp,
+  contentByKey: Record<string, string>
+): JSONContent[] =>
+  nodes.flatMap((node) => {
+    if (node.type === 'text' && typeof node.text === 'string') {
+      const {text} = node
+      const parts: JSONContent[] = []
+      let lastIndex = 0
+      regex.lastIndex = 0
+      let match: RegExpExecArray | null
+      while ((match = regex.exec(text))) {
+        const issueKey = match[1]!
+        if (match.index > lastIndex) parts.push({...node, text: text.slice(lastIndex, match.index)})
+        parts.push({
+          type: 'popoverMention',
+          attrs: {label: issueKey, content: contentByKey[issueKey] ?? ''}
+        })
+        lastIndex = match.index + issueKey.length
+      }
+      if (parts.length === 0) return [node]
+      if (lastIndex < text.length) parts.push({...node, text: text.slice(lastIndex)})
+      return parts
+    }
+    if (Array.isArray(node.content)) {
+      return [{...node, content: injectIssueKeyMentions(node.content, regex, contentByKey)}]
+    }
+    return [node]
+  })
+
+// Convert the AI markdown response into a TipTap comment doc, linking issue keys to popovers
+const buildEstimateCommentDoc = (
+  markdown: string,
+  contentByKey: Record<string, string>
+): JSONContent => {
+  const body = markdownToTipTap(markdown) as JSONContent[]
+  const content = body.length
+    ? body
+    : [{type: 'paragraph', content: [{type: 'text', text: markdown}]}]
+  const keys = Object.keys(contentByKey)
+  if (keys.length === 0) return {type: 'doc', content}
+  // longest keys first so e.g. PROJ-12 can't shadow PROJ-123, and guard against partial matches
+  const pattern = keys
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegExp)
+    .join('|')
+  const regex = new RegExp(`(?<![\\w-])(${pattern})(?![\\w-])`, 'g')
+  return {type: 'doc', content: injectIssueKeyMentions(content, regex, contentByKey)}
+}
+
+interface Options {
+  stage: EstimateStage
+  meetingId: string
+  teamId: string
+}
+
+// Generates an AI story-point estimate for a Jira Cloud issue and posts it as a
+// comment in the stage discussion. Called once votes are revealed, so the result
+// is published async via the meeting pubsub channel as soon as it is ready.
+export const generatePokerAIEstimate = async (options: Options) => {
+  const {stage, meetingId, teamId} = options
+  const dataLoader = getNewDataLoader('generatePokerAIEstimate')
+  const operationId = dataLoader.share()
+  const subOptions = {operationId}
+  const {taskId, dimensionRefIdx, discussionId} = stage
+
+  try {
+    // bail if an AI estimate was already posted for this discussion (e.g. votes were
+    // revealed again after the stage was reset) so we never post a duplicate
+    const existingComments = await dataLoader.get('commentsByDiscussionId').load(discussionId)
+    if (existingComments.some((comment) => comment.createdBy === PARABOL_AI_USER_ID)) return
+
+    const task = await dataLoader.get('tasks').load(taskId)
+    const integration = task?.integration
+    // only Jira Cloud issues are supported
+    if (!integration || integration.service !== 'jira') return
+    const {cloudId, issueKey, accessUserId} = integration
+    const projectKey = JiraProjectKeyId.join(issueKey)
+
+    // resolve the dimension + scale (possible story point values)
+    const meeting = await dataLoader.get('newMeetings').load(meetingId)
+    if (!meeting || meeting.meetingType !== 'poker') return
+    const templateRef = await dataLoader.get('templateRefs').loadNonNull(meeting.templateRefId)
+    const dimensionRef = templateRef.dimensions[dimensionRefIdx]
+    if (!dimensionRef) return
+    const {name: dimensionName, scaleRefId} = dimensionRef
+    const scaleRef = await dataLoader.get('templateScaleRefs').loadNonNull(scaleRefId)
+    const possibleLabels = scaleRef.values.map(({label}) => label)
+
+    const jiraIssue = await dataLoader.get('jiraIssue').load({
+      teamId,
+      userId: accessUserId,
+      cloudId,
+      issueKey,
+      taskId,
+      viewerId: accessUserId
+    })
+    if (!jiraIssue) return
+    const {issueType, summary, description} = jiraIssue
+
+    // figure out which Jira field holds the story points for this dimension
+    const dimensionFields = await dataLoader
+      .get('jiraDimensionFieldMap')
+      .load({teamId, cloudId, projectKey, issueType, dimensionName})
+    const fieldId = dimensionFields.find(
+      ({fieldId}) =>
+        fieldId !== SprintPokerDefaults.SERVICE_FIELD_COMMENT &&
+        fieldId !== SprintPokerDefaults.SERVICE_FIELD_NULL
+    )?.fieldId
+    // no real story-point field mapped (e.g. team writes estimate as a comment) -> nothing to reference
+    if (!fieldId) return
+
+    // fetch recent issues from the same project that already have an estimate
+    const auth = await dataLoader.get('freshAtlassianAuth').load({teamId, userId: accessUserId})
+    if (!auth) return
+    const manager = new AtlassianServerManager(auth.accessToken)
+    // over-fetch since issues without an estimate are filtered out below
+    const {issues: recentIssues} = await manager.getProjectIssuesWithField(
+      cloudId,
+      projectKey,
+      fieldId,
+      50
+    )
+
+    const references = (recentIssues ?? [])
+      .filter((issue) => issue.issueKey !== issueKey)
+      .slice(0, MAX_REFERENCE_ISSUES)
+      .map((issue) => ({
+        issueKey: issue.issueKey,
+        title: issue.summary,
+        description: adfToPlaintext(issue.description),
+        storyPoints: issue.storyPoints,
+        content: buildPopoverContent(issue.description, issue.summary)
+      }))
+
+    // the popover content doc is for the comment, not the prompt, so keep it out of the AI input
+    const issues = [
+      {issueKey, title: summary, description: adfToPlaintext(description), storyPoints: ''},
+      ...references.map(({content, ...rest}) => rest)
+    ]
+
+    const openAI = new OpenAIServerManager()
+    const estimate = await openAI.getPokerEstimate(issues, dimensionName, possibleLabels)
+    if (!estimate) return
+
+    // map every referenced issue key to its content doc for the comment's hover popovers
+    const contentByKey: Record<string, string> = {
+      [issueKey]: buildPopoverContent(description, summary)
+    }
+    for (const reference of references) {
+      contentByKey[reference.issueKey] = reference.content
+    }
+
+    const content = buildEstimateCommentDoc(estimate, contentByKey)
+    const comment = createAIComment(discussionId, content, 1)
+    await getKysely().insertInto('Comment').values(comment).execute()
+
+    const data = {commentId: comment.id, meetingId}
+    publish(SubscriptionChannel.MEETING, meetingId, 'AddCommentSuccess', data, subOptions)
+  } finally {
+    dataLoader.dispose()
+  }
+}

--- a/packages/server/graphql/public/mutations/pokerRevealVotes.ts
+++ b/packages/server/graphql/public/mutations/pokerRevealVotes.ts
@@ -8,7 +8,9 @@ import EstimateUserScore from '../../../database/types/EstimateUserScore'
 import getKysely from '../../../postgres/getKysely'
 import type {PokerMeetingMember} from '../../../postgres/types/Meeting'
 import getPhase from '../../../utils/getPhase'
+import {Logger} from '../../../utils/Logger'
 import publish from '../../../utils/publish'
+import {generatePokerAIEstimate} from '../../mutations/helpers/generatePokerAIEstimate'
 import type {MutationResolvers} from '../resolverTypes'
 
 const pokerRevealVotes: MutationResolvers['pokerRevealVotes'] = async (
@@ -98,6 +100,10 @@ const pokerRevealVotes: MutationResolvers['pokerRevealVotes'] = async (
     .where('id', '=', meetingId)
     .execute()
   dataLoader.clearAll('newMeetings')
+
+  // generate an AI estimate and publish it async once ready; the helper no-ops if an
+  // AI comment already exists for this discussion (e.g. votes revealed again after a reset)
+  generatePokerAIEstimate({stage, meetingId, teamId}).catch(Logger.error)
 
   const data = {meetingId, stageId}
   publish(SubscriptionChannel.MEETING, meetingId, 'PokerRevealVotesSuccess', data, subOptions)

--- a/packages/server/utils/AtlassianServerManager.ts
+++ b/packages/server/utils/AtlassianServerManager.ts
@@ -1,6 +1,7 @@
 import {fetch} from '@whatwg-node/fetch'
 
 import JiraProjectKeyId from 'parabol-client/shared/gqlIds/JiraProjectKeyId'
+import type {AdfNode} from 'parabol-client/shared/tiptap/convertADFToTipTap'
 import {SprintPokerDefaults} from 'parabol-client/types/constEnums'
 import AtlassianManager, {
   type AtlassianError,
@@ -632,6 +633,44 @@ class AtlassianServerManager extends AtlassianManager {
     })
     const {nextPageToken: nextNextPageToken, isLast} = res
     return {error: null, issues, nextPageToken: nextNextPageToken, isLast}
+  }
+
+  async getProjectIssuesWithField(
+    cloudId: string,
+    projectKey: string,
+    fieldId: string,
+    maxResults: number
+  ) {
+    const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search/jql`
+    // filter for a non-empty estimate field in JS rather than JQL, since custom field
+    // ids (e.g. customfield_10016) aren't valid JQL identifiers
+    const jql = `project = "${projectKey}" ORDER BY updated DESC`
+    const payload = {
+      jql,
+      maxResults,
+      fields: ['summary', 'description', fieldId]
+    }
+    const res = await this.post<
+      JiraSearchResponse<{summary: string; description: AdfNode} & {[fieldId: string]: unknown}>
+    >(url, payload)
+    if (res instanceof Error) {
+      return {error: res, issues: null}
+    }
+    const issues = res.issues
+      .map((issue) => {
+        const {key: issueKey, fields} = issue
+        const storyPointsRaw = fields[fieldId]
+        const storyPoints =
+          storyPointsRaw === null || storyPointsRaw === undefined ? '' : String(storyPointsRaw)
+        return {
+          issueKey,
+          summary: fields.summary,
+          description: fields.description,
+          storyPoints
+        }
+      })
+      .filter((issue) => issue.storyPoints !== '')
+    return {error: null, issues}
   }
 
   async getComments(cloudId: string, issueKey: string) {

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -202,6 +202,58 @@ Return JSON: { "groups": [{ "title": "...", "reflectionIds": ["id1", "id2"] }] }
     }
   }
 
+  async getPokerEstimate(
+    issues: {title: string; description: string; issueKey: string; storyPoints: string}[],
+    dimensionName: string,
+    possibleLabels: string[]
+  ): Promise<string | null> {
+    if (!this.openAIApi) return null
+    if (issues.length === 0) return null
+    const [target, ...references] = issues
+    if (!target) return null
+    if (references.length === 0) return null
+    const allowedValues = possibleLabels.join(', ')
+    const referenceBlock = references
+      .map(
+        ({issueKey, title, storyPoints, description}) =>
+          `- Key: ${issueKey}. Title: ${title}. Points: (${storyPoints}). Description: ${description}`
+      )
+      .join('\n')
+    const prompt = `You are an agile estimation assistant helping a team play planning poker. Estimate the "${dimensionName}" for the issue below.
+
+You MUST choose exactly one value from these allowed values: ${allowedValues}.
+
+Issue to estimate:
+Key: ${target.issueKey}. Title: ${target.title}. Description: ${target.description}
+
+Recent issues from the same project that already have an estimate, for reference:
+${referenceBlock}
+
+Compare the scope and complexity of the issue to estimate against the reference issues, then give your estimate.
+
+Respond in GitHub-flavored markdown. The first line MUST be exactly "**Estimate: <value>**" where <value> is the chosen allowed value. After a blank line, justify the estimate in 2-3 sentences. When you cite a reference issue, refer to it by its bare issue key only (e.g. ${references[0]?.issueKey ?? 'PROJ-123'}) — do not include its title or a link.`
+    try {
+      const response = await this.openAIApi.chat.completions.create({
+        model: 'gpt-5.4-mini',
+        messages: [
+          {
+            role: 'user',
+            content: prompt
+          }
+        ]
+      })
+      const estimate = response.choices[0]?.message?.content?.trim()
+      return estimate || null
+    } catch (e) {
+      const error =
+        e instanceof Error
+          ? e
+          : new Error(`OpenAI failed to generate a poker estimate for ${issues[0]?.issueKey}`)
+      logError(error)
+      return null
+    }
+  }
+
   async modifyCheckInQuestion(question: string, modifyType: ModifyType) {
     if (!this.openAIApi) return null
 


### PR DESCRIPTION
# Description

In retros we had AI start the discussion with a thoughtful summary & question. Why not do the same for poker meetings?
After the team votes on a jira issue, we go out to jira and make our own estimate & justify why.