### PR TITLE
fix: safeguard against invalid frame data

### DIFF
--- a/packages/server/hocusPocusHandler.ts
+++ b/packages/server/hocusPocusHandler.ts
@@ -47,7 +47,8 @@ export const hocusPocusHandler: WebSocketBehavior<HocusPocusSocketData> = {
     userData.socket = new HocusPocusWebSocket(ws)
     redisHocusPocus.onSocketOpen(userData.socket, userData.serializedHTTPRequest)
   },
-  async message(ws, message) {
+  async message(ws, message, isBinary) {
+    if (!isBinary) return
     const {serializedHTTPRequest} = ws.getUserData()
     redisHocusPocus.onSocketMessage(serializedHTTPRequest, message)
   },

--- a/packages/server/utils/tiptap/RedisServerAffinity.ts
+++ b/packages/server/utils/tiptap/RedisServerAffinity.ts
@@ -378,7 +378,13 @@ export class RedisServerAffinity<TCE extends CustomEvents> implements Extension 
   async onSocketMessage(serializedHTTPRequest: SerializedHTTPRequest, detachableMsg: ArrayBuffer) {
     const message = new Uint8Array(detachableMsg.slice())
     const tmpMsg = new IncomingMessage(detachableMsg)
-    const documentNameAndSessionId = tmpMsg.readVarString()
+    let documentNameAndSessionId: string
+    try {
+      documentNameAndSessionId = tmpMsg.readVarString()
+    } catch {
+      // User trying to pass in invalid frame data
+      return
+    }
     // session-aware providers suffix the documentName with \0sessionId
     const sepIdx = documentNameAndSessionId.indexOf('\0')
     const documentName =

--- a/packages/server/utils/tiptap/RedisServerAffinity.ts
+++ b/packages/server/utils/tiptap/RedisServerAffinity.ts
@@ -378,13 +378,7 @@ export class RedisServerAffinity<TCE extends CustomEvents> implements Extension 
   async onSocketMessage(serializedHTTPRequest: SerializedHTTPRequest, detachableMsg: ArrayBuffer) {
     const message = new Uint8Array(detachableMsg.slice())
     const tmpMsg = new IncomingMessage(detachableMsg)
-    let documentNameAndSessionId: string
-    try {
-      documentNameAndSessionId = tmpMsg.readVarString()
-    } catch {
-      // User trying to pass in invalid frame data
-      return
-    }
+    const documentNameAndSessionId = tmpMsg.readVarString()
     // session-aware providers suffix the documentName with \0sessionId
     const sepIdx = documentNameAndSessionId.indexOf('\0')
     const documentName =


### PR DESCRIPTION
# Description

readVarString requires a binary payload, now we check if it's binary.