### PR TITLE
chore: split SMTP emails into batches

### DIFF
--- a/packages/server/__tests__/MailManagerSMTP.test.ts
+++ b/packages/server/__tests__/MailManagerSMTP.test.ts
@@ -40,9 +40,7 @@ describe('MailManagerSMTP', () => {
       const result = await manager.sendEmail(makeOptions('user@example.com'))
 
       expect(mockSendMail).toHaveBeenCalledTimes(1)
-      expect(mockSendMail).toHaveBeenCalledWith(
-        expect.objectContaining({to: ['user@example.com']})
-      )
+      expect(mockSendMail).toHaveBeenCalledWith(expect.objectContaining({to: ['user@example.com']}))
       expect(result).toBe(true)
     })
 
@@ -63,10 +61,7 @@ describe('MailManagerSMTP', () => {
         1,
         expect.objectContaining({to: to.slice(0, 50)})
       )
-      expect(mockSendMail).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({to: to.slice(50)})
-      )
+      expect(mockSendMail).toHaveBeenNthCalledWith(2, expect.objectContaining({to: to.slice(50)}))
     })
 
     it('splits 100 recipients into 2 batches of 50', async () => {

--- a/packages/server/__tests__/MailManagerSMTP.test.ts
+++ b/packages/server/__tests__/MailManagerSMTP.test.ts
@@ -1,0 +1,140 @@
+import nodemailer from 'nodemailer'
+import logError from '../utils/logError'
+
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn()
+}))
+
+jest.mock('../utils/logError', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+import MailManagerSMTP from '../email/MailManagerSMTP'
+
+const mockCreateTransport = jest.mocked(nodemailer.createTransport)
+const mockLogError = jest.mocked(logError)
+
+const makeOptions = (to: string | string[]) => ({
+  to,
+  subject: 'Test Subject',
+  body: 'Test body',
+  html: '<p>Test</p>'
+})
+
+const makeRecipients = (count: number) =>
+  Array.from({length: count}, (_, i) => `user${i}@example.com`)
+
+describe('MailManagerSMTP', () => {
+  let mockSendMail: jest.Mock
+  let manager: MailManagerSMTP
+
+  beforeEach(() => {
+    mockSendMail = jest.fn().mockResolvedValue({messageId: 'test-id'})
+    mockCreateTransport.mockReturnValue({sendMail: mockSendMail, verify: jest.fn()} as any)
+    manager = new MailManagerSMTP()
+  })
+
+  describe('sendEmail', () => {
+    it('wraps single string recipient in array and sends one batch', async () => {
+      const result = await manager.sendEmail(makeOptions('user@example.com'))
+
+      expect(mockSendMail).toHaveBeenCalledTimes(1)
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({to: ['user@example.com']})
+      )
+      expect(result).toBe(true)
+    })
+
+    it('sends one batch for exactly 50 recipients', async () => {
+      const to = makeRecipients(50)
+      await manager.sendEmail(makeOptions(to))
+
+      expect(mockSendMail).toHaveBeenCalledTimes(1)
+      expect(mockSendMail).toHaveBeenCalledWith(expect.objectContaining({to}))
+    })
+
+    it('splits 51 recipients into 2 batches', async () => {
+      const to = makeRecipients(51)
+      await manager.sendEmail(makeOptions(to))
+
+      expect(mockSendMail).toHaveBeenCalledTimes(2)
+      expect(mockSendMail).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({to: to.slice(0, 50)})
+      )
+      expect(mockSendMail).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({to: to.slice(50)})
+      )
+    })
+
+    it('splits 100 recipients into 2 batches of 50', async () => {
+      const to = makeRecipients(100)
+      await manager.sendEmail(makeOptions(to))
+
+      expect(mockSendMail).toHaveBeenCalledTimes(2)
+    })
+
+    it('splits 150 recipients into 3 batches of 50', async () => {
+      const to = makeRecipients(150)
+      await manager.sendEmail(makeOptions(to))
+
+      expect(mockSendMail).toHaveBeenCalledTimes(3)
+    })
+
+    it('passes subject, body, html, and from to transport', async () => {
+      process.env.MAIL_FROM = 'noreply@example.com'
+      await manager.sendEmail(makeOptions('user@example.com'))
+
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: 'noreply@example.com',
+          subject: 'Test Subject',
+          text: 'Test body',
+          html: '<p>Test</p>'
+        })
+      )
+    })
+
+    it('passes attachments to transport', async () => {
+      const attachments = [{filename: 'file.pdf', path: '/tmp/file.pdf', cid: 'cid1'}]
+      await manager.sendEmail({...makeOptions('user@example.com'), attachments})
+
+      expect(mockSendMail).toHaveBeenCalledWith(expect.objectContaining({attachments}))
+    })
+
+    it('logs error and returns false when a batch fails with an Error', async () => {
+      const err = new Error('SMTP failure')
+      mockSendMail.mockRejectedValue(err)
+
+      const result = await manager.sendEmail(makeOptions('user@example.com'))
+
+      expect(mockLogError).toHaveBeenCalledWith(err, expect.any(Object))
+      expect(result).toBe(false)
+    })
+
+    it('wraps non-Error rejections in generic Error before logging', async () => {
+      mockSendMail.mockRejectedValue('some string error')
+
+      await manager.sendEmail(makeOptions('user@example.com'))
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        expect.objectContaining({message: 'SMTP nodemailer error'}),
+        expect.any(Object)
+      )
+    })
+
+    it('logs only failed batches when some batches succeed', async () => {
+      const to = makeRecipients(51)
+      const err = new Error('batch 2 failed')
+      mockSendMail.mockResolvedValueOnce({messageId: 'ok'}).mockRejectedValueOnce(err)
+
+      const result = await manager.sendEmail(makeOptions(to))
+
+      expect(mockLogError).toHaveBeenCalledTimes(1)
+      expect(mockLogError).toHaveBeenCalledWith(err, expect.any(Object))
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/packages/server/email/MailManagerSMTP.ts
+++ b/packages/server/email/MailManagerSMTP.ts
@@ -84,20 +84,23 @@ export default class MailManagerSMTP extends MailManager {
     //
     const toList = Array.isArray(to) ? to : [to]
 
-    const res = await Promise.allSettled(batch(toList, MAX_RECIPIENTS).map((to) =>
-      this.transport.sendMail({
-        from: process.env.MAIL_FROM,
-        to,
-        subject,
-        text: body,
-        html,
-        attachments
-      })
-    ))
+    const res = await Promise.allSettled(
+      batch(toList, MAX_RECIPIENTS).map((to) =>
+        this.transport.sendMail({
+          from: process.env.MAIL_FROM,
+          to,
+          subject,
+          text: body,
+          html,
+          attachments
+        })
+      )
+    )
 
     return res.reduce((success, value) => {
       if (value.status !== 'fulfilled') {
-        const error = value.reason instanceof Error ? value.reason : new Error('SMTP nodemailer error')
+        const error =
+          value.reason instanceof Error ? value.reason : new Error('SMTP nodemailer error')
         logError(error, {
           tags: {to: JSON.stringify(to)}
         })

--- a/packages/server/email/MailManagerSMTP.ts
+++ b/packages/server/email/MailManagerSMTP.ts
@@ -3,6 +3,10 @@ import {isNotNull} from '../../client/utils/predicates'
 import logError from '../utils/logError'
 import MailManager, {type MailManagerOptions} from './MailManager'
 
+// Amazon SES has a 50 recipients limit, but it's safe to apply everywhere SMTP
+// https://docs.aws.amazon.com/ses/latest/dg/quotas.html
+const MAX_RECIPIENTS = 50
+
 const composeConfig = () => {
   const {
     MAIL_SMTP_URL,
@@ -66,13 +70,22 @@ if (process.env.MAIL_SMTP_DEBUG === 'true') {
   verifyTransport()
 }
 
+const batch = <T extends Array<any>>(arr: T, batchSize: number) => {
+  const batches = Math.ceil(arr.length / batchSize)
+  return [...new Array(batches)].map((_, i) => arr.slice(i * batchSize, i * batchSize + batchSize))
+}
+
 export default class MailManagerSMTP extends MailManager {
   transport = nodemailer.createTransport(composeConfig())
 
   async sendEmail(options: MailManagerOptions) {
     const {subject, body, to, attachments, html} = options
-    try {
-      await this.transport.sendMail({
+    // process in batches
+    //
+    const toList = Array.isArray(to) ? to : [to]
+
+    const res = await Promise.allSettled(batch(toList, MAX_RECIPIENTS).map((to) =>
+      this.transport.sendMail({
         from: process.env.MAIL_FROM,
         to,
         subject,
@@ -80,13 +93,17 @@ export default class MailManagerSMTP extends MailManager {
         html,
         attachments
       })
-    } catch (e) {
-      const error = e instanceof Error ? e : new Error('SMTP nodemailer error')
-      logError(error, {
-        tags: {to: JSON.stringify(to)}
-      })
-      return false
-    }
-    return true
+    ))
+
+    return res.reduce((success, value) => {
+      if (value.status !== 'fulfilled') {
+        const error = value.reason instanceof Error ? value.reason : new Error('SMTP nodemailer error')
+        logError(error, {
+          tags: {to: JSON.stringify(to)}
+        })
+        return false
+      }
+      return success
+    }, true)
   }
 }

--- a/packages/server/email/MailManagerSMTP.ts
+++ b/packages/server/email/MailManagerSMTP.ts
@@ -70,7 +70,7 @@ if (process.env.MAIL_SMTP_DEBUG === 'true') {
   verifyTransport()
 }
 
-const batch = <T extends Array<any>>(arr: T, batchSize: number) => {
+const batch = <T>(arr: T[], batchSize: number): T[][] => {
   const batches = Math.ceil(arr.length / batchSize)
   return [...new Array(batches)].map((_, i) => arr.slice(i * batchSize, i * batchSize + batchSize))
 }
@@ -80,15 +80,15 @@ export default class MailManagerSMTP extends MailManager {
 
   async sendEmail(options: MailManagerOptions) {
     const {subject, body, to, attachments, html} = options
-    // process in batches
-    //
     const toList = Array.isArray(to) ? to : [to]
+    if (toList.length === 0) return true
 
+    const batches = batch(toList, MAX_RECIPIENTS)
     const res = await Promise.allSettled(
-      batch(toList, MAX_RECIPIENTS).map((to) =>
+      batches.map((batchTo) =>
         this.transport.sendMail({
           from: process.env.MAIL_FROM,
-          to,
+          to: batchTo,
           subject,
           text: body,
           html,
@@ -97,12 +97,12 @@ export default class MailManagerSMTP extends MailManager {
       )
     )
 
-    return res.reduce((success, value) => {
+    return res.reduce((success, value, i) => {
       if (value.status !== 'fulfilled') {
         const error =
           value.reason instanceof Error ? value.reason : new Error('SMTP nodemailer error')
         logError(error, {
-          tags: {to: JSON.stringify(to)}
+          tags: {to: JSON.stringify(batches[i])}
         })
         return false
       }

--- a/packages/server/email/sendSummaryEmail.tsx
+++ b/packages/server/email/sendSummaryEmail.tsx
@@ -7,7 +7,7 @@ import getKysely from '../postgres/getKysely'
 import getMailManager from './getMailManager'
 import {makeSummaryEmailV2} from './makeSummaryEmailV2'
 
-export const sendSummaryEmailV2 = async (
+export const sendSummaryEmail = async (
   meetingId: string,
   pageId: number,
   context: InternalContext,

--- a/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
@@ -5,7 +5,7 @@ import {DISCUSS} from 'parabol-client/utils/constants'
 import getMeetingPhase from 'parabol-client/utils/getMeetingPhase'
 import findStageById from 'parabol-client/utils/meetings/findStageById'
 import TimelineEventRetroComplete from '../../../database/types/TimelineEventRetroComplete'
-import {sendSummaryEmailV2} from '../../../email/sendSummaryEmailV2'
+import {sendSummaryEmail} from '../../../email/sendSummaryEmail'
 import getKysely from '../../../postgres/getKysely'
 import type {RetrospectiveMeeting} from '../../../postgres/types/Meeting'
 import archiveDoneTasksForMeeting from '../../../safeMutations/archiveDoneTasksForMeeting'
@@ -163,7 +163,7 @@ const safeEndRetrospective = async ({
   // don't await these, but put them after both "publish" calls so the dataloader has the same data
   summarizeRetroMeeting(completedRetrospective, context).catch(Logger.log)
   // do not await sending the email
-  if (page) sendSummaryEmailV2(meetingId, page.id, context, info).catch(Logger.log)
+  if (page) sendSummaryEmail(meetingId, page.id, context, info).catch(Logger.log)
   analytics
     .retrospectiveEnd(completedRetrospective, meetingMembers, template, dataLoader)
     .catch(Logger.log)

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -2,7 +2,7 @@ import type {GraphQLResolveInfo} from 'graphql'
 import {sql} from 'kysely'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import TimelineEventTeamPromptComplete from '../../../database/types/TimelineEventTeamPromptComplete'
-import {sendSummaryEmailV2} from '../../../email/sendSummaryEmailV2'
+import {sendSummaryEmail} from '../../../email/sendSummaryEmail'
 import getKysely from '../../../postgres/getKysely'
 import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
 import type {TeamPromptMeeting} from '../../../postgres/types/Meeting'
@@ -116,7 +116,7 @@ const safeEndTeamPrompt = async ({
   )
   publish(SubscriptionChannel.TEAM, teamId, 'EndTeamPromptSuccess', data, subOptions)
   // do not await sending the email
-  if (page) sendSummaryEmailV2(meetingId, page.id, context, info).catch(Logger.log)
+  if (page) sendSummaryEmail(meetingId, page.id, context, info).catch(Logger.log)
   return data
 }
 

--- a/packages/server/graphql/public/mutations/endCheckIn.ts
+++ b/packages/server/graphql/public/mutations/endCheckIn.ts
@@ -7,7 +7,7 @@ import {positionAfter} from '../../../../client/shared/sortOrder'
 // TODO: TimelineEventCheckinComplete is from the deprecated /database directory
 import TimelineEventCheckinComplete from '../../../database/types/TimelineEventCheckinComplete'
 import type {DataLoaderInstance} from '../../../dataloader/RootDataLoader'
-import {sendSummaryEmailV2} from '../../../email/sendSummaryEmailV2'
+import {sendSummaryEmail} from '../../../email/sendSummaryEmail'
 import generateUID from '../../../generateUID'
 import getKysely from '../../../postgres/getKysely'
 import {selectTasks} from '../../../postgres/select'
@@ -225,7 +225,7 @@ const endCheckIn: MutationResolvers['endCheckIn'] = async (_source, {meetingId},
     removedTaskIds
   }
   publish(SubscriptionChannel.TEAM, teamId, 'EndCheckInSuccess', data, subOptions)
-  sendSummaryEmailV2(meetingId, page.id, context, info).catch(Logger.log)
+  sendSummaryEmail(meetingId, page.id, context, info).catch(Logger.log)
   IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId).catch(Logger.log)
   analytics.checkInEnd(completedCheckIn, meetingMembers, dataLoader).catch(Logger.log)
   return data

--- a/packages/server/graphql/public/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/public/mutations/endSprintPoker.ts
@@ -4,7 +4,7 @@ import getMeetingPhase from 'parabol-client/utils/getMeetingPhase'
 import findStageById from 'parabol-client/utils/meetings/findStageById'
 // TODO: TimelineEventPokerComplete is from the deprecated /database directory
 import TimelineEventPokerComplete from '../../../database/types/TimelineEventPokerComplete'
-import {sendSummaryEmailV2} from '../../../email/sendSummaryEmailV2'
+import {sendSummaryEmail} from '../../../email/sendSummaryEmail'
 import getKysely from '../../../postgres/getKysely'
 import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId} from '../../../utils/authorization'
@@ -108,7 +108,7 @@ const endSprintPoker: MutationResolvers['endSprintPoker'] = async (
   completedMeeting.summaryPageId = page.id
   const data = {meetingId, teamId, isKill, removedTaskIds}
   publish(SubscriptionChannel.TEAM, teamId, 'EndSprintPokerSuccess', data, subOptions)
-  sendSummaryEmailV2(meetingId, page.id, context, info).catch(Logger.log)
+  sendSummaryEmail(meetingId, page.id, context, info).catch(Logger.log)
   IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId).catch(Logger.log)
   analytics.sprintPokerEnd(completedMeeting, meetingMembers, template, dataLoader).catch(Logger.log)
   return data


### PR DESCRIPTION

# Description

Fixes #13282 
Amazon SES has a recipient limit of 50. It's a corner case and is safe to apply to all SMTP providers, thus not introducing an additional configuration.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
