### PR TITLE
feat: darkMode pre-login LightIsland, fix ups

### DIFF
--- a/devTemplate.html
+++ b/devTemplate.html
@@ -9,14 +9,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#493272" />
     <!-- Dark mode boot: apply .theme-dark before first paint. 'theme' mirrors LocalStorageKey.THEME.
-         Dark mode is feature-flagged, so an absent/unrecognized value must resolve to light:
-         only an explicit 'dark', or an explicit 'system' on a dark OS, opts in. -->
+         Absent or 'system' follows the OS, matching DEFAULT_THEME_PREFERENCE in themePreference.ts. -->
     <script>
       try {
         var themePref = localStorage.getItem('theme')
         if (
           themePref === 'dark' ||
-          (themePref === 'system' && matchMedia('(prefers-color-scheme: dark)').matches)
+          (themePref !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches)
         ) {
           document.documentElement.className += ' theme-dark'
           var themeMeta = document.querySelector('meta[name="theme-color"]')

--- a/devTemplate.html
+++ b/devTemplate.html
@@ -8,13 +8,15 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#493272" />
-    <!-- Dark mode boot: apply .theme-dark before first paint. 'theme' mirrors LocalStorageKey.THEME -->
+    <!-- Dark mode boot: apply .theme-dark before first paint. 'theme' mirrors LocalStorageKey.THEME.
+         Dark mode is feature-flagged, so an absent/unrecognized value must resolve to light:
+         only an explicit 'dark', or an explicit 'system' on a dark OS, opts in. -->
     <script>
       try {
         var themePref = localStorage.getItem('theme')
         if (
           themePref === 'dark' ||
-          (themePref !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches)
+          (themePref === 'system' && matchMedia('(prefers-color-scheme: dark)').matches)
         ) {
           document.documentElement.className += ' theme-dark'
           var themeMeta = document.querySelector('meta[name="theme-color"]')

--- a/packages/client/components/Action/Action.tsx
+++ b/packages/client/components/Action/Action.tsx
@@ -66,10 +66,6 @@ const Action = memo(() => {
             )}
           >
             <Routes>
-              {/* Pre-login routes are pinned light — their chrome is raw palette and
-                  never flips with the theme. The demo and public /pages routes below are
-                  deliberately excluded: they're real product surfaces that were migrated
-                  to dark mode, so they follow the viewer's theme. */}
               <Route
                 path='/'
                 element={

--- a/packages/client/components/Action/Action.tsx
+++ b/packages/client/components/Action/Action.tsx
@@ -8,6 +8,7 @@ import {CREATE_ACCOUNT_SLUG, SIGNIN_SLUG} from '../../utils/constants'
 import ErrorBoundary from '../ErrorBoundary'
 import Banner from '../GlobalBanner'
 import {useIsAuthenticated} from '../IsAuthenticatedProvider'
+import LightIsland from '../LightIsland'
 import LoadingComponent from '../LoadingComponent/LoadingComponent'
 import PrivateRoutes from '../PrivateRoutes'
 import Snackbar from '../Snackbar'
@@ -65,38 +66,121 @@ const Action = memo(() => {
             )}
           >
             <Routes>
-              <Route path='/' element={<AuthenticationPage page={'signin'} />} />
-              <Route path={`/${SIGNIN_SLUG}`} element={<AuthenticationPage page={'signin'} />} />
+              {/* Pre-login routes are pinned light — their chrome is raw palette and
+                  never flips with the theme. The demo and public /pages routes below are
+                  deliberately excluded: they're real product surfaces that were migrated
+                  to dark mode, so they follow the viewer's theme. */}
+              <Route
+                path='/'
+                element={
+                  <LightIsland>
+                    <AuthenticationPage page={'signin'} />
+                  </LightIsland>
+                }
+              />
+              <Route
+                path={`/${SIGNIN_SLUG}`}
+                element={
+                  <LightIsland>
+                    <AuthenticationPage page={'signin'} />
+                  </LightIsland>
+                }
+              />
               <Route
                 path={`/${CREATE_ACCOUNT_SLUG}`}
-                element={<AuthenticationPage page={'create-account'} />}
+                element={
+                  <LightIsland>
+                    <AuthenticationPage page={'create-account'} />
+                  </LightIsland>
+                }
               />
-              <Route path='/auth/:provider' element={<AuthProvider />} />
-              <Route path='/saml-redirect' element={<SAMLRedirect />} />
+              <Route
+                path='/auth/:provider'
+                element={
+                  <LightIsland>
+                    <AuthProvider />
+                  </LightIsland>
+                }
+              />
+              <Route
+                path='/saml-redirect'
+                element={
+                  <LightIsland>
+                    <SAMLRedirect />
+                  </LightIsland>
+                }
+              />
               <Route path='/retrospective-demo/*' element={<DemoMeeting />} />
               <Route path='/retrospective-demo-summary/:urlAction' element={<DemoSummary />} />
               <Route path='/retrospective-demo-summary' element={<DemoSummary />} />
               {isInternalAuthEnabled && (
                 <Route
                   path='/forgot-password'
-                  element={<AuthenticationPage page={'forgot-password'} />}
+                  element={
+                    <LightIsland>
+                      <AuthenticationPage page={'forgot-password'} />
+                    </LightIsland>
+                  }
                 />
               )}
               {isInternalAuthEnabled && (
                 <Route
                   path='/forgot-password/submitted'
-                  element={<AuthenticationPage page={'forgot-password/submitted'} />}
+                  element={
+                    <LightIsland>
+                      <AuthenticationPage page={'forgot-password/submitted'} />
+                    </LightIsland>
+                  }
                 />
               )}
               <Route
                 path='/verify-email/:verificationToken/:invitationToken'
-                element={<VerifyEmail />}
+                element={
+                  <LightIsland>
+                    <VerifyEmail />
+                  </LightIsland>
+                }
               />
-              <Route path='/verify-email/:verificationToken' element={<VerifyEmail />} />
-              <Route path='/reset-password/:token' element={<SetNewPassword />} />
-              <Route path='/oauth/authorize' element={<OAuthAuthorizePage />} />
-              <Route path='/team-invitation/:token' element={<TeamInvitation />} />
-              <Route path='/invitation-link/:token' element={<InvitationLink />} />
+              <Route
+                path='/verify-email/:verificationToken'
+                element={
+                  <LightIsland>
+                    <VerifyEmail />
+                  </LightIsland>
+                }
+              />
+              <Route
+                path='/reset-password/:token'
+                element={
+                  <LightIsland>
+                    <SetNewPassword />
+                  </LightIsland>
+                }
+              />
+              <Route
+                path='/oauth/authorize'
+                element={
+                  <LightIsland>
+                    <OAuthAuthorizePage />
+                  </LightIsland>
+                }
+              />
+              <Route
+                path='/team-invitation/:token'
+                element={
+                  <LightIsland>
+                    <TeamInvitation />
+                  </LightIsland>
+                }
+              />
+              <Route
+                path='/invitation-link/:token'
+                element={
+                  <LightIsland>
+                    <InvitationLink />
+                  </LightIsland>
+                }
+              />
               {!isAuthenticated && (
                 <Route path='/pages/:pageSlug' element={<PageRoot viewerRef={null} isPublic />} />
               )}

--- a/packages/client/components/DashNavList/LeftNavPageLink.tsx
+++ b/packages/client/components/DashNavList/LeftNavPageLink.tsx
@@ -172,7 +172,8 @@ export const LeftNavPageLink = (props: Props) => {
           draggable={false}
           to={`/pages/${slug}`}
           key={slug}
-          className={'ml-1 flex w-full items-center'}
+          // inherit so the base `a:hover` rule can't repaint the label — see LeftDashNavItem
+          className={'ml-1 flex w-full items-center text-inherit hover:text-inherit'}
           onClick={(e) => {
             if (draggingPageId) {
               e.preventDefault()

--- a/packages/client/components/DashNavList/LeftNavPageLink.tsx
+++ b/packages/client/components/DashNavList/LeftNavPageLink.tsx
@@ -172,7 +172,6 @@ export const LeftNavPageLink = (props: Props) => {
           draggable={false}
           to={`/pages/${slug}`}
           key={slug}
-          // inherit so the base `a:hover` rule can't repaint the label — see LeftDashNavItem
           className={'ml-1 flex w-full items-center text-inherit hover:text-inherit'}
           onClick={(e) => {
             if (draggingPageId) {

--- a/packages/client/components/DashNavList/LeftNavTeamLink.tsx
+++ b/packages/client/components/DashNavList/LeftNavTeamLink.tsx
@@ -101,7 +101,6 @@ export const LeftNavTeamLink = (props: Props) => {
         <Link
           draggable={false}
           to={`/team/${teamId}`}
-          // inherit so the base `a:hover` rule can't repaint the label — see LeftDashNavItem
           className={'flex w-full items-center text-inherit hover:text-inherit'}
           onClick={(e) => {
             if (draggingPageId) {

--- a/packages/client/components/DashNavList/LeftNavTeamLink.tsx
+++ b/packages/client/components/DashNavList/LeftNavTeamLink.tsx
@@ -101,7 +101,8 @@ export const LeftNavTeamLink = (props: Props) => {
         <Link
           draggable={false}
           to={`/team/${teamId}`}
-          className={'flex w-full items-center'}
+          // inherit so the base `a:hover` rule can't repaint the label — see LeftDashNavItem
+          className={'flex w-full items-center text-inherit hover:text-inherit'}
           onClick={(e) => {
             if (draggingPageId) {
               e.preventDefault()

--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -130,7 +130,6 @@ const Dashboard = (props: Props) => {
           ...Page_viewer
           overLimitCopy
           theme
-          hasDarkMode: featureFlag(featureName: "darkMode")
           teams {
             activeMeetings {
               ...useSnacksForNewMeetings_meetings
@@ -154,7 +153,7 @@ const Dashboard = (props: Props) => {
 
   return (
     <SearchProvider>
-      <ThemeSync theme={viewer.theme} enabled={viewer.hasDarkMode} />
+      <ThemeSync theme={viewer.theme} />
       <GlobalSearchDialog />
       <DashLayout>
         <SkipLink href='#main'>Skip to content</SkipLink>

--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -130,6 +130,7 @@ const Dashboard = (props: Props) => {
           ...Page_viewer
           overLimitCopy
           theme
+          hasDarkMode: featureFlag(featureName: "darkMode")
           teams {
             activeMeetings {
               ...useSnacksForNewMeetings_meetings
@@ -153,7 +154,7 @@ const Dashboard = (props: Props) => {
 
   return (
     <SearchProvider>
-      <ThemeSync theme={viewer.theme} />
+      <ThemeSync theme={viewer.theme} enabled={viewer.hasDarkMode} />
       <GlobalSearchDialog />
       <DashLayout>
         <SkipLink href='#main'>Skip to content</SkipLink>

--- a/packages/client/components/Dashboard/LeftDashNavItem.tsx
+++ b/packages/client/components/Dashboard/LeftDashNavItem.tsx
@@ -30,7 +30,10 @@ const LeftDashNavItem = forwardRef((props: Props, ref: Ref<HTMLDivElement>) => {
         <LinkWrapper
           draggable={false}
           to={href}
-          className={'flex w-full items-center'}
+          // inherit: the row owns the text color across states. Without this the base
+          // `a:hover` rule repaints the label with accent-active when the cursor is over
+          // the link itself, so the row and its label disagree mid-hover.
+          className={'flex w-full items-center text-inherit hover:text-inherit'}
           onClick={onClick}
         >
           <div

--- a/packages/client/components/Dashboard/LeftDashNavItem.tsx
+++ b/packages/client/components/Dashboard/LeftDashNavItem.tsx
@@ -30,9 +30,6 @@ const LeftDashNavItem = forwardRef((props: Props, ref: Ref<HTMLDivElement>) => {
         <LinkWrapper
           draggable={false}
           to={href}
-          // inherit: the row owns the text color across states. Without this the base
-          // `a:hover` rule repaints the label with accent-active when the cursor is over
-          // the link itself, so the row and its label disagree mid-hover.
           className={'flex w-full items-center text-inherit hover:text-inherit'}
           onClick={onClick}
         >

--- a/packages/client/components/DialogContainer.ts
+++ b/packages/client/components/DialogContainer.ts
@@ -4,7 +4,8 @@ import {Radius} from '../types/constEnums'
 
 const DialogContainer = styled('div')({
   display: 'flex',
-  backgroundColor: 'white',
+  // themed: matches ui/Dialog/DialogContent's bg-surface-card
+  backgroundColor: 'var(--color-surface-card)',
   borderRadius: Radius.DIALOG,
   boxShadow: modalShadow,
   flexDirection: 'column',

--- a/packages/client/components/DialogContainer.ts
+++ b/packages/client/components/DialogContainer.ts
@@ -9,7 +9,6 @@ const DialogContainer = styled('div')({
   borderRadius: Radius.DIALOG,
   boxShadow: modalShadow,
   flexDirection: 'column',
-  // overflow: 'auto', removed because @hello-pangea/dnd only supports 1 scrolling parent
   margin: '0 auto',
   maxHeight: '90vh',
   maxWidth: 'calc(100vw - 48px)',

--- a/packages/client/components/EmailInputField.tsx
+++ b/packages/client/components/EmailInputField.tsx
@@ -15,10 +15,6 @@ const EmailInputField = (props: Props) => {
   const {autoFocus, dirty, error, onChange, onBlur, value} = props
   return (
     <React.Fragment>
-      {/* classes, not styled(TinyLabel): an Emotion override can't beat TinyLabel's own
-          Tailwind text size, but tailwind-merge resolves this against its text-[11px].
-          Arbitrary 12px rather than text-xs, which would also impose a 16px leading the
-          original styled(TinyLabel) never set. */}
       <TinyLabel className='font-semibold text-[12px]'>Email</TinyLabel>
       <UnderlineInput
         ariaLabel={'Email'}

--- a/packages/client/components/EmailInputField.tsx
+++ b/packages/client/components/EmailInputField.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import * as React from 'react'
 import UnderlineInput from './InputField/UnderlineInput'
 import TinyLabel from './TinyLabel'
@@ -12,16 +11,15 @@ interface Props {
   onBlur: (e: React.FocusEvent<HTMLInputElement>) => void
 }
 
-const Label = styled(TinyLabel)({
-  fontSize: 12,
-  fontWeight: 600
-})
-
 const EmailInputField = (props: Props) => {
   const {autoFocus, dirty, error, onChange, onBlur, value} = props
   return (
     <React.Fragment>
-      <Label>Email</Label>
+      {/* classes, not styled(TinyLabel): an Emotion override can't beat TinyLabel's own
+          Tailwind text size, but tailwind-merge resolves this against its text-[11px].
+          Arbitrary 12px rather than text-xs, which would also impose a 16px leading the
+          original styled(TinyLabel) never set. */}
+      <TinyLabel className='font-semibold text-[12px]'>Email</TinyLabel>
       <UnderlineInput
         ariaLabel={'Email'}
         autoFocus={autoFocus}

--- a/packages/client/components/FieldLabel/FieldLabel.tsx
+++ b/packages/client/components/FieldLabel/FieldLabel.tsx
@@ -1,10 +1,6 @@
 import styled from '@emotion/styled'
 import ui from '../../styles/ui'
 
-// Styles the <label> directly rather than composing styled(LabelHeading).withComponent().
-// withComponent swaps the base element, so once LabelHeading moved to Tailwind its classes
-// were dropped on the floor and this label lost its color/size/weight/tracking entirely.
-// These base values mirror LabelHeading, minus the uppercase this has always overridden.
 const FieldLabelStyles = styled('label')<
   Pick<Props, 'customStyles' | 'fieldSize' | 'indent' | 'inline'>
 >(({customStyles, fieldSize, indent, inline}) => {

--- a/packages/client/components/FieldLabel/FieldLabel.tsx
+++ b/packages/client/components/FieldLabel/FieldLabel.tsx
@@ -1,8 +1,11 @@
 import styled from '@emotion/styled'
 import ui from '../../styles/ui'
-import LabelHeading from '../LabelHeading/LabelHeading'
 
-const FieldLabelStyles = styled(LabelHeading)<
+// Styles the <label> directly rather than composing styled(LabelHeading).withComponent().
+// withComponent swaps the base element, so once LabelHeading moved to Tailwind its classes
+// were dropped on the floor and this label lost its color/size/weight/tracking entirely.
+// These base values mirror LabelHeading, minus the uppercase this has always overridden.
+const FieldLabelStyles = styled('label')<
   Pick<Props, 'customStyles' | 'fieldSize' | 'indent' | 'inline'>
 >(({customStyles, fieldSize, indent, inline}) => {
   const size = (fieldSize || ui.buttonSizeOptions[1]) as 'small' | 'medium' | 'large'
@@ -15,6 +18,12 @@ const FieldLabelStyles = styled(LabelHeading)<
   }
   const useInlineStyles = fieldSize && inline && inlineStyles
   return {
+    color: 'var(--color-fg-secondary)',
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: '.03em',
+    lineHeight: '16px',
+    userSelect: 'none',
     display: 'block',
     padding: 0,
     textTransform: 'none',
@@ -27,7 +36,7 @@ const FieldLabelStyles = styled(LabelHeading)<
   }
 })
 
-const FieldLabelBlock = FieldLabelStyles.withComponent('label')
+const FieldLabelBlock = FieldLabelStyles
 
 interface Props {
   customStyles?: object

--- a/packages/client/components/HorizontalSeparator/HorizontalSeparator.tsx
+++ b/packages/client/components/HorizontalSeparator/HorizontalSeparator.tsx
@@ -8,8 +8,6 @@ import styled from '@emotion/styled'
 import {Fragment} from 'react'
 import LabelHeading from '../LabelHeading/LabelHeading'
 
-// font size lives in the className below, not here: an Emotion fontSize can't beat
-// LabelHeading's own `text-xs`, but tailwind-merge resolves `text-[11px]` against it
 const SeparatorContainer = styled(LabelHeading)<{
   margin: string | number | undefined
 }>(({margin}) => ({
@@ -46,8 +44,6 @@ interface Props {
   text?: string
 }
 
-// leading-4 is restated alongside text-[11px] because tailwind-merge treats font-size as
-// conflicting with leading (a `text-*` may carry its own), so it drops LabelHeading's
 export default ({margin, text}: Props) => (
   <SeparatorContainer className='text-[11px] leading-4' margin={margin}>
     {text ? (

--- a/packages/client/components/HorizontalSeparator/HorizontalSeparator.tsx
+++ b/packages/client/components/HorizontalSeparator/HorizontalSeparator.tsx
@@ -8,11 +8,12 @@ import styled from '@emotion/styled'
 import {Fragment} from 'react'
 import LabelHeading from '../LabelHeading/LabelHeading'
 
+// font size lives in the className below, not here: an Emotion fontSize can't beat
+// LabelHeading's own `text-xs`, but tailwind-merge resolves `text-[11px]` against it
 const SeparatorContainer = styled(LabelHeading)<{
   margin: string | number | undefined
 }>(({margin}) => ({
   display: 'flex',
-  fontSize: 11,
   margin,
   maxWidth: '100%',
   padding: '16px 0',
@@ -45,8 +46,10 @@ interface Props {
   text?: string
 }
 
+// leading-4 is restated alongside text-[11px] because tailwind-merge treats font-size as
+// conflicting with leading (a `text-*` may carry its own), so it drops LabelHeading's
 export default ({margin, text}: Props) => (
-  <SeparatorContainer margin={margin}>
+  <SeparatorContainer className='text-[11px] leading-4' margin={margin}>
     {text ? (
       <Fragment>
         <LeftSeparator />

--- a/packages/client/components/InputField/UnderlineInput.tsx
+++ b/packages/client/components/InputField/UnderlineInput.tsx
@@ -20,8 +20,6 @@ const Input = styled('input')({
   padding: '.3125rem 1rem .3125rem 0',
   width: '100%',
   ':hover,:focus,:active': {
-    // light resolves to #493272, identical to the GRAPE_700 this replaced; dark gets a
-    // lilac that stays visible against the card instead of purple-on-purple
     borderColor: 'var(--color-accent-active)'
   }
 })

--- a/packages/client/components/InputField/UnderlineInput.tsx
+++ b/packages/client/components/InputField/UnderlineInput.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import * as React from 'react'
 import {forwardRef, type Ref} from 'react'
-import {PALETTE} from '../../styles/paletteV3'
 import {FONT_FAMILY} from '../../styles/typographyV2'
 import StyledError from '../StyledError'
 
@@ -21,7 +20,9 @@ const Input = styled('input')({
   padding: '.3125rem 1rem .3125rem 0',
   width: '100%',
   ':hover,:focus,:active': {
-    borderColor: PALETTE.GRAPE_700
+    // light resolves to #493272, identical to the GRAPE_700 this replaced; dark gets a
+    // lilac that stays visible against the card instead of purple-on-purple
+    borderColor: 'var(--color-accent-active)'
   }
 })
 

--- a/packages/client/components/InviteDialog.tsx
+++ b/packages/client/components/InviteDialog.tsx
@@ -3,7 +3,9 @@ import {modalShadow} from '../styles/elevation'
 import {Radius} from '../types/constEnums'
 
 const InviteDialog = styled('div')({
-  background: 'white',
+  // themed: descendants (DialogTitle, TinyLabel, UnderlineInput) resolve their color from
+  // semantic tokens, so a hard-coded white here left them near-white on white in dark mode
+  background: 'var(--color-surface-card)',
   borderRadius: Radius.DIALOG,
   boxShadow: modalShadow,
   display: 'flex',

--- a/packages/client/components/InviteDialog.tsx
+++ b/packages/client/components/InviteDialog.tsx
@@ -3,8 +3,6 @@ import {modalShadow} from '../styles/elevation'
 import {Radius} from '../types/constEnums'
 
 const InviteDialog = styled('div')({
-  // themed: descendants (DialogTitle, TinyLabel, UnderlineInput) resolve their color from
-  // semantic tokens, so a hard-coded white here left them near-white on white in dark mode
   background: 'var(--color-surface-card)',
   borderRadius: Radius.DIALOG,
   boxShadow: modalShadow,

--- a/packages/client/components/LightIsland.tsx
+++ b/packages/client/components/LightIsland.tsx
@@ -1,0 +1,26 @@
+import type {ReactNode} from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+/**
+ * Pins a subtree to the light theme.
+ *
+ * Pre-login surfaces (auth, invitations, verify/reset password) render inside
+ * chrome that is deliberately raw palette — TeamInvitationWrapper's
+ * `bg-slate-200 text-slate-700`, AuthPage/Header's GRAPE_700 — so it never
+ * flips with the theme. Token-based descendants like InviteDialog *do* flip,
+ * which left dark cards floating on a light page. Pinning the whole subtree
+ * light keeps both halves in agreement.
+ *
+ * `contents` generates no box, so this can wrap a route element without
+ * disturbing the surrounding flex layout; custom properties and `color`
+ * still inherit through it.
+ */
+const LightIsland = (props: Props) => {
+  const {children} = props
+  return <div className='light-island contents'>{children}</div>
+}
+
+export default LightIsland

--- a/packages/client/components/PasswordInputField.tsx
+++ b/packages/client/components/PasswordInputField.tsx
@@ -15,7 +15,6 @@ const PasswordInputField = (props: Props) => {
   const {autoFocus, dirty, error, onChange, onBlur, value} = props
   return (
     <React.Fragment>
-      {/* classes, not styled(TinyLabel) — see EmailInputField */}
       <TinyLabel className='font-semibold text-[12px]'>Password</TinyLabel>
       <UnderlineInput
         ariaLabel={'Password'}

--- a/packages/client/components/PasswordInputField.tsx
+++ b/packages/client/components/PasswordInputField.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import * as React from 'react'
 import UnderlineInput from './InputField/UnderlineInput'
 import TinyLabel from './TinyLabel'
@@ -12,16 +11,12 @@ interface Props {
   onBlur: (e: React.FocusEvent<HTMLInputElement>) => void
 }
 
-const Label = styled(TinyLabel)({
-  fontSize: 12,
-  fontWeight: 600
-})
-
 const PasswordInputField = (props: Props) => {
   const {autoFocus, dirty, error, onChange, onBlur, value} = props
   return (
     <React.Fragment>
-      <Label>Password</Label>
+      {/* classes, not styled(TinyLabel) — see EmailInputField */}
+      <TinyLabel className='font-semibold text-[12px]'>Password</TinyLabel>
       <UnderlineInput
         ariaLabel={'Password'}
         autoComplete='current-password'

--- a/packages/client/components/SuggestedActionBackground.tsx
+++ b/packages/client/components/SuggestedActionBackground.tsx
@@ -33,10 +33,6 @@ const ColorBackground = styled(FullBackground)<{backgroundColor: string}>(({back
 }))
 
 const BackgroundClip = styled('div')({
-  // Deliberately theme-invariant. Both layers above are translucent (0.5 / 0.35), so they
-  // composite against whatever is behind them — the card's surface token. On the dark card
-  // that muddied the illustration, so pin the backdrop to white and keep the artwork at its
-  // intended contrast in both themes.
   backgroundColor: PALETTE.WHITE,
   height: BACKGROUND_HEIGHT,
   overflow: 'hidden',

--- a/packages/client/components/SuggestedActionBackground.tsx
+++ b/packages/client/components/SuggestedActionBackground.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import {PALETTE} from '../styles/paletteV3'
 import patternTile from '../styles/theme/images/icon-pattern-tile.svg'
 import {DashTimeline} from '../types/constEnums'
 import getRotatedBBox from '../utils/getRotatedBBox'
@@ -32,6 +33,11 @@ const ColorBackground = styled(FullBackground)<{backgroundColor: string}>(({back
 }))
 
 const BackgroundClip = styled('div')({
+  // Deliberately theme-invariant. Both layers above are translucent (0.5 / 0.35), so they
+  // composite against whatever is behind them — the card's surface token. On the dark card
+  // that muddied the illustration, so pin the backdrop to white and keep the artwork at its
+  // intended contrast in both themes.
+  backgroundColor: PALETTE.WHITE,
   height: BACKGROUND_HEIGHT,
   overflow: 'hidden',
   position: 'relative',

--- a/packages/client/components/ThemeSync.tsx
+++ b/packages/client/components/ThemeSync.tsx
@@ -5,6 +5,8 @@ import {useThemePreference} from './ThemeProvider'
 interface Props {
   // Relay-generated enums include '%future added value', so accept string and guard
   theme: string
+  // viewer's `darkMode` feature flag
+  enabled: boolean
 }
 
 /**
@@ -13,18 +15,28 @@ interface Props {
  * to local preference changes: while an updateUserTheme mutation is in flight
  * the local value is newer than the server's, and "server wins" during that
  * window would revert to the stale value and flicker the old theme.
+ *
+ * Gated on the `darkMode` flag: User.theme defaults to 'system' in the database,
+ * so without this an unflagged viewer on a dark OS would have that default synced
+ * down and land in the unreleased theme with no Appearance panel to escape it.
  */
 const ThemeSync = (props: Props) => {
-  const {theme} = props
+  const {theme, enabled} = props
   const {preference, setPreference} = useThemePreference()
   const preferenceRef = useRef(preference)
   preferenceRef.current = preference
 
   useEffect(() => {
+    if (!enabled) {
+      // the flag is authoritative: a viewer who picked dark and then lost the flag would
+      // otherwise stay dark forever, since the Appearance panel is gone with it
+      if (preferenceRef.current !== 'light') setPreference('light')
+      return
+    }
     if (isThemePreference(theme) && theme !== preferenceRef.current) {
       setPreference(theme)
     }
-  }, [theme, setPreference])
+  }, [theme, enabled, setPreference])
 
   return null
 }

--- a/packages/client/components/ThemeSync.tsx
+++ b/packages/client/components/ThemeSync.tsx
@@ -5,8 +5,6 @@ import {useThemePreference} from './ThemeProvider'
 interface Props {
   // Relay-generated enums include '%future added value', so accept string and guard
   theme: string
-  // viewer's `darkMode` feature flag
-  enabled: boolean
 }
 
 /**
@@ -15,28 +13,18 @@ interface Props {
  * to local preference changes: while an updateUserTheme mutation is in flight
  * the local value is newer than the server's, and "server wins" during that
  * window would revert to the stale value and flicker the old theme.
- *
- * Gated on the `darkMode` flag: User.theme defaults to 'system' in the database,
- * so without this an unflagged viewer on a dark OS would have that default synced
- * down and land in the unreleased theme with no Appearance panel to escape it.
  */
 const ThemeSync = (props: Props) => {
-  const {theme, enabled} = props
+  const {theme} = props
   const {preference, setPreference} = useThemePreference()
   const preferenceRef = useRef(preference)
   preferenceRef.current = preference
 
   useEffect(() => {
-    if (!enabled) {
-      // the flag is authoritative: a viewer who picked dark and then lost the flag would
-      // otherwise stay dark forever, since the Appearance panel is gone with it
-      if (preferenceRef.current !== 'light') setPreference('light')
-      return
-    }
     if (isThemePreference(theme) && theme !== preferenceRef.current) {
       setPreference(theme)
     }
-  }, [theme, enabled, setPreference])
+  }, [theme, setPreference])
 
   return null
 }

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlanDrawer.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlanDrawer.tsx
@@ -109,8 +109,6 @@ const OrgPlanDrawer = (props: Props) => {
       >
         <Drawer isDesktop={isDesktop} isOpen={showDrawer}>
           <DrawerHeader>
-            {/* classes, not styled(LabelHeading): Emotion overrides lose to LabelHeading's
-                own utilities, so `normal-case` here is what actually un-uppercases it */}
             <LabelHeading className='text-xs normal-case leading-[18px]'>
               {'Plan Details'}
             </LabelHeading>

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlanDrawer.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlanDrawer.tsx
@@ -68,12 +68,6 @@ const StyledCloseButton = styled(PlainButton)({
   alignItems: 'center'
 })
 
-const StyledLabelHeading = styled(LabelHeading)({
-  fontSize: 12,
-  lineHeight: '18px',
-  textTransform: 'none'
-})
-
 type Props = {
   organizationRef: OrgPlanDrawer_organization$key
 }
@@ -115,7 +109,11 @@ const OrgPlanDrawer = (props: Props) => {
       >
         <Drawer isDesktop={isDesktop} isOpen={showDrawer}>
           <DrawerHeader>
-            <StyledLabelHeading>{'Plan Details'}</StyledLabelHeading>
+            {/* classes, not styled(LabelHeading): Emotion overrides lose to LabelHeading's
+                own utilities, so `normal-case` here is what actually un-uppercases it */}
+            <LabelHeading className='text-xs normal-case leading-[18px]'>
+              {'Plan Details'}
+            </LabelHeading>
             <StyledCloseButton onClick={toggleSidebar}>
               <CloseIcon />
             </StyledCloseButton>

--- a/packages/client/modules/userDashboard/components/UserProfile.tsx
+++ b/packages/client/modules/userDashboard/components/UserProfile.tsx
@@ -26,7 +26,6 @@ const query = graphql`
       ...PersonalAccessTokens_viewer
       preferredName
       picture
-      hasDarkMode: featureFlag(featureName: "darkMode")
       identities {
         type
       }
@@ -37,7 +36,7 @@ const query = graphql`
 const UserProfile = ({queryRef}: Props) => {
   const data = usePreloadedQuery<UserProfileQuery>(query, queryRef)
   const {viewer} = data
-  const {identities, hasDarkMode} = viewer
+  const {identities} = viewer
   const isLocal = identities?.find((identity) => identity?.type === AuthIdentityTypeEnum.LOCAL)
   useDocumentTitle('My Profile | Parabol', 'My Profile')
   return (
@@ -46,7 +45,7 @@ const UserProfile = ({queryRef}: Props) => {
         <Panel label='Profile' casing={'capitalize'}>
           <UserSettingsForm viewer={viewer} />
         </Panel>
-        {hasDarkMode && <AppearancePanel />}
+        <AppearancePanel />
         {isLocal && (
           <Panel label='Authentication' casing={'capitalize'}>
             <div className='border-hairline border-t p-4 text-center'>

--- a/packages/client/utils/__tests__/themePreference.test.ts
+++ b/packages/client/utils/__tests__/themePreference.test.ts
@@ -42,18 +42,18 @@ describe('stored theme preference', () => {
     store.clear()
   })
 
-  it('defaults to light so the flagged dark theme never applies unopted', () => {
-    expect(getStoredThemePreference()).toBe('light')
+  it('defaults to system so an untouched install follows the OS', () => {
+    expect(getStoredThemePreference()).toBe('system')
   })
 
-  it('defaults to light when the stored value is unrecognized', () => {
+  it('defaults to system when the stored value is unrecognized', () => {
     window.localStorage.setItem('theme', 'grape')
-    expect(getStoredThemePreference()).toBe('light')
+    expect(getStoredThemePreference()).toBe('system')
   })
 
-  it('round-trips every preference, including system', () => {
-    // regression: 'system' was once stored by REMOVING the key, which now reads back as
-    // 'light' and would silently downgrade a deliberate "follow my OS" choice
+  it('round-trips every preference, including an explicit light', () => {
+    // 'light' is the one value the boot script treats specially, so it must survive
+    // a round trip rather than collapsing into the system default
     setStoredThemePreference('light')
     expect(getStoredThemePreference()).toBe('light')
     setStoredThemePreference('dark')

--- a/packages/client/utils/__tests__/themePreference.test.ts
+++ b/packages/client/utils/__tests__/themePreference.test.ts
@@ -1,4 +1,9 @@
-import {isThemePreference, resolveTheme} from '../themePreference'
+import {
+  getStoredThemePreference,
+  isThemePreference,
+  resolveTheme,
+  setStoredThemePreference
+} from '../themePreference'
 
 describe('resolveTheme', () => {
   it('returns the explicit preference regardless of the system setting', () => {
@@ -11,6 +16,50 @@ describe('resolveTheme', () => {
   it('follows the OS for the system preference', () => {
     expect(resolveTheme('system', true)).toBe('dark')
     expect(resolveTheme('system', false)).toBe('light')
+  })
+})
+
+describe('stored theme preference', () => {
+  // jest runs the client suite in the `node` environment and jest-environment-jsdom isn't
+  // installed, so stand up the minimal window.localStorage surface these helpers touch
+  const store = new Map<string, string>()
+  beforeAll(() => {
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        localStorage: {
+          getItem: (key: string) => store.get(key) ?? null,
+          setItem: (key: string, value: string) => void store.set(key, value),
+          removeItem: (key: string) => void store.delete(key),
+          clear: () => store.clear()
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+  })
+
+  beforeEach(() => {
+    store.clear()
+  })
+
+  it('defaults to light so the flagged dark theme never applies unopted', () => {
+    expect(getStoredThemePreference()).toBe('light')
+  })
+
+  it('defaults to light when the stored value is unrecognized', () => {
+    window.localStorage.setItem('theme', 'grape')
+    expect(getStoredThemePreference()).toBe('light')
+  })
+
+  it('round-trips every preference, including system', () => {
+    // regression: 'system' was once stored by REMOVING the key, which now reads back as
+    // 'light' and would silently downgrade a deliberate "follow my OS" choice
+    setStoredThemePreference('light')
+    expect(getStoredThemePreference()).toBe('light')
+    setStoredThemePreference('dark')
+    expect(getStoredThemePreference()).toBe('dark')
+    setStoredThemePreference('system')
+    expect(getStoredThemePreference()).toBe('system')
   })
 })
 

--- a/packages/client/utils/themePreference.ts
+++ b/packages/client/utils/themePreference.ts
@@ -17,23 +17,25 @@ export const resolveTheme = (
   return preference
 }
 
+// Dark mode is feature-flagged, and the theme is applied above Relay (Root.tsx) where the
+// flag isn't readable. So the default must be the opted-out theme: users only ever reach
+// dark by explicitly choosing 'dark' or 'system', which the flagged Appearance panel gates.
+const DEFAULT_THEME_PREFERENCE: ThemePreference = 'light'
+
 export const getStoredThemePreference = (): ThemePreference => {
   try {
     const stored = window.localStorage.getItem(LocalStorageKey.THEME)
-    return isThemePreference(stored) ? stored : 'system'
+    return isThemePreference(stored) ? stored : DEFAULT_THEME_PREFERENCE
   } catch {
-    return 'system'
+    return DEFAULT_THEME_PREFERENCE
   }
 }
 
 export const setStoredThemePreference = (preference: ThemePreference) => {
   try {
-    if (preference === 'system') {
-      // absent key = system, matching the boot script's fallback
-      window.localStorage.removeItem(LocalStorageKey.THEME)
-    } else {
-      window.localStorage.setItem(LocalStorageKey.THEME, preference)
-    }
+    // 'system' is persisted explicitly: an absent key now means light, so removing the
+    // key would silently downgrade a deliberate "follow my OS" choice to light.
+    window.localStorage.setItem(LocalStorageKey.THEME, preference)
   } catch {
     // localStorage unavailable (e.g. private mode) — theme just won't persist
   }

--- a/packages/client/utils/themePreference.ts
+++ b/packages/client/utils/themePreference.ts
@@ -17,8 +17,6 @@ export const resolveTheme = (
   return preference
 }
 
-// Dark mode is generally available, so an untouched install follows the OS.
-// Keep this in sync with the boot script in template.html / devTemplate.html.
 const DEFAULT_THEME_PREFERENCE: ThemePreference = 'system'
 
 export const getStoredThemePreference = (): ThemePreference => {
@@ -32,8 +30,6 @@ export const getStoredThemePreference = (): ThemePreference => {
 
 export const setStoredThemePreference = (preference: ThemePreference) => {
   try {
-    // 'system' is persisted explicitly: an absent key now means light, so removing the
-    // key would silently downgrade a deliberate "follow my OS" choice to light.
     window.localStorage.setItem(LocalStorageKey.THEME, preference)
   } catch {
     // localStorage unavailable (e.g. private mode) — theme just won't persist

--- a/packages/client/utils/themePreference.ts
+++ b/packages/client/utils/themePreference.ts
@@ -17,10 +17,9 @@ export const resolveTheme = (
   return preference
 }
 
-// Dark mode is feature-flagged, and the theme is applied above Relay (Root.tsx) where the
-// flag isn't readable. So the default must be the opted-out theme: users only ever reach
-// dark by explicitly choosing 'dark' or 'system', which the flagged Appearance panel gates.
-const DEFAULT_THEME_PREFERENCE: ThemePreference = 'light'
+// Dark mode is generally available, so an untouched install follows the OS.
+// Keep this in sync with the boot script in template.html / devTemplate.html.
+const DEFAULT_THEME_PREFERENCE: ThemePreference = 'system'
 
 export const getStoredThemePreference = (): ThemePreference => {
   try {

--- a/packages/server/utils/featureFlags.ts
+++ b/packages/server/utils/featureFlags.ts
@@ -35,16 +35,6 @@ export const FEATURE_FLAGS = {
     createdAt: new Date('2025-11-20T12:18:02.763416+00:00'),
     updatedAt: new Date('2025-11-20T12:18:02.763416+00:00'),
     isPublic: true
-  },
-  darkMode: {
-    featureName: 'darkMode',
-    scope: 'User',
-    description: 'Grape Dusk dark mode appearance setting',
-    // GA checklist: remove this flag (and the Appearance panel gate) before expiry
-    expiresAt: new Date('2027-06-30T23:59:59.999+00:00'),
-    createdAt: new Date('2026-07-15T00:00:00.000+00:00'),
-    updatedAt: new Date('2026-07-15T00:00:00.000+00:00'),
-    isPublic: true
   }
 } as const satisfies Record<string, FeatureFlag>
 

--- a/template.html
+++ b/template.html
@@ -26,13 +26,15 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#493272" />
-    <!-- Dark mode boot: apply .theme-dark before first paint. 'theme' mirrors LocalStorageKey.THEME -->
+    <!-- Dark mode boot: apply .theme-dark before first paint. 'theme' mirrors LocalStorageKey.THEME.
+         Dark mode is feature-flagged, so an absent/unrecognized value must resolve to light:
+         only an explicit 'dark', or an explicit 'system' on a dark OS, opts in. -->
     <script>
       try {
         var themePref = localStorage.getItem('theme')
         if (
           themePref === 'dark' ||
-          (themePref !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches)
+          (themePref === 'system' && matchMedia('(prefers-color-scheme: dark)').matches)
         ) {
           document.documentElement.className += ' theme-dark'
           var themeMeta = document.querySelector('meta[name="theme-color"]')

--- a/template.html
+++ b/template.html
@@ -27,14 +27,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#493272" />
     <!-- Dark mode boot: apply .theme-dark before first paint. 'theme' mirrors LocalStorageKey.THEME.
-         Dark mode is feature-flagged, so an absent/unrecognized value must resolve to light:
-         only an explicit 'dark', or an explicit 'system' on a dark OS, opts in. -->
+         Absent or 'system' follows the OS, matching DEFAULT_THEME_PREFERENCE in themePreference.ts. -->
     <script>
       try {
         var themePref = localStorage.getItem('theme')
         if (
           themePref === 'dark' ||
-          (themePref === 'system' && matchMedia('(prefers-color-scheme: dark)').matches)
+          (themePref !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches)
         ) {
           document.documentElement.className += ' theme-dark'
           var themeMeta = document.querySelector('meta[name="theme-color"]')


### PR DESCRIPTION
# Description

During testing on staging I found that the current implementation defaulted to `system`, exposing dark mode to current users. I didn't want this, so I made some changes.

Also, this PR includes:

- leftNav fixes
- History always uses lightest bg illustration
- Everything pre login is now wrapped in a `LightIsland` component
- Misc style fixes