### PR TITLE
fix: dark mode fix-ups, GitLab on Inspiration

### DIFF
--- a/packages/client/components/GitLabSVG.tsx
+++ b/packages/client/components/GitLabSVG.tsx
@@ -1,8 +1,13 @@
 import {memo} from 'react'
 
-const GitLabSVG = memo(() => {
+interface Props {
+  className?: string
+}
+
+const GitLabSVG = memo(({className}: Props) => {
   return (
     <svg
+      className={className}
       version='1.1'
       width='24'
       height='24'

--- a/packages/client/components/LinearSVG.tsx
+++ b/packages/client/components/LinearSVG.tsx
@@ -1,8 +1,13 @@
 import {memo} from 'react'
 
-const LinearSVG = memo(() => {
+interface Props {
+  className?: string
+}
+
+const LinearSVG = memo(({className}: Props) => {
   return (
     <svg
+      className={className}
       version='1.1'
       width='24'
       height='24'

--- a/packages/client/components/TaskWatermark.tsx
+++ b/packages/client/components/TaskWatermark.tsx
@@ -1,4 +1,5 @@
 import type React from 'react'
+import {cn} from '../ui/cn'
 import AzureDevOpsSVG from './AzureDevOpsSVG'
 import GitHubSVG from './GitHubSVG'
 import GitLabSVG from './GitLabSVG'
@@ -11,22 +12,27 @@ import LinearSVG from './LinearSVG'
 
 interface WatermarkSVGProps {
   Icon: React.ComponentType
+  className?: string
 }
 
-const WatermarkSVG = ({Icon}: WatermarkSVGProps) => (
-  <div className='absolute right-[24px] bottom-[8px] scale-500 transform'>
+const WatermarkSVG = ({Icon, className}: WatermarkSVGProps) => (
+  <div className={cn('absolute right-[24px] bottom-[8px] scale-500 transform', className)}>
     <Icon />
   </div>
 )
 
-const iconLookup = {
-  _xGitHubIssue: GitHubSVG,
-  JiraIssue: JiraSVG,
-  JiraServerIssue: JiraServerSVG,
-  _xGitLabIssue: GitLabSVG,
-  AzureDevOpsWorkItem: AzureDevOpsSVG,
-  _xLinearIssue: LinearSVG
-} as const
+// GitHub and Linear logos are near-black, so they need the white variant in dark mode.
+// The other services' logos are colored and stay legible on dark surfaces.
+const iconLookup: {
+  [type: string]: {Icon: React.ComponentType; className?: string} | undefined
+} = {
+  _xGitHubIssue: {Icon: GitHubSVG, className: 'dark:[&_path]:fill-white'},
+  JiraIssue: {Icon: JiraSVG},
+  JiraServerIssue: {Icon: JiraServerSVG},
+  _xGitLabIssue: {Icon: GitLabSVG},
+  AzureDevOpsWorkItem: {Icon: AzureDevOpsSVG},
+  _xLinearIssue: {Icon: LinearSVG, className: 'dark:[&_path]:fill-white'}
+}
 
 interface Props {
   type: string | undefined
@@ -35,12 +41,13 @@ interface Props {
 const TaskWatermark = (props: Props) => {
   const {type} = props
   if (!type) return null
-  const Icon = iconLookup[type as keyof typeof iconLookup]
-  if (!Icon) return null
+  const entry = iconLookup[type]
+  if (!entry) return null
+  const {Icon, className} = entry
 
   return (
     <div className='pointer-events-none absolute inset-0 z-10 overflow-hidden text-center align-middle opacity-20'>
-      <WatermarkSVG Icon={Icon} />
+      <WatermarkSVG Icon={Icon} className={className} />
     </div>
   )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
@@ -10,12 +10,14 @@ import AtlassianClientManager from '../../utils/AtlassianClientManager'
 import GitHubClientManager from '../../utils/GitHubClientManager'
 import SendClientSideEvent from '../../utils/SendClientSideEvent'
 import GitHubSVG from '../GitHubSVG'
+import GitLabSVG from '../GitLabSVG'
 import JiraServerSVG from '../JiraServerSVG'
 import JiraSVG from '../JiraSVG'
 import LinearSVG from '../LinearSVG'
 import ParabolLogoSVG from '../ParabolLogoSVG'
 import GCalIntegrationPanel from './WorkDrawer/GCalIntegrationPanel'
 import GitHubIntegrationPanel from './WorkDrawer/GitHubIntegrationPanel'
+import GitLabIntegrationPanel from './WorkDrawer/GitLabIntegrationPanel'
 import JiraIntegrationPanel from './WorkDrawer/JiraIntegrationPanel'
 import JiraServerIntegrationPanel from './WorkDrawer/JiraServerIntegrationPanel'
 import LinearIntegrationPanel from './WorkDrawer/LinearIntegrationPanel'
@@ -41,6 +43,7 @@ const TeamPromptWorkDrawer = (props: Props) => {
         }
         ...ParabolTasksPanel_meeting
         ...GitHubIntegrationPanel_meeting
+        ...GitLabIntegrationPanel_meeting
         ...JiraIntegrationPanel_meeting
         ...GCalIntegrationPanel_meeting
         ...JiraServerIntegrationPanel_meeting
@@ -64,6 +67,11 @@ const TeamPromptWorkDrawer = (props: Props) => {
                   id
                 }
               }
+              gitlab {
+                cloudProvider {
+                  id
+                }
+              }
             }
           }
         }
@@ -79,6 +87,8 @@ const TeamPromptWorkDrawer = (props: Props) => {
   const hasLinear =
     !!meeting.viewerMeetingMember?.teamMember?.integrations.linear?.cloudProvider?.id
   const hasGCal = !!meeting.viewerMeetingMember?.teamMember?.integrations.gcal?.cloudProvider?.id
+  const hasGitLab =
+    !!meeting.viewerMeetingMember?.teamMember?.integrations.gitlab?.cloudProvider?.id
 
   useEffect(() => {
     SendClientSideEvent(atmosphere, 'Inspiration Drawer Impression', {
@@ -114,6 +124,16 @@ const TeamPromptWorkDrawer = (props: Props) => {
           }
         ]
       : []),
+    ...(hasGitLab
+      ? [
+          {
+            icon: <GitLabSVG />,
+            service: 'gitlab',
+            label: 'GitLab',
+            Component: GitLabIntegrationPanel
+          }
+        ]
+      : []),
     ...(AtlassianClientManager.isAvailable
       ? [
           {
@@ -127,7 +147,7 @@ const TeamPromptWorkDrawer = (props: Props) => {
     ...(hasLinear
       ? [
           {
-            icon: <LinearSVG />,
+            icon: <LinearSVG className='dark:[&_path]:fill-white' />,
             service: 'linear',
             label: 'Linear',
             Component: LinearIntegrationPanel

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationPanel.tsx
@@ -6,11 +6,11 @@ import useAtmosphere from '../../../hooks/useAtmosphere'
 import useInspirationDrawer from '../../../hooks/useInspirationDrawer'
 import useMutationProps from '../../../hooks/useMutationProps'
 import useSessionStorageState from '../../../hooks/useSessionStorageState'
-import gitHubSVG from '../../../styles/theme/images/graphics/github-circle.svg'
 import {Button} from '../../../ui/Button/Button'
 import {cn} from '../../../ui/cn'
 import GitHubClientManager from '../../../utils/GitHubClientManager'
 import SendClientSideEvent from '../../../utils/SendClientSideEvent'
+import GitHubSVG from '../../GitHubSVG'
 import GitHubIntegrationResultsRoot from './GitHubIntegrationResultsRoot'
 import GitHubRepoFilterBar from './GitHubRepoFilterBar'
 import InspirationItemsPanel from './InspirationItemsPanel'
@@ -175,7 +175,7 @@ const GitHubIntegrationPanel = (props: Props) => {
       ) : (
         <div className='flex flex-col items-center gap-2 pt-12'>
           <div className='h-10 w-10'>
-            <img className='h-10 w-10' src={gitHubSVG} />
+            <GitHubSVG className='h-10 w-10 dark:[&_path]:fill-white' />
           </div>
           <b>Connect to GitHub</b>
           <div className='w-1/2 text-center text-sm'>

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitHubObjectCard.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitHubObjectCard.tsx
@@ -6,7 +6,6 @@ import type {GitHubObjectCard_result$key} from '../../../__generated__/GitHubObj
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import {MenuPosition} from '../../../hooks/useCoords'
 import useTooltip from '../../../hooks/useTooltip'
-import gitHubSVG from '../../../styles/theme/images/graphics/github-circle.svg'
 import githubIssueClosed from '../../../styles/theme/images/graphics/github-issue-closed.svg'
 import githubIssueOpen from '../../../styles/theme/images/graphics/github-issue-open.svg'
 import gitHubMerged from '../../../styles/theme/images/graphics/github-merged.svg'
@@ -16,6 +15,7 @@ import githubPROpen from '../../../styles/theme/images/graphics/github-pr-open.s
 import relativeDate from '../../../utils/date/relativeDate'
 import {mergeRefs} from '../../../utils/react/mergeRefs'
 import SendClientSideEvent from '../../../utils/SendClientSideEvent'
+import GitHubSVG from '../../GitHubSVG'
 
 const ISSUE_STATUS_MAP: Record<string, any> = {
   OPEN: githubIssueOpen,
@@ -153,7 +153,7 @@ const GitHubObjectCard = (props: Props) => {
       <div className='flex items-center justify-between'>
         <div className='flex items-center gap-2'>
           <div className='h-4 w-4'>
-            <img src={gitHubSVG} />
+            <GitHubSVG className='h-4 w-4 dark:[&_path]:fill-white' />
           </div>
           <a
             href={repoUrl}

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitLabIntegrationPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitLabIntegrationPanel.tsx
@@ -1,0 +1,101 @@
+import graphql from 'babel-plugin-relay/macro'
+import {useFragment} from 'react-relay'
+import type {GitLabIntegrationPanel_meeting$key} from '../../../__generated__/GitLabIntegrationPanel_meeting.graphql'
+import useAtmosphere from '../../../hooks/useAtmosphere'
+import useMutationProps from '../../../hooks/useMutationProps'
+import GitLabClientManager from '../../../utils/GitLabClientManager'
+import SendClientSideEvent from '../../../utils/SendClientSideEvent'
+import GitLabSVG from '../../GitLabSVG'
+import GitLabIntegrationResultsRoot from './GitLabIntegrationResultsRoot'
+
+interface Props {
+  meetingRef: GitLabIntegrationPanel_meeting$key
+}
+
+const GitLabIntegrationPanel = (props: Props) => {
+  const {meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment GitLabIntegrationPanel_meeting on NewMeeting {
+        id
+        teamId
+        viewerMeetingMember {
+          teamMember {
+            teamId
+            integrations {
+              gitlab {
+                auth {
+                  isActive
+                }
+                cloudProvider {
+                  id
+                  clientId
+                  serverBaseUrl
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
+
+  const atmosphere = useAtmosphere()
+  const teamMember = meeting.viewerMeetingMember?.teamMember
+  const gitlab = teamMember?.integrations.gitlab
+  const isActive = !!gitlab?.auth?.isActive
+  const provider = gitlab?.cloudProvider
+
+  const mutationProps = useMutationProps()
+  const {error, onError} = mutationProps
+
+  const authGitLab = () => {
+    if (!teamMember) {
+      return onError(new Error('Could not find team member'))
+    }
+    if (!provider) {
+      return onError(new Error('Could not find GitLab provider'))
+    }
+    const {id: providerId, clientId, serverBaseUrl} = provider
+    GitLabClientManager.openOAuth(
+      atmosphere,
+      providerId,
+      clientId,
+      serverBaseUrl,
+      teamMember.teamId,
+      mutationProps
+    )
+
+    SendClientSideEvent(atmosphere, 'Inspiration Drawer Integration Connected', {
+      teamId: meeting.teamId,
+      meetingId: meeting.id,
+      service: 'gitlab'
+    })
+  }
+
+  return (
+    <>
+      {isActive && teamMember ? (
+        <GitLabIntegrationResultsRoot teamId={teamMember.teamId} />
+      ) : (
+        <div className='flex flex-col items-center gap-2 pt-12'>
+          <div className='h-10 w-10'>
+            <GitLabSVG className='h-10 w-10' />
+          </div>
+          <b>Connect to GitLab</b>
+          <div className='w-1/2 text-center text-sm'>Connect to GitLab to view your issues.</div>
+          <button
+            className='mt-4 cursor-pointer rounded-md bg-sky-500 px-8 py-2 font-semibold text-white hover:bg-sky-600'
+            onClick={authGitLab}
+          >
+            Connect
+          </button>
+          {error && <div className='text-fg-error'>Error: {error.message}</div>}
+        </div>
+      )}
+    </>
+  )
+}
+
+export default GitLabIntegrationPanel

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitLabIntegrationResults.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitLabIntegrationResults.tsx
@@ -1,0 +1,114 @@
+import graphql from 'babel-plugin-relay/macro'
+import {type PreloadedQuery, usePaginationFragment, usePreloadedQuery} from 'react-relay'
+import {Link} from 'react-router'
+import halloweenRetrospectiveTemplate from '../../../../../static/images/illustrations/halloweenRetrospectiveTemplate.png'
+import type {GitLabIntegrationResults_search$key} from '../../../__generated__/GitLabIntegrationResults_search.graphql'
+import type {GitLabIntegrationResultsQuery} from '../../../__generated__/GitLabIntegrationResultsQuery.graphql'
+import type {GitLabIntegrationResultsSearchPaginationQuery} from '../../../__generated__/GitLabIntegrationResultsSearchPaginationQuery.graphql'
+import useLoadNextOnScrollBottom from '../../../hooks/useLoadNextOnScrollBottom'
+import Ellipsis from '../../Ellipsis/Ellipsis'
+import GitLabObjectCard from './GitLabObjectCard'
+
+interface Props {
+  queryRef: PreloadedQuery<GitLabIntegrationResultsQuery>
+  teamId: string
+}
+
+const GitLabIntegrationResults = (props: Props) => {
+  const {queryRef, teamId} = props
+  const query = usePreloadedQuery(
+    graphql`
+      query GitLabIntegrationResultsQuery($teamId: ID!) {
+        ...GitLabIntegrationResults_search @arguments(teamId: $teamId)
+      }
+    `,
+    queryRef
+  )
+
+  const paginationRes = usePaginationFragment<
+    GitLabIntegrationResultsSearchPaginationQuery,
+    GitLabIntegrationResults_search$key
+  >(
+    graphql`
+      fragment GitLabIntegrationResults_search on Query
+      @argumentDefinitions(
+        cursor: {type: "String"}
+        count: {type: "Int", defaultValue: 25}
+        teamId: {type: "ID!"}
+      )
+      @refetchable(queryName: "GitLabIntegrationResultsSearchPaginationQuery") {
+        viewer {
+          teamMember(teamId: $teamId) {
+            integrations {
+              gitlab {
+                projectsIssues(
+                  first: $count
+                  after: $cursor
+                  searchQuery: ""
+                  state: "opened"
+                  sort: "UPDATED_DESC"
+                ) @connection(key: "GitLabIntegrationResults_projectsIssues") {
+                  error {
+                    message
+                  }
+                  edges {
+                    node {
+                      ... on _xGitLabIssue {
+                        id
+                        ...GitLabObjectCard_issue
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    query
+  )
+
+  const lastItem = useLoadNextOnScrollBottom(paginationRes, {}, 20)
+  const {data, hasNext} = paginationRes
+
+  const gitlab = data.viewer.teamMember?.integrations.gitlab
+  const gitlabResults = gitlab?.projectsIssues?.edges?.map((edge) => edge?.node)
+  const error = gitlab?.projectsIssues?.error ?? null
+
+  return (
+    <>
+      <div className='flex h-full flex-col gap-y-2 overflow-auto p-4'>
+        {gitlabResults && gitlabResults.length > 0 ? (
+          gitlabResults?.map((result, idx) => {
+            if (!result) {
+              return null
+            }
+            return <GitLabObjectCard key={idx} issueRef={result} />
+          })
+        ) : (
+          <div className='flex flex-col items-center pt-12'>
+            <img className='w-20' src={halloweenRetrospectiveTemplate} />
+            <div className='mt-7 w-2/3 text-center'>
+              {error?.message ? error.message : `Looks like you don’t have any issues to display.`}
+            </div>
+            <Link
+              to={`/team/${teamId}/integrations`}
+              className='mt-4 font-semibold text-accent hover:text-sky-400'
+            >
+              Review your GitLab configuration
+            </Link>
+          </div>
+        )}
+        {lastItem}
+        {hasNext && (
+          <div className='-mt-4 mx-auto mb-4 h-8 text-2xl' key={'loadingNext'}>
+            <Ellipsis />
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+export default GitLabIntegrationResults

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitLabIntegrationResultsRoot.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitLabIntegrationResultsRoot.tsx
@@ -1,0 +1,28 @@
+import {Suspense} from 'react'
+import {Loader} from '~/utils/relay/renderLoader'
+import gitLabIntegrationResultsQuery, {
+  type GitLabIntegrationResultsQuery
+} from '../../../__generated__/GitLabIntegrationResultsQuery.graphql'
+import useQueryLoaderNow from '../../../hooks/useQueryLoaderNow'
+import ErrorBoundary from '../../ErrorBoundary'
+import GitLabIntegrationResults from './GitLabIntegrationResults'
+
+interface Props {
+  teamId: string
+}
+
+const GitLabIntegrationResultsRoot = (props: Props) => {
+  const {teamId} = props
+  const queryRef = useQueryLoaderNow<GitLabIntegrationResultsQuery>(gitLabIntegrationResultsQuery, {
+    teamId
+  })
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={<Loader />}>
+        {queryRef && <GitLabIntegrationResults queryRef={queryRef} teamId={teamId} />}
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+
+export default GitLabIntegrationResultsRoot

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitLabObjectCard.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitLabObjectCard.tsx
@@ -3,39 +3,32 @@ import graphql from 'babel-plugin-relay/macro'
 import {memo} from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import {useFragment} from 'react-relay'
-import type {LinearObjectCard_issue$key} from '../../../__generated__/LinearObjectCard_issue.graphql'
+import type {GitLabObjectCard_issue$key} from '../../../__generated__/GitLabObjectCard_issue.graphql'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import {MenuPosition} from '../../../hooks/useCoords'
 import useTooltip from '../../../hooks/useTooltip'
-import {getLinearRepoName} from '../../../utils/getLinearRepoName'
+import relativeDate from '../../../utils/date/relativeDate'
+import {parseWebPath} from '../../../utils/parseWebPath'
 import {mergeRefs} from '../../../utils/react/mergeRefs'
 import SendClientSideEvent from '../../../utils/SendClientSideEvent'
-import LinearSVG from '../../LinearSVG'
+import GitLabSVG from '../../GitLabSVG'
 
 interface Props {
-  issueRef: LinearObjectCard_issue$key
+  issueRef: GitLabObjectCard_issue$key
 }
 
-const LinearObjectCard = memo((props: Props) => {
+const GitLabObjectCard = memo((props: Props) => {
   const {issueRef} = props
 
   const issue = useFragment(
     graphql`
-      fragment LinearObjectCard_issue on _xLinearIssue {
+      fragment GitLabObjectCard_issue on _xGitLabIssue {
         id
+        iid
         title
-        identifier
-        url
-        state {
-          name
-        }
-        project {
-          name
-          url
-        }
-        team {
-          displayName
-        }
+        webUrl
+        webPath
+        updatedAt
       }
     `,
     issueRef
@@ -56,13 +49,13 @@ const LinearObjectCard = memo((props: Props) => {
 
   const trackLinkClick = () => {
     SendClientSideEvent(atmosphere, 'Inspiration Drawer Card Link Clicked', {
-      service: 'linear'
+      service: 'gitlab'
     })
   }
 
   const trackCopy = () => {
     SendClientSideEvent(atmosphere, 'Inspiration Drawer Card Copied', {
-      service: 'linear'
+      service: 'gitlab'
     })
   }
 
@@ -78,27 +71,27 @@ const LinearObjectCard = memo((props: Props) => {
     return null
   }
 
-  const {
-    title,
-    identifier,
-    url,
-    state,
-    project,
-    team: {displayName: teamName}
-  } = issue
-  const repoStr = getLinearRepoName(project, teamName)
-  const repoUrl = project?.url
+  const {iid, title, webUrl, webPath, updatedAt} = issue
+  const {fullPath} = parseWebPath(webPath)
+  const projectUrl = webUrl.split('/-/')[0]
 
   return (
     <div className='rounded-sm border border-hairline border-solid p-4 hover:border-hairline-strong'>
-      <div className='flex items-center gap-2 text-fg-secondary text-xs'>
-        <span className='font-medium'>{identifier}</span>
-        <span>•</span>
-        <span>{state.name}</span>
+      <div className='flex gap-2 text-fg-secondary text-xs'>
+        <a
+          href={webUrl}
+          target='_blank'
+          className='font-medium hover:underline'
+          rel='noreferrer'
+          onClick={trackLinkClick}
+        >
+          #{iid}
+        </a>
+        <div>Updated {relativeDate(updatedAt)}</div>
       </div>
       <div className='my-2 text-sm'>
         <a
-          href={url}
+          href={webUrl}
           target='_blank'
           className='hover:underline'
           rel='noreferrer'
@@ -109,26 +102,20 @@ const LinearObjectCard = memo((props: Props) => {
       </div>
       <div className='flex items-center justify-between'>
         <div className='flex items-center gap-2'>
-          <div className='flex h-4 w-4 items-center justify-center'>
-            <LinearSVG className='h-4 w-4 dark:[&_path]:fill-white' />
+          <div className='h-4 w-4'>
+            <GitLabSVG className='h-4 w-4' />
           </div>
-          {repoUrl ? (
-            <a
-              href={repoUrl}
-              target='_blank'
-              className='flex items-center text-fg-secondary text-xs hover:underline'
-              rel='noreferrer'
-              onClick={trackLinkClick}
-            >
-              <span className='leading-none'>{repoStr}</span>
-            </a>
-          ) : (
-            <span className='flex items-center text-fg-secondary text-xs leading-none'>
-              {repoStr}
-            </span>
-          )}
+          <a
+            href={projectUrl}
+            target='_blank'
+            className='text-fg-secondary text-xs hover:underline'
+            rel='noreferrer'
+            onClick={trackLinkClick}
+          >
+            {fullPath}
+          </a>
         </div>
-        <CopyToClipboard text={url} onCopy={handleCopy}>
+        <CopyToClipboard text={webUrl} onCopy={handleCopy}>
           <div
             className='h-6 w-6 cursor-pointer rounded-md bg-transparent p-0.5 text-fg-muted hover:bg-surface-hover'
             onMouseEnter={openTooltip}
@@ -145,4 +132,4 @@ const LinearObjectCard = memo((props: Props) => {
   )
 })
 
-export default LinearObjectCard
+export default GitLabObjectCard

--- a/packages/client/components/TeamPrompt/WorkDrawer/LinearIntegrationPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/LinearIntegrationPanel.tsx
@@ -5,10 +5,10 @@ import useAtmosphere from '../../../hooks/useAtmosphere'
 import useInspirationDrawer from '../../../hooks/useInspirationDrawer'
 import useMutationProps from '../../../hooks/useMutationProps'
 import useSessionStorageState from '../../../hooks/useSessionStorageState'
-import linearSVG from '../../../styles/theme/images/graphics/linear.svg'
 import LinearClientManager from '../../../utils/LinearClientManager'
 import {makeLinearWorkFilter} from '../../../utils/makeLinearWorkFilter'
 import SendClientSideEvent from '../../../utils/SendClientSideEvent'
+import LinearSVG from '../../LinearSVG'
 import InspirationItemsPanel from './InspirationItemsPanel'
 import LinearIntegrationResultsRoot from './LinearIntegrationResultsRoot'
 import LinearProjectFilterBar from './LinearProjectFilterBar'
@@ -133,7 +133,7 @@ const LinearIntegrationPanel = (props: Props) => {
       ) : (
         <div className='flex flex-col items-center gap-2 pt-12'>
           <div className='h-10 w-10'>
-            <img className='h-10 w-10' src={linearSVG} />
+            <LinearSVG className='h-10 w-10 dark:[&_path]:fill-white' />
           </div>
           <b>Connect to Linear</b>
           <div className='w-1/2 text-center text-sm'>

--- a/packages/client/components/TeamPrompt/WorkDrawer/RetroWorkDrawer.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/RetroWorkDrawer.tsx
@@ -12,12 +12,14 @@ import GitHubClientManager from '../../../utils/GitHubClientManager'
 import getNextSortOrder from '../../../utils/getNextSortOrder'
 import SendClientSideEvent from '../../../utils/SendClientSideEvent'
 import GitHubSVG from '../../GitHubSVG'
+import GitLabSVG from '../../GitLabSVG'
 import JiraServerSVG from '../../JiraServerSVG'
 import JiraSVG from '../../JiraSVG'
 import LinearSVG from '../../LinearSVG'
 import ParabolLogoSVG from '../../ParabolLogoSVG'
 import GCalIntegrationPanel from './GCalIntegrationPanel'
 import GitHubIntegrationPanel from './GitHubIntegrationPanel'
+import GitLabIntegrationPanel from './GitLabIntegrationPanel'
 import JiraIntegrationPanel from './JiraIntegrationPanel'
 import JiraServerIntegrationPanel from './JiraServerIntegrationPanel'
 import LinearIntegrationPanel from './LinearIntegrationPanel'
@@ -54,6 +56,7 @@ const RetroWorkDrawer = (props: Props) => {
         }
         ...ParabolTasksPanel_meeting
         ...GitHubIntegrationPanel_meeting
+        ...GitLabIntegrationPanel_meeting
         ...JiraIntegrationPanel_meeting
         ...GCalIntegrationPanel_meeting
         ...JiraServerIntegrationPanel_meeting
@@ -77,6 +80,11 @@ const RetroWorkDrawer = (props: Props) => {
                   id
                 }
               }
+              gitlab {
+                cloudProvider {
+                  id
+                }
+              }
             }
           }
         }
@@ -90,6 +98,8 @@ const RetroWorkDrawer = (props: Props) => {
   const hasLinear =
     !!meeting.viewerMeetingMember?.teamMember?.integrations.linear?.cloudProvider?.id
   const hasGCal = !!meeting.viewerMeetingMember?.teamMember?.integrations.gcal?.cloudProvider?.id
+  const hasGitLab =
+    !!meeting.viewerMeetingMember?.teamMember?.integrations.gitlab?.cloudProvider?.id
 
   useEffect(() => {
     SendClientSideEvent(atmosphere, 'Inspiration Drawer Impression', {
@@ -148,6 +158,16 @@ const RetroWorkDrawer = (props: Props) => {
           }
         ]
       : []),
+    ...(hasGitLab
+      ? [
+          {
+            icon: <GitLabSVG />,
+            service: 'gitlab',
+            label: 'GitLab',
+            Component: GitLabIntegrationPanel
+          }
+        ]
+      : []),
     ...(AtlassianClientManager.isAvailable
       ? [
           {
@@ -161,7 +181,7 @@ const RetroWorkDrawer = (props: Props) => {
     ...(hasLinear
       ? [
           {
-            icon: <LinearSVG />,
+            icon: <LinearSVG className='dark:[&_path]:fill-white' />,
             service: 'linear',
             label: 'Linear',
             Component: LinearIntegrationPanel

--- a/packages/client/mutations/AddTeamMemberIntegrationAuthMutation.ts
+++ b/packages/client/mutations/AddTeamMemberIntegrationAuthMutation.ts
@@ -36,6 +36,16 @@ const mutation = graphql`
           integrations {
             ...MattermostProviderRowTeamMemberIntegrations
             ...MSTeamsProviderRowTeamMemberIntegrations
+            gitlab {
+              auth {
+                isActive
+              }
+            }
+            linear {
+              auth {
+                isActive
+              }
+            }
             gdrive {
               isActive
             }


### PR DESCRIPTION
# Description

Fixes up 

- Adds GitLab in the Inspiration panel add to both the retro and standup work drawers. Shows a "Connect to GitLab" screen when unconnected. No AI features yet.

- Dark-mode icon fixes. LinearSVG and GitLabSVG now accept className; the near-black GitHub/Linear logos get dark.

- Task card watermarks — TaskWatermark applies the white variant to GitHub and Linear logos in dark mode.

- OAuth live-update bug fix. AddTeamMemberIntegrationAuthMutation now fetches gitlab.auth.isActive and linear.auth.isActive, so those panels flip to the connected state immediately after the OAuth popup closes instead of requiring a page refresh
