### PR TITLE
fix: Add Time resets timer for clients with skewed clocks

### DIFF
--- a/packages/client/components/StageTimerModalTimeLimit.tsx
+++ b/packages/client/components/StageTimerModalTimeLimit.tsx
@@ -56,11 +56,12 @@ const StageTimerModalTimeLimit = (props: Props) => {
       fragment StageTimerModalTimeLimit_stage on NewMeetingStage {
         suggestedTimeLimit
         scheduledEndTime
+        localScheduledEndTime
       }
     `,
     stageRef
   )
-  const {suggestedTimeLimit, scheduledEndTime} = stage
+  const {suggestedTimeLimit, scheduledEndTime, localScheduledEndTime} = stage
   const initialTimeLimit =
     scheduledEndTime || !suggestedTimeLimit
       ? defaultTimeLimit
@@ -71,9 +72,8 @@ const StageTimerModalTimeLimit = (props: Props) => {
   const {submitting, onError, onCompleted, submitMutation, error} = useMutationProps()
   const startTimer = () => {
     if (submitting) return
-    const spareTime = scheduledEndTime
-      ? Math.max(0, new Date(scheduledEndTime).getTime() - Date.now())
-      : 0
+    const endTime = localScheduledEndTime ?? scheduledEndTime
+    const spareTime = endTime ? Math.max(0, new Date(endTime).getTime() - Date.now()) : 0
     const timeRemaining = minuteTimeLimit * ms('1m') + spareTime
     submitMutation()
     SetStageTimerMutation(


### PR DESCRIPTION
Compute spare time from the skew-corrected localScheduledEndTime instead of subtracting client Date.now() from the raw server scheduledEndTime. A fast client clock zeroed the remainder, so Add Time replaced the timer with just the selected minutes.

