### PR TITLE
fix: Team Health category label and recurrence editing

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityCard.tsx
@@ -8,10 +8,9 @@ import {cn} from '../../ui/cn'
 import {Tooltip} from '../../ui/Tooltip/Tooltip'
 import {TooltipContent} from '../../ui/Tooltip/TooltipContent'
 import {TooltipTrigger} from '../../ui/Tooltip/TooltipTrigger'
-import {upperFirst} from '../../utils/upperFirst'
 import {ActivityLibraryCardDescription} from './ActivityLibraryCardDescription'
 import {backgroundImgMap} from './backgroundImgMap'
-import {type CategoryID, MEETING_TYPE_TO_CATEGORY} from './Categories'
+import {CATEGORY_ID_TO_NAME, type CategoryID, MEETING_TYPE_TO_CATEGORY} from './Categories'
 
 export interface CardTheme {
   primary: string
@@ -125,7 +124,9 @@ export const ActivityCard = (props: ActivityCardProps) => {
       {title && category && (
         <div className='mt-2 px-2 pb-2'>
           <div className='truncate pb-1 text-fg-primary text-lg leading-5'>{title}</div>
-          <div className={cn('font-semibold italic', `${theme.text}`)}>{upperFirst(category)}</div>
+          <div className={cn('font-semibold italic', `${theme.text}`)}>
+            {CATEGORY_ID_TO_NAME[category]}
+          </div>
         </div>
       )}
     </div>

--- a/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
+++ b/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
@@ -163,7 +163,11 @@ const updateRecurrenceSettings: MutationResolvers['updateRecurrenceSettings'] = 
   }
   const {teamId, meetingType, meetingSeriesId} = meeting
 
-  if (meetingType !== 'teamPrompt' && meetingType !== 'retrospective') {
+  if (
+    meetingType !== 'teamPrompt' &&
+    meetingType !== 'retrospective' &&
+    meetingType !== 'teamHealth'
+  ) {
     return standardError(new Error('Recurring meeting type is not implemented'), {userId: viewerId})
   }
 


### PR DESCRIPTION
# Description

A couple quick fixes I noticed while testing.

Quick tweak to map category names of meetings to real strings ("Team Health" instead of "TeamHealth").

I also couldn't end TeamHealth meeting series. updateRecurrenceSettings.ts:166, only allowed teamPrompt and retrospective. Added teamHealth.
