### PR TITLE
chore: add integration platform contracts and registries

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -224,7 +224,7 @@
       }
     },
     {
-      "includes": ["**/__tests__/**"],
+      "includes": ["**/__tests__/**", "packages/server/integrations/platform/conformance/**"],
       "linter": {
         "domains": {
           "test": "all"

--- a/packages/client/integrations/azureDevOps/index.ts
+++ b/packages/client/integrations/azureDevOps/index.ts
@@ -1,0 +1,32 @@
+import AzureDevOpsIssueId from '../../shared/gqlIds/AzureDevOpsIssueId'
+import {Providers} from '../../types/constEnums'
+import AzureDevOpsClientManager from '../../utils/AzureDevOpsClientManager'
+import type {ClientIntegrationDefinition} from '../platform/ClientIntegrationDefinition'
+
+const azureDevOps: ClientIntegrationDefinition = {
+  service: 'azureDevOps',
+  label: Providers.AZUREDEVOPS_NAME,
+  description: Providers.AZUREDEVOPS_DESC,
+  ids: {
+    joinIssue: (parts) =>
+      AzureDevOpsIssueId.join(
+        String(parts.instanceId),
+        String(parts.projectKey),
+        String(parts.issueKey)
+      ),
+    splitIssue: (id) => AzureDevOpsIssueId.split(id)
+  },
+  connect: {
+    open: (atmosphere, {teamId, mutationProps, provider}) => {
+      if (!provider) return
+      void AzureDevOpsClientManager.openOAuth(
+        atmosphere,
+        teamId,
+        {id: provider.id, tenantId: provider.tenantId, clientId: provider.clientId},
+        mutationProps
+      )
+    }
+  }
+}
+
+export default azureDevOps

--- a/packages/client/integrations/github/index.ts
+++ b/packages/client/integrations/github/index.ts
@@ -1,0 +1,21 @@
+import GitHubIssueId from '../../shared/gqlIds/GitHubIssueId'
+import {Providers} from '../../types/constEnums'
+import GitHubClientManager from '../../utils/GitHubClientManager'
+import type {ClientIntegrationDefinition} from '../platform/ClientIntegrationDefinition'
+
+const github: ClientIntegrationDefinition = {
+  service: 'github',
+  label: Providers.GITHUB_NAME,
+  description: Providers.GITHUB_DESC,
+  ids: {
+    joinIssue: (parts) =>
+      GitHubIssueId.join(String(parts.nameWithOwner), Number(parts.issueNumber)),
+    splitIssue: (id) => GitHubIssueId.split(id)
+  },
+  connect: {
+    open: (atmosphere, {teamId, mutationProps}) =>
+      GitHubClientManager.openOAuth(atmosphere, teamId, mutationProps)
+  }
+}
+
+export default github

--- a/packages/client/integrations/gitlab/index.ts
+++ b/packages/client/integrations/gitlab/index.ts
@@ -1,0 +1,29 @@
+import GitLabIssueId from '../../shared/gqlIds/GitLabIssueId'
+import {Providers} from '../../types/constEnums'
+import GitLabClientManager from '../../utils/GitLabClientManager'
+import type {ClientIntegrationDefinition} from '../platform/ClientIntegrationDefinition'
+
+const gitlab: ClientIntegrationDefinition = {
+  service: 'gitlab',
+  label: Providers.GITLAB_NAME,
+  description: 'Use GitLab Issues from within Parabol.',
+  ids: {
+    joinIssue: (parts) => GitLabIssueId.join(String(parts.providerId), String(parts.gid)),
+    splitIssue: (id) => GitLabIssueId.split(id)
+  },
+  connect: {
+    open: (atmosphere, {teamId, mutationProps, provider}) => {
+      if (!provider) return
+      GitLabClientManager.openOAuth(
+        atmosphere,
+        provider.id,
+        provider.clientId,
+        provider.serverBaseUrl,
+        teamId,
+        mutationProps
+      )
+    }
+  }
+}
+
+export default gitlab

--- a/packages/client/integrations/jira/index.ts
+++ b/packages/client/integrations/jira/index.ts
@@ -1,0 +1,20 @@
+import JiraIssueId from '../../shared/gqlIds/JiraIssueId'
+import {Providers} from '../../types/constEnums'
+import AtlassianClientManager from '../../utils/AtlassianClientManager'
+import type {ClientIntegrationDefinition} from '../platform/ClientIntegrationDefinition'
+
+const jira: ClientIntegrationDefinition = {
+  service: 'jira',
+  label: Providers.ATLASSIAN_NAME,
+  description: Providers.ATLASSIAN_DESC,
+  ids: {
+    joinIssue: (parts) => JiraIssueId.join(String(parts.cloudId), String(parts.issueKey)),
+    splitIssue: (id) => JiraIssueId.split(id)
+  },
+  connect: {
+    open: (atmosphere, {teamId, mutationProps}) =>
+      AtlassianClientManager.openOAuth(atmosphere, teamId, mutationProps)
+  }
+}
+
+export default jira

--- a/packages/client/integrations/jiraServer/index.ts
+++ b/packages/client/integrations/jiraServer/index.ts
@@ -1,0 +1,27 @@
+import JiraServerIssueId from '../../shared/gqlIds/JiraServerIssueId'
+import {Providers} from '../../types/constEnums'
+import JiraServerClientManager from '../../utils/JiraServerClientManager'
+import type {ClientIntegrationDefinition} from '../platform/ClientIntegrationDefinition'
+
+const jiraServer: ClientIntegrationDefinition = {
+  service: 'jiraServer',
+  label: Providers.JIRA_SERVER_NAME,
+  description: Providers.JIRA_SERVER_DESC,
+  ids: {
+    joinIssue: (parts) =>
+      JiraServerIssueId.join(
+        Number(parts.providerId),
+        String(parts.repositoryId),
+        String(parts.issueId)
+      ),
+    splitIssue: (id) => JiraServerIssueId.split(id)
+  },
+  connect: {
+    open: (atmosphere, {teamId, mutationProps, provider}) => {
+      if (!provider) return
+      JiraServerClientManager.openOAuth(atmosphere, provider.id, teamId, mutationProps)
+    }
+  }
+}
+
+export default jiraServer

--- a/packages/client/integrations/linear/index.ts
+++ b/packages/client/integrations/linear/index.ts
@@ -1,0 +1,27 @@
+import LinearIssueId from '../../shared/gqlIds/LinearIssueId'
+import {Providers} from '../../types/constEnums'
+import LinearClientManager from '../../utils/LinearClientManager'
+import type {ClientIntegrationDefinition} from '../platform/ClientIntegrationDefinition'
+
+const linear: ClientIntegrationDefinition = {
+  service: 'linear',
+  label: Providers.LINEAR_NAME,
+  description: Providers.LINEAR_DESC,
+  ids: {
+    joinIssue: (parts) => LinearIssueId.join(String(parts.repoId), String(parts.issueId)),
+    splitIssue: (id) => LinearIssueId.split(id)
+  },
+  connect: {
+    open: (atmosphere, {teamId, mutationProps, provider}) => {
+      if (!provider) return
+      void LinearClientManager.openOAuth(
+        atmosphere,
+        teamId,
+        {id: provider.id, clientId: provider.clientId, serverBaseUrl: provider.serverBaseUrl},
+        mutationProps
+      )
+    }
+  }
+}
+
+export default linear

--- a/packages/client/integrations/platform/ClientIntegrationDefinition.ts
+++ b/packages/client/integrations/platform/ClientIntegrationDefinition.ts
@@ -1,0 +1,33 @@
+import type Atmosphere from '../../Atmosphere'
+import type {MenuMutationProps} from '../../hooks/useMutationProps'
+import type {TaskServiceEnum} from '../../shared/types/TaskIntegration'
+
+export type IssueParts = Record<string, string | number>
+
+export interface IntegrationIdCodec {
+  joinIssue(parts: IssueParts): string
+  splitIssue(id: string): IssueParts
+}
+
+export interface ConnectProvider {
+  id: string
+  clientId: string
+  serverBaseUrl: string
+  tenantId: string | null
+}
+
+export interface ConnectParams {
+  teamId: string
+  mutationProps: MenuMutationProps
+  provider?: ConnectProvider
+}
+
+export interface ClientIntegrationDefinition {
+  service: Exclude<TaskServiceEnum, 'PARABOL'>
+  label: string
+  description: string
+  ids: IntegrationIdCodec
+  connect: {
+    open(atmosphere: Atmosphere, params: ConnectParams): void
+  }
+}

--- a/packages/client/integrations/platform/__tests__/registry.test.ts
+++ b/packages/client/integrations/platform/__tests__/registry.test.ts
@@ -1,0 +1,71 @@
+jest.mock('../../../utils/AtlassianClientManager', () => ({
+  __esModule: true,
+  default: {openOAuth: jest.fn()}
+}))
+jest.mock('../../../utils/JiraServerClientManager', () => ({
+  __esModule: true,
+  default: {openOAuth: jest.fn()}
+}))
+jest.mock('../../../utils/GitHubClientManager', () => ({
+  __esModule: true,
+  default: {openOAuth: jest.fn()}
+}))
+jest.mock('../../../utils/GitLabClientManager', () => ({
+  __esModule: true,
+  default: {openOAuth: jest.fn()}
+}))
+jest.mock('../../../utils/AzureDevOpsClientManager', () => ({
+  __esModule: true,
+  default: {openOAuth: jest.fn()}
+}))
+jest.mock('../../../utils/LinearClientManager', () => ({
+  __esModule: true,
+  default: {openOAuth: jest.fn()}
+}))
+
+import type {IssueParts} from '../ClientIntegrationDefinition'
+import {clientIntegrations, getClientIntegration} from '../registry'
+
+const SAMPLE_ISSUE_PARTS: Record<string, IssueParts> = {
+  azureDevOps: {instanceId: 'dev.azure.com/acme', projectKey: 'WebApp', issueKey: '42'},
+  github: {nameWithOwner: 'ParabolInc/parabol', issueNumber: 123},
+  gitlab: {providerId: '7', gid: 'gid://gitlab/Issue/321'},
+  jira: {cloudId: 'cloud-123', issueKey: 'WEB-42'},
+  jiraServer: {providerId: 9, repositoryId: '10001', issueId: '10042'},
+  linear: {repoId: 'team1:proj1', issueId: 'a1b2c3'}
+}
+
+describe('clientIntegrations registry', () => {
+  it('registers exactly the six task services', () => {
+    expect(Object.keys(clientIntegrations).sort()).toEqual([
+      'azureDevOps',
+      'github',
+      'gitlab',
+      'jira',
+      'jiraServer',
+      'linear'
+    ])
+  })
+
+  it.each(Object.entries(clientIntegrations))('%s: service matches key', (key, def) => {
+    expect(def.service).toBe(key)
+  })
+
+  it.each(Object.entries(clientIntegrations))('%s: has label and description', (_key, def) => {
+    expect(def.label.length).toBeGreaterThan(0)
+    expect(def.description.length).toBeGreaterThan(0)
+  })
+
+  it.each(Object.entries(clientIntegrations))('%s: issue codec round-trips', (key, def) => {
+    const id = def.ids.joinIssue(SAMPLE_ISSUE_PARTS[key]!)
+    expect(def.ids.joinIssue(def.ids.splitIssue(id))).toBe(id)
+  })
+
+  it('returns null for an unknown service', () => {
+    expect(getClientIntegration('asana')).toBeNull()
+  })
+
+  it('returns null for an inherited prototype key', () => {
+    expect(getClientIntegration('toString')).toBeNull()
+  })
+})

--- a/packages/client/integrations/platform/registry.ts
+++ b/packages/client/integrations/platform/registry.ts
@@ -1,0 +1,24 @@
+import azureDevOps from '../azureDevOps'
+import github from '../github'
+import gitlab from '../gitlab'
+import jira from '../jira'
+import jiraServer from '../jiraServer'
+import linear from '../linear'
+import type {ClientIntegrationDefinition} from './ClientIntegrationDefinition'
+
+export const clientIntegrations = {
+  azureDevOps,
+  github,
+  gitlab,
+  jira,
+  jiraServer,
+  linear
+} satisfies Record<string, ClientIntegrationDefinition>
+
+export type RegisteredClientIntegration = keyof typeof clientIntegrations
+
+const isRegistered = (service: string): service is RegisteredClientIntegration =>
+  Object.hasOwn(clientIntegrations, service)
+
+export const getClientIntegration = (service: string): ClientIntegrationDefinition | null =>
+  isRegistered(service) ? clientIntegrations[service] : null

--- a/packages/server/integrations/azureDevOps/index.ts
+++ b/packages/server/integrations/azureDevOps/index.ts
@@ -1,0 +1,41 @@
+import type {
+  IntegrationAuth,
+  IntegrationCtx,
+  ServerIntegrationDefinition
+} from '../platform/ServerIntegrationDefinition'
+import TaskIntegrationManagerFactory from '../TaskIntegrationManagerFactory'
+
+const resolveAuth = async (ctx: IntegrationCtx): Promise<IntegrationAuth | null> => {
+  const {dataLoader, teamId, userId} = ctx
+  const auth = await dataLoader
+    .get('teamMemberIntegrationAuthsByServiceTeamAndUserId')
+    .load({service: 'azureDevOps', teamId, userId})
+  if (!auth?.accessToken) return null
+  return {
+    accessToken: auth.accessToken,
+    accessUserId: auth.userId,
+    providerId: auth.providerId,
+    raw: auth
+  }
+}
+
+const azureDevOps: ServerIntegrationDefinition = {
+  service: 'azureDevOps',
+  title: 'Azure DevOps',
+  authStrategy: 'oauth2',
+  resolveAuth,
+  capabilities: {
+    issueCreate: {
+      initManager: (ctx) =>
+        TaskIntegrationManagerFactory.initManager(
+          ctx.dataLoader,
+          'azureDevOps',
+          {teamId: ctx.teamId, userId: ctx.userId},
+          ctx.context,
+          ctx.info
+        )
+    }
+  }
+}
+
+export default azureDevOps

--- a/packages/server/integrations/github/index.ts
+++ b/packages/server/integrations/github/index.ts
@@ -1,0 +1,34 @@
+import type {
+  IntegrationAuth,
+  IntegrationCtx,
+  ServerIntegrationDefinition
+} from '../platform/ServerIntegrationDefinition'
+import TaskIntegrationManagerFactory from '../TaskIntegrationManagerFactory'
+
+const resolveAuth = async (ctx: IntegrationCtx): Promise<IntegrationAuth | null> => {
+  const {dataLoader, teamId, userId} = ctx
+  const auth = await dataLoader.get('githubAuth').load({teamId, userId})
+  if (!auth?.accessToken) return null
+  return {accessToken: auth.accessToken, accessUserId: auth.userId, providerId: null, raw: auth}
+}
+
+const github: ServerIntegrationDefinition = {
+  service: 'github',
+  title: 'GitHub',
+  authStrategy: 'oauth2',
+  resolveAuth,
+  capabilities: {
+    issueCreate: {
+      initManager: (ctx) =>
+        TaskIntegrationManagerFactory.initManager(
+          ctx.dataLoader,
+          'github',
+          {teamId: ctx.teamId, userId: ctx.userId},
+          ctx.context,
+          ctx.info
+        )
+    }
+  }
+}
+
+export default github

--- a/packages/server/integrations/gitlab/index.ts
+++ b/packages/server/integrations/gitlab/index.ts
@@ -1,0 +1,39 @@
+import type {
+  IntegrationAuth,
+  IntegrationCtx,
+  ServerIntegrationDefinition
+} from '../platform/ServerIntegrationDefinition'
+import TaskIntegrationManagerFactory from '../TaskIntegrationManagerFactory'
+
+const resolveAuth = async (ctx: IntegrationCtx): Promise<IntegrationAuth | null> => {
+  const {dataLoader, teamId, userId} = ctx
+  const auth = await dataLoader.get('freshGitlabAuth').load({teamId, userId})
+  if (!auth?.accessToken) return null
+  return {
+    accessToken: auth.accessToken,
+    accessUserId: auth.userId,
+    providerId: auth.providerId,
+    raw: auth
+  }
+}
+
+const gitlab: ServerIntegrationDefinition = {
+  service: 'gitlab',
+  title: 'GitLab',
+  authStrategy: 'oauth2',
+  resolveAuth,
+  capabilities: {
+    issueCreate: {
+      initManager: (ctx) =>
+        TaskIntegrationManagerFactory.initManager(
+          ctx.dataLoader,
+          'gitlab',
+          {teamId: ctx.teamId, userId: ctx.userId},
+          ctx.context,
+          ctx.info
+        )
+    }
+  }
+}
+
+export default gitlab

--- a/packages/server/integrations/jira/index.ts
+++ b/packages/server/integrations/jira/index.ts
@@ -1,0 +1,34 @@
+import type {
+  IntegrationAuth,
+  IntegrationCtx,
+  ServerIntegrationDefinition
+} from '../platform/ServerIntegrationDefinition'
+import TaskIntegrationManagerFactory from '../TaskIntegrationManagerFactory'
+
+const resolveAuth = async (ctx: IntegrationCtx): Promise<IntegrationAuth | null> => {
+  const {dataLoader, teamId, userId} = ctx
+  const auth = await dataLoader.get('freshAtlassianAuth').load({teamId, userId})
+  if (!auth?.accessToken) return null
+  return {accessToken: auth.accessToken, accessUserId: auth.userId, providerId: null, raw: auth}
+}
+
+const jira: ServerIntegrationDefinition = {
+  service: 'jira',
+  title: 'Jira',
+  authStrategy: 'oauth2',
+  resolveAuth,
+  capabilities: {
+    issueCreate: {
+      initManager: (ctx) =>
+        TaskIntegrationManagerFactory.initManager(
+          ctx.dataLoader,
+          'jira',
+          {teamId: ctx.teamId, userId: ctx.userId},
+          ctx.context,
+          ctx.info
+        )
+    }
+  }
+}
+
+export default jira

--- a/packages/server/integrations/jiraServer/index.ts
+++ b/packages/server/integrations/jiraServer/index.ts
@@ -1,0 +1,41 @@
+import type {
+  IntegrationAuth,
+  IntegrationCtx,
+  ServerIntegrationDefinition
+} from '../platform/ServerIntegrationDefinition'
+import TaskIntegrationManagerFactory from '../TaskIntegrationManagerFactory'
+
+const resolveAuth = async (ctx: IntegrationCtx): Promise<IntegrationAuth | null> => {
+  const {dataLoader, teamId, userId} = ctx
+  const auth = await dataLoader
+    .get('teamMemberIntegrationAuthsByServiceTeamAndUserId')
+    .load({service: 'jiraServer', teamId, userId})
+  if (!auth?.accessToken) return null
+  return {
+    accessToken: auth.accessToken,
+    accessUserId: auth.userId,
+    providerId: auth.providerId,
+    raw: auth
+  }
+}
+
+const jiraServer: ServerIntegrationDefinition = {
+  service: 'jiraServer',
+  title: 'Jira Data Center',
+  authStrategy: 'oauth1',
+  resolveAuth,
+  capabilities: {
+    issueCreate: {
+      initManager: (ctx) =>
+        TaskIntegrationManagerFactory.initManager(
+          ctx.dataLoader,
+          'jiraServer',
+          {teamId: ctx.teamId, userId: ctx.userId},
+          ctx.context,
+          ctx.info
+        )
+    }
+  }
+}
+
+export default jiraServer

--- a/packages/server/integrations/linear/index.ts
+++ b/packages/server/integrations/linear/index.ts
@@ -1,0 +1,39 @@
+import type {
+  IntegrationAuth,
+  IntegrationCtx,
+  ServerIntegrationDefinition
+} from '../platform/ServerIntegrationDefinition'
+import TaskIntegrationManagerFactory from '../TaskIntegrationManagerFactory'
+
+const resolveAuth = async (ctx: IntegrationCtx): Promise<IntegrationAuth | null> => {
+  const {dataLoader, teamId, userId} = ctx
+  const auth = await dataLoader.get('freshLinearAuth').load({teamId, userId})
+  if (!auth?.accessToken) return null
+  return {
+    accessToken: auth.accessToken,
+    accessUserId: auth.userId,
+    providerId: auth.providerId,
+    raw: auth
+  }
+}
+
+const linear: ServerIntegrationDefinition = {
+  service: 'linear',
+  title: 'Linear',
+  authStrategy: 'oauth2',
+  resolveAuth,
+  capabilities: {
+    issueCreate: {
+      initManager: (ctx) =>
+        TaskIntegrationManagerFactory.initManager(
+          ctx.dataLoader,
+          'linear',
+          {teamId: ctx.teamId, userId: ctx.userId},
+          ctx.context,
+          ctx.info
+        )
+    }
+  }
+}
+
+export default linear

--- a/packages/server/integrations/platform/ServerIntegrationDefinition.ts
+++ b/packages/server/integrations/platform/ServerIntegrationDefinition.ts
@@ -1,0 +1,67 @@
+import type {GraphQLResolveInfo} from 'graphql'
+import type {DataLoaderWorker, GQLContext} from '../../graphql/graphql'
+import type {
+  IntegrationProviderServiceEnumType,
+  TaskIntegrationManager
+} from '../TaskIntegrationManagerFactory'
+
+export interface IntegrationCtx {
+  dataLoader: DataLoaderWorker
+  teamId: string
+  userId: string
+}
+
+export interface GqlIntegrationCtx extends IntegrationCtx {
+  context: GQLContext
+  info: GraphQLResolveInfo
+}
+
+export interface IntegrationAuth {
+  accessToken: string
+  accessUserId: string
+  providerId: number | null
+  raw: unknown
+}
+
+export interface IssueCreateCapability {
+  initManager(ctx: GqlIntegrationCtx): Promise<TaskIntegrationManager | null>
+}
+
+export interface IssueReadCapability {
+  getIssue(ctx: GqlIntegrationCtx, issueId: string): Promise<unknown>
+}
+
+export interface IssueSearchCapability {
+  persistQueries: boolean
+}
+
+export interface RepoListCapability {
+  fetchRepos(ctx: GqlIntegrationCtx): Promise<unknown[]>
+}
+
+export interface EstimatePushCapability {
+  targets: Array<'comment' | 'field' | 'label'>
+}
+
+export interface WorkItemsCapability {
+  getUserWorkItems(ctx: GqlIntegrationCtx): Promise<unknown[]>
+}
+
+export interface ServerIntegrationCapabilities {
+  issueCreate?: IssueCreateCapability
+  issueRead?: IssueReadCapability
+  issueSearch?: IssueSearchCapability
+  repoList?: RepoListCapability
+  estimatePush?: EstimatePushCapability
+  workItems?: WorkItemsCapability
+}
+
+export type IntegrationCapabilityKey = keyof ServerIntegrationCapabilities
+
+export interface ServerIntegrationDefinition {
+  service: IntegrationProviderServiceEnumType
+  title: string
+  authStrategy: 'oauth1' | 'oauth2' | 'pat' | 'webhook'
+  resolveAuth(ctx: IntegrationCtx): Promise<IntegrationAuth | null>
+  capabilities: ServerIntegrationCapabilities
+}

--- a/packages/server/integrations/platform/__tests__/conformance.test.ts
+++ b/packages/server/integrations/platform/__tests__/conformance.test.ts
@@ -1,0 +1,11 @@
+jest.mock('../../TaskIntegrationManagerFactory', () => ({
+  __esModule: true,
+  default: {initManager: jest.fn()}
+}))
+
+import {describeServerIntegrationConformance} from '../conformance/describeServerIntegrationConformance'
+import {serverIntegrations} from '../registry'
+
+describe('server integration conformance', () => {
+  Object.values(serverIntegrations).forEach(describeServerIntegrationConformance)
+})

--- a/packages/server/integrations/platform/__tests__/registry.test.ts
+++ b/packages/server/integrations/platform/__tests__/registry.test.ts
@@ -1,0 +1,62 @@
+jest.mock('../../TaskIntegrationManagerFactory', () => ({
+  __esModule: true,
+  default: {initManager: jest.fn()}
+}))
+
+import {deriveCapabilityKeys} from '../capabilities'
+import {getServerIntegration, serverIntegrations} from '../registry'
+import type {IntegrationCapabilityKey} from '../ServerIntegrationDefinition'
+
+const KNOWN_CAPABILITIES: IntegrationCapabilityKey[] = [
+  'issueCreate',
+  'issueRead',
+  'issueSearch',
+  'repoList',
+  'estimatePush',
+  'workItems'
+]
+
+describe('serverIntegrations registry', () => {
+  const entries = Object.entries(serverIntegrations)
+
+  it('registers exactly the six task services', () => {
+    expect(Object.keys(serverIntegrations).sort()).toEqual([
+      'azureDevOps',
+      'github',
+      'gitlab',
+      'jira',
+      'jiraServer',
+      'linear'
+    ])
+  })
+
+  it.each(entries)('%s: service field matches its registry key', (key, def) => {
+    expect(def.service).toBe(key)
+  })
+
+  it.each(entries)('%s: has a non-empty title', (_key, def) => {
+    expect(def.title.length).toBeGreaterThan(0)
+  })
+
+  it.each(entries)('%s: declares only known capability keys', (_key, def) => {
+    for (const capability of deriveCapabilityKeys(def)) {
+      expect(KNOWN_CAPABILITIES).toContain(capability)
+    }
+  })
+
+  it.each(entries)('%s: declares issueCreate', (_key, def) => {
+    expect(def.capabilities.issueCreate).toBeDefined()
+  })
+
+  it('getServerIntegration returns null for an unknown service', () => {
+    expect(getServerIntegration('asana')).toBeNull()
+  })
+
+  it('getServerIntegration resolves a known service', () => {
+    expect(getServerIntegration('jira')).toBe(serverIntegrations.jira)
+  })
+
+  it('getServerIntegration returns null for an inherited prototype key', () => {
+    expect(getServerIntegration('toString')).toBeNull()
+  })
+})

--- a/packages/server/integrations/platform/capabilities.ts
+++ b/packages/server/integrations/platform/capabilities.ts
@@ -1,0 +1,11 @@
+import type {
+  IntegrationCapabilityKey,
+  ServerIntegrationDefinition
+} from './ServerIntegrationDefinition'
+
+export const deriveCapabilityKeys = (
+  def: ServerIntegrationDefinition
+): IntegrationCapabilityKey[] => {
+  const keys = Object.keys(def.capabilities) as IntegrationCapabilityKey[]
+  return keys.filter((key) => def.capabilities[key] !== undefined)
+}

--- a/packages/server/integrations/platform/conformance/describeServerIntegrationConformance.ts
+++ b/packages/server/integrations/platform/conformance/describeServerIntegrationConformance.ts
@@ -1,0 +1,20 @@
+import type {ServerIntegrationDefinition} from '../ServerIntegrationDefinition'
+
+const AUTH_STRATEGIES = ['oauth1', 'oauth2', 'pat', 'webhook']
+
+export const describeServerIntegrationConformance = (def: ServerIntegrationDefinition) => {
+  describe(`${def.service} conformance`, () => {
+    it('has a valid authStrategy', () => {
+      expect(AUTH_STRATEGIES).toContain(def.authStrategy)
+    })
+
+    it('declares at least one capability', () => {
+      expect(Object.keys(def.capabilities).length).toBeGreaterThan(0)
+    })
+
+    it('exposes resolveAuth as a function of arity 1', () => {
+      expect(typeof def.resolveAuth).toBe('function')
+      expect(def.resolveAuth.length).toBe(1)
+    })
+  })
+}

--- a/packages/server/integrations/platform/registry.ts
+++ b/packages/server/integrations/platform/registry.ts
@@ -1,0 +1,24 @@
+import azureDevOps from '../azureDevOps'
+import github from '../github'
+import gitlab from '../gitlab'
+import jira from '../jira'
+import jiraServer from '../jiraServer'
+import linear from '../linear'
+import type {ServerIntegrationDefinition} from './ServerIntegrationDefinition'
+
+export const serverIntegrations = {
+  azureDevOps,
+  github,
+  gitlab,
+  jira,
+  jiraServer,
+  linear
+} satisfies Record<string, ServerIntegrationDefinition>
+
+export type RegisteredServerIntegration = keyof typeof serverIntegrations
+
+const isRegistered = (service: string): service is RegisteredServerIntegration =>
+  Object.hasOwn(serverIntegrations, service)
+
+export const getServerIntegration = (service: string): ServerIntegrationDefinition | null =>
+  isRegistered(service) ? serverIntegrations[service] : null

--- a/packages/server/jest.config.js
+++ b/packages/server/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
   transformIgnorePatterns: ['/marked\.esm\.js/'],
   modulePaths: ['<rootDir>/packages/'],
   moduleNameMapper: {
-    'server/(.*)': ['<rootDir>/$1'],
+    '^server/(.*)': ['<rootDir>/$1'],
     'parabol-client/(.*)': ['<rootDir>/../client/$1'],
     '~/(.*)': ['<rootDir>/../client/$1']
   },


### PR DESCRIPTION
# Description

Adding a task integration today means touching ~40 switch sites spread across the codebase. This PR is the first step (P0) of the integration architecture refactor: give the app a single source of truth for "what integrations exist and what can each one do."

## What

- Typed contracts: `ServerIntegrationDefinition` and `ClientIntegrationDefinition`
- One definition per service (Jira, Jira Data Center, GitHub, GitLab, Azure DevOps, Linear) on each side. They are thin adapters that delegate to the existing managers, dataloaders, and gqlId codecs
- A registry per side, plus a structural conformance suite (auth strategy, capability keys, codec round-trips) that every service must pass

**Nothing consumes this interface (these registries) yet — there is zero effect on the running
system.**

The diff is all new files except two one-line test-infra fixes (anchoring an unanchored jest `moduleNameMapper` regex, widening a biome jest-globals glob) needed to run the new tests.

## Next step(s)

We're going to chip away at this refactoring, aiming to cause no regressions along the way.

The next PR will pick one behavior, issue creation, and route it through the registry: the mutation that currently does a per-service `switch` to pick the right manager will instead look up the service's definition and call its `issueCreate` capability. 

Follow-up PRs will repeat that pattern for the other behaviors (`issueRead`, `issueSearch`,
`estimatePush`, …), filling in each capability's per-service implementation as its switch is removed. Once all sites are converted, adding a new integration means writing one definition file instead of editing dozens of dispatch sites.
