### PR TITLE
fix: mailgun attachments, cid images inlined

### DIFF
--- a/packages/server/__tests__/MailManagerMailgun.test.ts
+++ b/packages/server/__tests__/MailManagerMailgun.test.ts
@@ -1,3 +1,7 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
 const mockCreate = jest.fn()
 
 jest.mock('mailgun.js', () => ({
@@ -7,7 +11,10 @@ jest.mock('mailgun.js', () => ({
   }))
 }))
 
+jest.mock('../utils/logError', () => ({__esModule: true, default: jest.fn()}))
+
 import MailManagerMailgun from '../email/MailManagerMailgun'
+import logError from '../utils/logError'
 
 const makeOptions = () => ({
   to: 'user@example.com',
@@ -18,10 +25,17 @@ const makeOptions = () => ({
 
 describe('MailManagerMailgun', () => {
   let manager: MailManagerMailgun
+  let tmpDir: string
 
   beforeEach(() => {
+    mockCreate.mockReset()
     mockCreate.mockResolvedValue({id: 'test-id', status: 200})
     manager = new MailManagerMailgun()
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mailgun-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, {recursive: true, force: true})
   })
 
   it("sends the plaintext body as Mailgun's `text` parameter", async () => {
@@ -30,17 +44,83 @@ describe('MailManagerMailgun', () => {
 
     const [, payload] = mockCreate.mock.calls[0]!
     expect(payload.text).toBe(options.body)
-    // `body` is not a Mailgun parameter; sending it drops the text/plain part
     expect(payload).not.toHaveProperty('body')
   })
 
-  it("sends attachments as Mailgun's `attachment` parameter", async () => {
-    const attachments = [{filename: 'summary.pdf', path: '/tmp/summary.pdf', cid: 'cid1'}]
+  it('sends file attachments as `attachment` with the file bytes as `data`', async () => {
+    const filePath = path.join(tmpDir, 'summary.pdf')
+    fs.writeFileSync(filePath, 'PDF BYTES')
+    const attachments = [{filename: 'summary.pdf', path: filePath}]
+
+    const success = await manager.sendEmail({...makeOptions(), attachments})
+
+    expect(success).toBe(true)
+    const [, payload] = mockCreate.mock.calls[0]!
+    expect(payload).not.toHaveProperty('attachments')
+    expect(payload.inline).toBeUndefined()
+    expect(payload.attachment).toHaveLength(1)
+    const [file] = payload.attachment
+    expect(file.filename).toBe('summary.pdf')
+    expect(file.contentType).toBe('application/pdf')
+    expect(Buffer.isBuffer(file.data)).toBe(true)
+    expect(file.data.toString()).toBe('PDF BYTES')
+    expect(file).not.toHaveProperty('path')
+  })
+
+  it('sends attachments with a `cid` as `inline`, named by the cid so `cid:` references resolve', async () => {
+    const filePath = path.join(tmpDir, 'logo.png')
+    fs.writeFileSync(filePath, 'PNG BYTES')
+    const attachments = [{filename: 'logo.png', path: filePath, cid: 'logo'}]
+
     await manager.sendEmail({...makeOptions(), attachments})
 
     const [, payload] = mockCreate.mock.calls[0]!
-    expect(payload.attachment).toBe(attachments)
-    expect(payload).not.toHaveProperty('attachments')
+    expect(payload.attachment).toBeUndefined()
+    expect(payload.inline).toHaveLength(1)
+    const [file] = payload.inline
+    expect(file.filename).toBe('logo')
+    expect(file.contentType).toBe('image/png')
+    expect(file.data.toString()).toBe('PNG BYTES')
+  })
+
+  it('splits a mixed list into `attachment` and `inline`', async () => {
+    const pdfPath = path.join(tmpDir, 'summary.pdf')
+    const pngPath = path.join(tmpDir, 'logo.png')
+    fs.writeFileSync(pdfPath, 'PDF')
+    fs.writeFileSync(pngPath, 'PNG')
+
+    await manager.sendEmail({
+      ...makeOptions(),
+      attachments: [
+        {filename: 'summary.pdf', path: pdfPath},
+        {filename: 'logo.png', path: pngPath, cid: 'logo'}
+      ]
+    })
+
+    const [, payload] = mockCreate.mock.calls[0]!
+    expect(payload.attachment.map((f: {filename: string}) => f.filename)).toEqual(['summary.pdf'])
+    expect(payload.inline.map((f: {filename: string}) => f.filename)).toEqual(['logo'])
+  })
+
+  it('omits `attachment` and `inline` when there are no attachments', async () => {
+    await manager.sendEmail(makeOptions())
+
+    const [, payload] = mockCreate.mock.calls[0]!
+    expect(payload.attachment).toBeUndefined()
+    expect(payload.inline).toBeUndefined()
+  })
+
+  it('returns false and logs when an attachment file cannot be read', async () => {
+    const attachments = [{filename: 'missing.pdf', path: path.join(tmpDir, 'missing.pdf')}]
+
+    const success = await manager.sendEmail({...makeOptions(), attachments})
+
+    expect(success).toBe(false)
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(logError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({tags: expect.objectContaining({type: 'Mailgun error'})})
+    )
   })
 
   it('passes the domain, recipients, subject, html and tags through unchanged', async () => {

--- a/packages/server/email/MailManager.ts
+++ b/packages/server/email/MailManager.ts
@@ -1,7 +1,7 @@
-interface Attachment {
+export interface Attachment {
   filename: string
   path: string
-  cid: string
+  cid?: string
 }
 
 export interface MailManagerOptions {

--- a/packages/server/email/MailManagerMailgun.ts
+++ b/packages/server/email/MailManagerMailgun.ts
@@ -1,7 +1,30 @@
 import FormData from 'form-data'
+import fs from 'fs'
 import Mailgun from 'mailgun.js'
+import mime from 'mime-types'
 import logError from '../utils/logError'
-import MailManager, {type MailManagerOptions} from './MailManager'
+import MailManager, {type Attachment, type MailManagerOptions} from './MailManager'
+
+interface MailgunFile {
+  filename: string
+  data: Buffer
+  contentType?: string
+}
+
+const toMailgunFile = async ({filename, path, cid}: Attachment): Promise<MailgunFile> => ({
+  filename: cid ?? filename,
+  data: await fs.promises.readFile(path),
+  contentType: mime.lookup(filename) || undefined
+})
+
+const toMailgunFiles = async (attachments: Attachment[]) => {
+  const inline = await Promise.all(attachments.filter((a) => a.cid).map(toMailgunFile))
+  const attachment = await Promise.all(attachments.filter((a) => !a.cid).map(toMailgunFile))
+  return {
+    inline: inline.length ? inline : undefined,
+    attachment: attachment.length ? attachment : undefined
+  }
+}
 
 export default class MailManagerMailgun extends MailManager {
   mailgun = new Mailgun(FormData)
@@ -14,13 +37,15 @@ export default class MailManagerMailgun extends MailManager {
     const toArr = Array.isArray(to) ? to : [to]
     const toStr = toArr.join(',')
     try {
+      const {attachment, inline} = await toMailgunFiles(attachments ?? [])
       await this.mailgunClient.messages.create(process.env.MAILGUN_DOMAIN!, {
         to: toStr,
         from: process.env.MAIL_FROM,
         subject,
         html,
         text: body,
-        attachment: attachments,
+        attachment,
+        inline,
         'o:tag': tags
       })
     } catch (e) {


### PR DESCRIPTION
While reviewing the mailgun path, I found some more bugs.

The `Attachment` interface was designed fore nodemailer and the Mailgun adapter was never written to handle the translation for attachments. This bug goes all the way back to 2020!

MailManagerMailgun forwarded the nodemailer-shaped Attachment ({filename, path, cid}) as mailgun.js's attachment. In mailgun.js@9.4.1, FormDataBuilder.addFilesToFD reads only data (Buffer/stream) + filename/contentType; path and cid are ignored, and form-data accepts undefined without complaint.

I've made the fixes here.