### PR TITLE
fix: accept private Slack channels at install time

### DIFF
--- a/packages/client/components/ShareTopicModal.tsx
+++ b/packages/client/components/ShareTopicModal.tsx
@@ -92,7 +92,7 @@ const ShareTopicModal = (props: Props) => {
   const slack = meeting?.viewerMeetingMember?.teamMember.integrations.slack ?? null
   const isSlackConnected = slack?.isActive
   const slackDefaultTeamChannelId = slack?.defaultTeamChannelId
-  const slackChannels = useSlackChannels(slack)
+  const {channels: slackChannels} = useSlackChannels(slack)
   const channelsLoading = slackChannels.length === 0 && isSlackConnected
   const isLoading = slackOAuthSubmitting || shareTopicSubmitting
 

--- a/packages/client/components/SlackChannelDropdown.tsx
+++ b/packages/client/components/SlackChannelDropdown.tsx
@@ -2,6 +2,8 @@ import type * as React from 'react'
 import type {MenuProps} from '../hooks/useMenu'
 import Menu from './Menu'
 import MenuItem from './MenuItem'
+import MenuItemHR from './MenuItemHR'
+import SlackPrivateChannelHint from './SlackPrivateChannelHint'
 
 export type SlackChannelDropdownChannels = {id: string; name: string}[]
 export type SlackChannelDropdownOnClick = (
@@ -26,6 +28,8 @@ const SlackChannelDropdown = (props: Props) => {
       {channels.map((channel) => {
         return <MenuItem key={channel.id!} label={channel.name} onClick={onClick(channel.id)} />
       })}
+      <MenuItemHR />
+      <SlackPrivateChannelHint />
     </Menu>
   )
 }

--- a/packages/client/components/SlackPrivateChannelHint.tsx
+++ b/packages/client/components/SlackPrivateChannelHint.tsx
@@ -1,0 +1,11 @@
+import {forwardRef} from 'react'
+
+const SlackPrivateChannelHint = forwardRef<HTMLDivElement>((_props, ref) => (
+  <div ref={ref} className='max-w-72 whitespace-normal px-4 py-1 text-fg-muted text-xs leading-5'>
+    Don't see a private channel? In Slack, run{' '}
+    <code className='rounded bg-surface-well px-1'>/invite @Parabol</code> in that channel, then
+    reopen this list.
+  </div>
+))
+
+export default SlackPrivateChannelHint

--- a/packages/client/hooks/useSlackChannels.ts
+++ b/packages/client/hooks/useSlackChannels.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 import type {SlackChannelDropdownChannels} from '../components/SlackChannelDropdown'
 import SlackClientManager from '../utils/SlackClientManager'
 
@@ -11,6 +11,8 @@ const useSlackChannels = (
   slackAuth: {botAccessToken: string | null | undefined; slackUserId: string} | null | undefined
 ) => {
   const [channels, setChannels] = useState<SlackChannelDropdownChannels>([])
+  const [fetchCount, setFetchCount] = useState(0)
+  const refetch = useCallback(() => setFetchCount((count) => count + 1), [])
   useEffect(() => {
     if (!slackAuth || !slackAuth.botAccessToken) return
     let isMounted = true
@@ -47,8 +49,8 @@ const useSlackChannels = (
     return () => {
       isMounted = false
     }
-  }, [slackAuth])
-  return channels
+  }, [slackAuth, fetchCount])
+  return {channels, refetch}
 }
 
 export default useSlackChannels

--- a/packages/client/modules/teamDashboard/components/ProviderRow/SlackChannelPicker.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/SlackChannelPicker.tsx
@@ -1,3 +1,4 @@
+import type * as React from 'react'
 import DropdownMenuToggle from '../../../../components/DropdownMenuToggle'
 import type {
   SlackChannelDropdownChannels,
@@ -15,6 +16,7 @@ interface Props {
   channels: SlackChannelDropdownChannels
   localChannelId: string | null
   onClick: SlackChannelDropdownOnClick
+  onOpen: () => void
   teamId: string
 }
 
@@ -33,7 +35,7 @@ enum ChannelState {
 }
 
 const SlackChannelPicker = (props: Props) => {
-  const {isTokenValid, channels, localChannelId, onClick, teamId} = props
+  const {isTokenValid, channels, localChannelId, onClick, onOpen, teamId} = props
   const activeIdx = localChannelId
     ? channels.findIndex((channel) => channel.id === localChannelId)
     : -1
@@ -58,7 +60,10 @@ const SlackChannelPicker = (props: Props) => {
   const mutationProps = useMutationProps()
   const handleClick =
     channelState !== ChannelState.error
-      ? togglePortal
+      ? (e?: React.MouseEvent | React.TouchEvent) => {
+          onOpen()
+          togglePortal(e)
+        }
       : () => {
           SlackClientManager.openOAuth(atmosphere, teamId, mutationProps)
         }

--- a/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationList.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationList.tsx
@@ -58,7 +58,7 @@ const SlackNotificationList = (props: Props) => {
   const {integrations} = teamMember!
   const {slack} = integrations
   const notifications = slack?.notifications ?? []
-  const channels = useSlackChannels(slack)
+  const {channels, refetch: refetchChannels} = useSlackChannels(slack)
   const {submitting, onError, onCompleted, submitMutation, error} = useMutationProps()
   const atmosphere = useAtmosphere()
   const localPrivateChannel = channels.find((channel) => channel.name === '@Parabol')
@@ -107,6 +107,7 @@ const SlackNotificationList = (props: Props) => {
           isTokenValid={isActive}
           localChannelId={defaultTeamChannelId}
           onClick={changeTeamChannel}
+          onOpen={refetchChannels}
           teamId={teamId}
         />
       </div>

--- a/packages/server/graphql/mutations/helpers/__tests__/joinSlackChannel.test.ts
+++ b/packages/server/graphql/mutations/helpers/__tests__/joinSlackChannel.test.ts
@@ -1,0 +1,55 @@
+import joinSlackChannel from '../joinSlackChannel'
+
+const makeManager = (opts: {
+  info?:
+    | {ok: true; channel: {id: string; is_member: boolean; is_archived: boolean}}
+    | {ok: false; error: string}
+  join?: {ok: true; channel: {id: string}} | {ok: false; error: string}
+}) => {
+  const getConversationInfo = jest.fn().mockResolvedValue(opts.info)
+  const joinConversation = jest.fn().mockResolvedValue(opts.join)
+  return {getConversationInfo, joinConversation}
+}
+
+const channel = (overrides: Partial<{is_member: boolean; is_archived: boolean}> = {}) => ({
+  ok: true as const,
+  channel: {id: 'C123', is_member: false, is_archived: false, ...overrides}
+})
+
+describe('joinSlackChannel', () => {
+  it('uses a channel the bot is already a member of without calling join', async () => {
+    const manager = makeManager({info: channel({is_member: true})})
+    const res = await joinSlackChannel(manager, 'C123')
+    expect(res).toEqual({ok: true, channelId: 'C123'})
+    expect(manager.joinConversation).not.toHaveBeenCalled()
+  })
+
+  it('joins a public channel the bot is not yet a member of', async () => {
+    const manager = makeManager({info: channel(), join: {ok: true, channel: {id: 'C123'}}})
+    const res = await joinSlackChannel(manager, 'C123')
+    expect(res).toEqual({ok: true, channelId: 'C123'})
+    expect(manager.joinConversation).toHaveBeenCalledWith('C123')
+  })
+
+  it('fails when the bot cannot see the channel (private channel it was not invited to)', async () => {
+    const manager = makeManager({info: {ok: false, error: 'channel_not_found'}})
+    const res = await joinSlackChannel(manager, 'G999')
+    expect(res).toEqual({ok: false, error: 'channel_not_found'})
+    expect(manager.joinConversation).not.toHaveBeenCalled()
+  })
+
+  it('fails on an archived channel', async () => {
+    const manager = makeManager({info: channel({is_member: true, is_archived: true})})
+    const res = await joinSlackChannel(manager, 'C123')
+    expect(res).toEqual({ok: false, error: 'Slack channel archived'})
+  })
+
+  it('fails when join is rejected', async () => {
+    const manager = makeManager({
+      info: channel(),
+      join: {ok: false, error: 'method_not_supported_for_channel_type'}
+    })
+    const res = await joinSlackChannel(manager, 'C123')
+    expect(res).toEqual({ok: false, error: 'Unable to join slack channel'})
+  })
+})

--- a/packages/server/graphql/mutations/helpers/joinSlackChannel.ts
+++ b/packages/server/graphql/mutations/helpers/joinSlackChannel.ts
@@ -1,0 +1,29 @@
+import type SlackManager from 'parabol-client/utils/SlackManager'
+
+type JoinSlackChannelResult = {ok: true; channelId: string} | {ok: false; error: string}
+
+type ChannelManager = Pick<SlackManager, 'getConversationInfo' | 'joinConversation'>
+
+const joinSlackChannel = async (
+  manager: ChannelManager,
+  channelId: string
+): Promise<JoinSlackChannelResult> => {
+  const channelInfo = await manager.getConversationInfo(channelId)
+  if (!channelInfo.ok) {
+    return {ok: false, error: channelInfo.error}
+  }
+  const {channel} = channelInfo
+  if (channel.is_archived) {
+    return {ok: false, error: 'Slack channel archived'}
+  }
+  if (channel.is_member) {
+    return {ok: true, channelId: channel.id}
+  }
+  const joinConvoRes = await manager.joinConversation(channelId)
+  if (!joinConvoRes.ok) {
+    return {ok: false, error: 'Unable to join slack channel'}
+  }
+  return {ok: true, channelId: joinConvoRes.channel.id}
+}
+
+export default joinSlackChannel

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -19,6 +19,7 @@ import logError from '../../../../utils/logError'
 import SlackServerManager from '../../../../utils/SlackServerManager'
 import {convertToMarkdown} from '../../../../utils/tiptap/convertToMarkdown'
 import type {DataLoaderWorker} from '../../../graphql'
+import joinSlackChannel from '../joinSlackChannel'
 import getSummaryText from './getSummaryText'
 import {makeButtons, makeHeader, makeSection, makeSections} from './makeSlackBlocks'
 import type {NotificationIntegrationHelper} from './NotificationIntegrationHelper'
@@ -42,7 +43,7 @@ const handleError = async (
   const {channelId, auth} = notificationChannel
   if ('error' in res) {
     const {error} = res
-    if (error === 'channel_not_found') {
+    if (error === 'channel_not_found' || error === 'not_in_channel') {
       await getKysely()
         .updateTable('SlackNotification')
         .set({channelId: null})
@@ -50,9 +51,9 @@ const handleError = async (
         .where('channelId', '=', channelId)
         .execute()
       return {
-        error: new Error('channel_not_found')
+        error: new Error(error)
       }
-    } else if (error === 'not_in_channel' || error === 'invalid_auth') {
+    } else if (error === 'invalid_auth') {
       logError(new Error(`Slack Channel Notification Error: ${teamId}, ${channelId}, ${auth.id}`))
       return {
         error: new Error(error)
@@ -81,7 +82,12 @@ const notifySlack = async (
   const {channelId, auth} = notificationChannel
   const {botAccessToken} = auth
   const manager = new SlackServerManager(botAccessToken!)
-  const res = await manager.postMessage(channelId!, slackMessage, notificationText, ts)
+  const post = () => manager.postMessage(channelId!, slackMessage, notificationText, ts)
+  let res = await post()
+  if (!res.ok && res.error === 'not_in_channel') {
+    const joinRes = await manager.joinConversation(channelId!)
+    if (joinRes.ok) res = await post()
+  }
   analytics.slackNotificationSent(user, teamId, event, reflectionGroupId)
 
   return res
@@ -621,21 +627,9 @@ export const SlackNotifier = {
 
     const {botAccessToken} = slackAuth
     const manager = new SlackServerManager(botAccessToken!)
-
-    const channelInfo = await manager.getConversationInfo(channelId)
-    if (!channelInfo.ok) {
-      throw new Error(channelInfo.error)
-    }
-    const {channel} = channelInfo
-    const {is_member: isMember, is_archived: isArchived} = channel
-    if (isArchived) {
-      throw new Error('Slack channel archived')
-    }
-    if (!isMember) {
-      const joinConvoRes = await manager.joinConversation(channelId)
-      if (!joinConvoRes.ok) {
-        throw new Error('Unable to join slack channel')
-      }
+    const joinRes = await joinSlackChannel(manager, channelId)
+    if (!joinRes.ok) {
+      throw new Error(joinRes.error)
     }
 
     const topic = reflectionGroup.title

--- a/packages/server/graphql/public/mutations/addSlackAuth.ts
+++ b/packages/server/graphql/public/mutations/addSlackAuth.ts
@@ -6,6 +6,7 @@ import {getUserId} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import SlackServerManager from '../../../utils/SlackServerManager'
 import standardError from '../../../utils/standardError'
+import joinSlackChannel from '../../mutations/helpers/joinSlackChannel'
 import type {MutationResolvers} from '../resolverTypes'
 import {slackNotificationEventTypeLookup} from '../types/SlackNotification'
 
@@ -92,8 +93,8 @@ const addSlackAuth: MutationResolvers['addSlackAuth'] = async (
   const {response} = manager
   const slackUserId = response.authed_user.id
   const defaultChannelId = response.incoming_webhook.channel_id
-  const [joinConvoRes, userInfoRes, viewer] = await Promise.all([
-    manager.joinConversation(defaultChannelId),
+  const [joinRes, userInfoRes, viewer] = await Promise.all([
+    joinSlackChannel(manager, defaultChannelId),
     manager.getUserInfo(slackUserId),
     dataLoader.get('users').loadNonNull(viewerId)
   ])
@@ -101,9 +102,8 @@ const addSlackAuth: MutationResolvers['addSlackAuth'] = async (
     return standardError(new Error(userInfoRes.error), {userId: viewerId})
   }
 
-  // The default channel could be anything: public, private, im, mpim. Only allow public channels or the @Parabol channel
-  // Using the slackUserId sends a DM to the user from @Parabol
-  const teamChannelId = joinConvoRes.ok ? joinConvoRes.channel.id : slackUserId
+  // If the bot can't post to the chosen channel (e.g. a private channel it wasn't invited to), DM the user from @Parabol instead
+  const teamChannelId = joinRes.ok ? joinRes.channelId : slackUserId
 
   const [, slackAuthId] = await Promise.all([
     upsertNotifications(viewerId, teamId, teamChannelId, defaultChannelId),

--- a/packages/server/graphql/public/mutations/setDefaultSlackChannel.ts
+++ b/packages/server/graphql/public/mutations/setDefaultSlackChannel.ts
@@ -2,6 +2,7 @@ import getKysely from '../../../postgres/getKysely'
 import {getUserId} from '../../../utils/authorization'
 import SlackServerManager from '../../../utils/SlackServerManager'
 import standardError from '../../../utils/standardError'
+import joinSlackChannel from '../../mutations/helpers/joinSlackChannel'
 import type {MutationResolvers} from '../resolverTypes'
 
 const setDefaultSlackChannel: MutationResolvers['setDefaultSlackChannel'] = async (
@@ -20,30 +21,13 @@ const setDefaultSlackChannel: MutationResolvers['setDefaultSlackChannel'] = asyn
     })
   }
   const {id: slackAuthId, botAccessToken, defaultTeamChannelId, slackUserId} = slackAuth
-  const manager = new SlackServerManager(botAccessToken!)
-  const channelInfo = await manager.getConversationInfo(slackChannelId)
 
   // should either be a public / private channel or the slackUserId if messaging from @Parabol
   if (slackChannelId !== slackUserId) {
-    if (!channelInfo.ok) {
-      return standardError(new Error(channelInfo.error), {
-        userId: viewerId
-      })
-    }
-    const {channel} = channelInfo
-    const {id: channelId, is_member: isMember, is_archived: isArchived} = channel
-    if (isArchived) {
-      return standardError(new Error('Slack channel archived'), {
-        userId: viewerId
-      })
-    }
-    if (!isMember) {
-      const joinConvoRes = await manager.joinConversation(channelId)
-      if (!joinConvoRes.ok) {
-        return standardError(new Error('Unable to join slack channel'), {
-          userId: viewerId
-        })
-      }
+    const manager = new SlackServerManager(botAccessToken!)
+    const joinRes = await joinSlackChannel(manager, slackChannelId)
+    if (!joinRes.ok) {
+      return standardError(new Error(joinRes.error), {userId: viewerId})
     }
   }
 


### PR DESCRIPTION
addSlackAuth probed channel membership with conversations.join, which Slack only supports for public channels, so a private channel picked on the install screen always fell back to DMing the user. Share one info→is_member→join helper across addSlackAuth/setDefaultSlackChannel/ shareTopic, retry once after joining on not_in_channel, and hint users to /invite @Parabol from the channel picker.

## Demo

<img width="314" height="294" alt="image" src="https://github.com/user-attachments/assets/50443caf-80e6-4d80-b683-08cfeee1a657" />

##  Description

Fixed #13378

