### PR TITLE
fix: Activity Library card tooltip text invisible in light mode

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibraryCardDescription.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryCardDescription.tsx
@@ -141,7 +141,7 @@ export const ActivityLibraryCardDescription = (props: Props) => {
   return (
     <ScrollArea.Root className={cn('flex-1 overflow-auto', className)}>
       <ScrollArea.Viewport>
-        <div className='flex flex-1 flex-col gap-y-1 px-2 py-1 text-fg-primary'>
+        <div className='flex flex-1 flex-col gap-y-1 px-2 py-1'>
           {template.type === 'retrospective' && <RetroDescription prompts={template.prompts} />}
           {template.type === 'poker' && <PokerDescription dimensions={template.dimensions} />}
           {template.type === 'action' && <ActionDescription />}


### PR DESCRIPTION
Trivial fix to dark mode regression.