### PR TITLE
fix: height reflection in flight. autofocus editor. editor height

### DIFF
--- a/packages/client/components/RetroReflectPhase/HTMLReflection.tsx
+++ b/packages/client/components/RetroReflectPhase/HTMLReflection.tsx
@@ -9,12 +9,18 @@ interface Props {
 export const HTMLReflection = (props: Props) => {
   const {html, disableAnonymity} = props
   return (
-    <div className={cn('relative w-full overflow-auto text-fg-primary text-sm leading-5')}>
+    // The vertical padding lives out here because `.ProseMirror` in global.css is unlayered and
+    // sets its own py, which outranks every Tailwind utility (they're in `layer(utilities)`).
+    // 8px matches the `py-2` that ReflectionCardRoot carries in ReflectionCard, so this ghost is
+    // the same height as the card it stands in for
+    <div
+      className={cn(
+        'relative w-full overflow-auto pt-2 text-fg-primary text-sm leading-5',
+        disableAnonymity ? 'pb-0' : 'pb-2'
+      )}
+    >
       <div
-        className={cn(
-          'ProseMirror flex max-h-41 min-h-6 w-full flex-col items-start justify-center px-4 pt-2.5 leading-5',
-          disableAnonymity ? 'pb-0' : 'pb-2.5'
-        )}
+        className='ProseMirror flex max-h-41 min-h-6 w-full flex-col items-start justify-center px-4 leading-5'
         dangerouslySetInnerHTML={{__html: sanitizeExternalHtml(html)}}
       ></div>
     </div>

--- a/packages/client/components/RetroReflectPhase/PhaseItemColumn.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemColumn.tsx
@@ -28,10 +28,11 @@ interface Props {
   meeting: PhaseItemColumn_meeting$key
   phaseRef: RefObject<HTMLDivElement>
   prompt: PhaseItemColumn_prompt$key
+  autoFocus: boolean
 }
 
 const PhaseItemColumn = (props: Props) => {
-  const {idx, meeting: meetingRef, phaseRef, prompt: promptRef, isDesktop} = props
+  const {idx, meeting: meetingRef, phaseRef, prompt: promptRef, isDesktop, autoFocus} = props
   const prompt = useFragment(
     graphql`
       fragment PhaseItemColumn_prompt on ReflectPrompt {
@@ -210,6 +211,7 @@ const PhaseItemColumn = (props: Props) => {
                   promptId={promptId}
                   stackTopRef={stackTopRef}
                   readOnly={!!endedAt}
+                  autoFocus={autoFocus}
                   meetingRef={meeting}
                 />
               </div>

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -6,6 +6,7 @@ import useEventCallback from '~/hooks/useEventCallback'
 import type {PhaseItemEditor_meeting$key} from '../../__generated__/PhaseItemEditor_meeting.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useIsEditing from '../../hooks/useIsEditing'
+import useIsFocused from '../../hooks/useIsFocused'
 import useMutationProps from '../../hooks/useMutationProps'
 import usePortal from '../../hooks/usePortal'
 import {useTipTapReflectionEditor} from '../../hooks/useTipTapReflectionEditor'
@@ -36,6 +37,7 @@ interface Props {
   stackTopRef: RefObject<HTMLDivElement>
   dataCy: string
   readOnly?: boolean
+  autoFocus: boolean
   meetingRef: PhaseItemEditor_meeting$key
 }
 
@@ -50,6 +52,7 @@ const PhaseItemEditor = (props: Props) => {
     forceUpdateColumn,
     dataCy,
     readOnly,
+    autoFocus,
     meetingRef
   } = props
   const atmosphere = useAtmosphere()
@@ -150,7 +153,8 @@ const PhaseItemEditor = (props: Props) => {
       placeholder,
       teamId,
       readOnly: !!readOnly,
-      onModEnter: handleSubmit
+      onModEnter: handleSubmit,
+      autoFocus: autoFocus && !readOnly
     }
   )
 
@@ -182,7 +186,7 @@ const PhaseItemEditor = (props: Props) => {
       })
     }
   })
-  const isFocused = editor?.isFocused
+  const isFocused = useIsFocused(editor)
 
   useEffect(() => {
     if (!editor) return
@@ -233,7 +237,7 @@ const PhaseItemEditor = (props: Props) => {
       <ReflectionCardRoot data-cy={dataCy} ref={phaseEditorRef} className='pb-2'>
         <TipTapEditor
           className={cn('flex h-fit max-h-41 overflow-auto px-4 pt-2 transition-all', {
-            'min-h-16': isEditing || isFocused
+            'min-h-16': isFocused
           })}
           editor={editor}
         />

--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -59,6 +59,9 @@ const RetroReflectPhase = (props: Props) => {
   const reflectPrompts = localPhase!.reflectPrompts
   const focusedPromptId = localPhase!.focusedPromptId
   const ColumnWrapper = isDesktop ? ReflectWrapperDesktop : ReflectWrapperMobile
+  const focusedIdx = reflectPrompts.findIndex(({id}) => id === focusedPromptId)
+  // a focusedPromptId from another phase (or none at all) falls back to the first column
+  const autoFocusIdx = focusedIdx === -1 ? 0 : focusedIdx
 
   return (
     <MeetingContent ref={callbackRef}>
@@ -79,11 +82,7 @@ const RetroReflectPhase = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <StageTimerDisplay meeting={meeting} />
-          <ColumnWrapper
-            setActiveIdx={setActiveIdx}
-            activeIdx={activeIdx}
-            focusedIdx={reflectPrompts.findIndex(({id}) => id === focusedPromptId)}
-          >
+          <ColumnWrapper setActiveIdx={setActiveIdx} activeIdx={activeIdx} focusedIdx={focusedIdx}>
             {reflectPrompts.map((prompt, idx) => (
               <PhaseItemColumn
                 key={prompt.id}
@@ -92,6 +91,7 @@ const RetroReflectPhase = (props: Props) => {
                 idx={idx}
                 phaseRef={phaseRef}
                 isDesktop={isDesktop}
+                autoFocus={idx === autoFocusIdx}
               />
             ))}
           </ColumnWrapper>

--- a/packages/client/hooks/useIsFocused.ts
+++ b/packages/client/hooks/useIsFocused.ts
@@ -1,0 +1,26 @@
+import type {Editor} from '@tiptap/core'
+import {useEffect, useState} from 'react'
+
+// editor.isFocused reads straight off the ProseMirror instance, so focus and blur mutate it
+// without React hearing about it. Mirror it into state so the UI can respond to focus alone
+const useIsFocused = (editor: Editor | null) => {
+  const [isFocused, setIsFocused] = useState(false)
+
+  useEffect(() => {
+    if (!editor) return
+    const onFocus = () => setIsFocused(true)
+    const onBlur = () => setIsFocused(false)
+    // the editor can already hold focus by the time the listeners attach
+    setIsFocused(editor.isFocused)
+    editor.on('focus', onFocus)
+    editor.on('blur', onBlur)
+    return () => {
+      editor.off('focus', onFocus)
+      editor.off('blur', onBlur)
+    }
+  }, [editor])
+
+  return isFocused
+}
+
+export default useIsFocused

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -33,9 +33,10 @@ export const useTipTapReflectionEditor = (
     readOnly?: boolean
     placeholder?: string
     onModEnter?: () => void
+    autoFocus?: boolean
   }
 ) => {
-  const {atmosphere, teamId, readOnly, placeholder, onModEnter} = options
+  const {atmosphere, teamId, readOnly, placeholder, onModEnter, autoFocus} = options
   const [contentJSON] = useState(() => (content ? JSON.parse(content) : undefined))
   const placeholderRef = useRef(placeholder)
   const [commit] = useUploadUserAsset()
@@ -107,7 +108,9 @@ export const useTipTapReflectionEditor = (
           openOnClick: false
         })
       ].filter(isValid),
-      autofocus: generateText(contentJSON, serverTipTapExtensions).length === 0,
+      // every reflect column starts empty, so defaulting to "focus when empty" made all of them
+      // grab focus on mount and the last one mounted won. Callers with siblings must opt in
+      autofocus: autoFocus ?? generateText(contentJSON, serverTipTapExtensions).length === 0,
       editable: !readOnly
     },
     []


### PR DESCRIPTION
# Description

Fixes 3 bugs:
- phase item editor height wouldn't expand/collapse correctly
- phase item editor wouldn't autofocus the first column
- reflection in flight would lose its height for 1-liners

